### PR TITLE
typescript: export namespaces

### DIFF
--- a/rasn-compiler/src/generator/typescript/mod.rs
+++ b/rasn-compiler/src/generator/typescript/mod.rs
@@ -83,7 +83,7 @@ impl Backend for Typescript {
             Ok(GeneratedModule {
                 generated: Some(format!(
                     r#"
-                namespace {namespace} {{
+                export namespace {namespace} {{
                     {imports}
 
                     {pdus}


### PR DESCRIPTION
Currently, generated TS namespaces are not exported, limiting their usage to TS's global namespaces.

This pull request allows to deal with namespaces that have different contents but share the same name, as the following example describes:

```typescript
import { CAM_PDU_Descriptions as CAM_PDU_Descriptions_V1} from "./types/cam_v1";
import { CAM_PDU_Descriptions as CAM_PDU_Descriptions_V2} from "./types/cam_v2";

type CAM_V1 = CAM_PDU_Descriptions_V1.CAM
type CAM_V2 = CAM_PDU_Descriptions_V2.CAM
```