### PR TITLE
General bindings formatting

### DIFF
--- a/rasn-compiler/src/generator/mod.rs
+++ b/rasn-compiler/src/generator/mod.rs
@@ -22,6 +22,10 @@ pub trait Backend: Sized {
         &self,
         top_level_declarations: Vec<ToplevelDefinition>,
     ) -> Result<GeneratedModule, GeneratorError>;
+
+    fn format_bindings(bindings: &String) -> Result<String, Box<dyn Error>> {
+        Ok(bindings.clone())
+    }
 }
 
 pub struct GeneratedModule {

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -1,6 +1,14 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
-use std::{collections::BTreeMap, error::Error, str::FromStr};
+use std::{
+    collections::BTreeMap,
+    env::{self},
+    error::Error,
+    io::{self, Write},
+    path::PathBuf,
+    process::{Command, Stdio},
+    str::FromStr,
+};
 
 use crate::{
     generator::{Backend, GeneratedModule},
@@ -83,6 +91,52 @@ impl Backend for Rust {
             }.to_string()), warnings})
         } else {
             Ok(GeneratedModule::empty())
+        }
+    }
+
+    fn format_bindings(bindings: &String) -> Result<String, Box<dyn Error>> {
+        let mut rustfmt = PathBuf::from(env::var("CARGO_HOME")?);
+        rustfmt.push("bin/rustfmt");
+        let mut cmd = Command::new(&*rustfmt);
+
+        cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+
+        let mut child = cmd.spawn()?;
+        let mut child_stdin = child.stdin.take().unwrap();
+        let mut child_stdout = child.stdout.take().unwrap();
+
+        // Write to stdin in a new thread, so that we can read from stdout on this
+        // thread. This keeps the child from blocking on writing to its stdout which
+        // might block us from writing to its stdin.
+        let bindings = bindings.to_owned();
+        let stdin_handle = ::std::thread::spawn(move || {
+            let _ = child_stdin.write_all(bindings.as_bytes());
+            bindings
+        });
+
+        let mut output = vec![];
+        io::copy(&mut child_stdout, &mut output)?;
+
+        let status = child.wait()?;
+        let bindings = stdin_handle.join().expect(
+            "The thread writing to rustfmt's stdin doesn't do \
+             anything that could panic",
+        );
+
+        match String::from_utf8(output) {
+            Ok(bindings) => match status.code() {
+                Some(0) => Ok(bindings),
+                Some(2) => Err(Box::new(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Rustfmt parsing errors.".to_string(),
+                ))),
+                Some(3) => Ok(bindings),
+                _ => Err(Box::new(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Internal rustfmt error".to_string(),
+                ))),
+            },
+            _ => Ok(bindings),
         }
     }
 }


### PR DESCRIPTION
Non-Rust bindings generated by custom backends are currently forced to pass through rustfmt. This PR should generalize this.
There is probably a better way to do this (like maybe binding `CompileResult` to a specific `Backend`?), but requires a bit more refactoring.