### PR TITLE
typescript: add optional fields

### DIFF
--- a/rasn-compiler/src/generator/typescript/utils.rs
+++ b/rasn-compiler/src/generator/typescript/utils.rs
@@ -65,8 +65,9 @@ pub fn format_sequence_or_set_members(se: &SequenceOrSet) -> String {
         se.members
             .iter()
             .map(|m| format!(
-                r#"{}: {},"#,
+                r#"{}{}: {},"#,
                 to_jer_identifier(&m.name),
+                if m.is_optional { "?" } else { "" },
                 type_to_tokens(&m.ty)
             ))
             .collect::<Vec<_>>()


### PR DESCRIPTION
Currently, every field in compiled TS types is mandatory. This pull request adds the optional tag `?` to fields which are specified as optional in the ASN definitions.