### PR TITLE
fix: Parse value assignment with constraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,25 +594,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rasn-compiler"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fa0aca69af57e604d8f710fea321c8d8b7344e0407fbe3a985d9bfd2fc0a79"
-dependencies = [
- "chrono",
- "nom",
- "num",
- "proc-macro2",
- "quote",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "rasn-compiler-derive"
 version = "0.3.0"
 dependencies = [
  "proc-macro2",
- "rasn-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rasn-compiler",
  "syn 2.0.58",
 ]
 
@@ -626,7 +612,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "rasn",
- "rasn-compiler 0.3.0",
+ "rasn-compiler",
  "rasn-compiler-derive",
  "rasn-kerberos",
 ]

--- a/rasn-compiler-derive/Cargo.toml
+++ b/rasn-compiler-derive/Cargo.toml
@@ -16,7 +16,6 @@ authors = ["Kevin Westphal"]
 proc-macro = true
 
 [dependencies]
-#rasn-compiler = { version = "0.3.0" }
-rasn-compiler = { path = "../rasn-compiler" }
+rasn-compiler = { path = "../rasn-compiler", version = "0.3.0" }
 proc-macro2 = "1"
 syn= "2"

--- a/rasn-compiler-derive/Cargo.toml
+++ b/rasn-compiler-derive/Cargo.toml
@@ -16,6 +16,7 @@ authors = ["Kevin Westphal"]
 proc-macro = true
 
 [dependencies]
-rasn-compiler = { version = "0.3.0" }
+#rasn-compiler = { version = "0.3.0" }
+rasn-compiler = { path = "../rasn-compiler" }
 proc-macro2 = "1"
 syn= "2"

--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -30,6 +30,12 @@ e2e_pdu!(
 );
 
 e2e_pdu!(
+    integer_value_constrained,
+    "test-int INTEGER(0..255) ::= 4",
+    r#" lazy_static! { pub static ref TEST_INT: Integer = Integer::from(4); }                           "#
+);
+
+e2e_pdu!(
     integer_distinguished_values,
     "Test-Int ::= INTEGER {
         first(0),

--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -32,7 +32,13 @@ e2e_pdu!(
 e2e_pdu!(
     integer_value_constrained,
     "test-int INTEGER(0..255) ::= 4",
-    r#" lazy_static! { pub static ref TEST_INT: u8 = 4; } "#
+    r#"pub const TEST_INT: u8 = 4;"#
+);
+
+e2e_pdu!(
+    integer_value_large_constrained,
+    "test-int INTEGER(0..MAX) ::= 4",
+    r#"lazy_static! { pub static ref TEST_INT: Integer = Integer::from(4); }"#
 );
 
 e2e_pdu!(

--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -32,7 +32,7 @@ e2e_pdu!(
 e2e_pdu!(
     integer_value_constrained,
     "test-int INTEGER(0..255) ::= 4",
-    r#" lazy_static! { pub static ref TEST_INT: Integer = Integer::from(4); }                           "#
+    r#" lazy_static! { pub static ref TEST_INT: u8 = 4; } "#
 );
 
 e2e_pdu!(

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -9,13 +9,11 @@ use crate::intermediate::{
         ObjectSetValue, ToplevelInformationDefinition,
     },
     ASN1Type, ASN1Value, ToplevelDefinition, ToplevelTypeDefinition, ToplevelValueDefinition,
-    BIT_STRING, BOOLEAN, GENERALIZED_TIME, INTEGER, NULL, OCTET_STRING, UTC_TIME,
+    CharacterStringType
 };
 
 use super::{
-    information_object::InformationObjectClassField, template::*, Rasn, BMP_STRING, GENERAL_STRING,
-    IA5_STRING, NUMERIC_STRING, OBJECT_IDENTIFIER, PRINTABLE_STRING, SEQUENCE_OF, SET_OF,
-    UTF8_STRING, VISIBLE_STRING,
+    information_object::InformationObjectClassField, template::*, Rasn,
 };
 use crate::generator::error::{GeneratorError, GeneratorErrorType};
 
@@ -131,7 +129,7 @@ impl Rasn {
         if let ASN1Value::LinkedIntValue { integer_type, .. } = tld.value {
             let formatted_value = self.value_to_tokens(&tld.value, None)?;
             let ty = self.to_rust_title_case(&tld.associated_type.as_str());
-            if tld.associated_type.as_str() == INTEGER {
+            if tld.associated_type.is_builtin_type() {
                 Ok(lazy_static_value_template(
                     self.format_comments(&tld.comments)?,
                     self.to_rust_const_case(&tld.name),
@@ -322,19 +320,20 @@ impl Rasn {
         &self,
         tld: ToplevelValueDefinition,
     ) -> Result<TokenStream, GeneratorError> {
-        let ty = tld.associated_type.as_str();
+        let ty = &tld.associated_type;
         match &tld.value {
-            ASN1Value::Null if ty == NULL => {
+            ASN1Value::Null if ty.is_builtin_type() => {
                 call_template!(self, primitive_value_template, tld, quote!(()), quote!(()))
             }
-            ASN1Value::Null => call_template!(
+            ASN1Value::Null => {
+                call_template!(
                 self,
                 primitive_value_template,
                 tld,
-                self.to_rust_title_case(&tld.associated_type.as_str()),
-                assignment!(self, &tld.associated_type.as_str(), quote!(()))
-            ),
-            ASN1Value::Boolean(b) if ty == BOOLEAN => call_template!(
+                self.to_rust_title_case(&ty.as_str()),
+                assignment!(self, &ty.as_str(), quote!(()))
+            )},
+            ASN1Value::Boolean(b) if ty.is_builtin_type() => call_template!(
                 self,
                 primitive_value_template,
                 tld,
@@ -345,18 +344,18 @@ impl Rasn {
                 self,
                 primitive_value_template,
                 tld,
-                self.to_rust_title_case(&tld.associated_type.as_str()),
-                assignment!(self, &tld.associated_type.as_str(), b.to_token_stream())
+                self.to_rust_title_case(&ty.as_str()),
+                assignment!(self, &ty.as_str(), b.to_token_stream())
             ),
             ASN1Value::LinkedIntValue { .. } => self.generate_integer_value(tld),
-            ASN1Value::BitString(_) if ty == BIT_STRING => call_template!(
+            ASN1Value::BitString(_) if ty.is_builtin_type() => call_template!(
                 self,
                 lazy_static_value_template,
                 tld,
                 quote!(BitString),
                 self.value_to_tokens(&tld.value, None)?
             ),
-            ASN1Value::OctetString(_) if ty == OCTET_STRING => call_template!(
+            ASN1Value::OctetString(_) if ty.is_builtin_type() => call_template!(
                 self,
                 lazy_static_value_template,
                 tld,
@@ -373,7 +372,7 @@ impl Rasn {
                         self,
                         const_choice_value_template,
                         tld,
-                        self.to_rust_title_case(&tld.associated_type.as_str()),
+                        self.to_rust_title_case(&ty.as_str()),
                         self.to_rust_enum_identifier(variant_name),
                         self.value_to_tokens(inner_value, None)?
                     )
@@ -382,7 +381,7 @@ impl Rasn {
                         self,
                         choice_value_template,
                         tld,
-                        self.to_rust_title_case(&tld.associated_type.as_str()),
+                        self.to_rust_title_case(&ty.as_str()),
                         self.to_rust_enum_identifier(variant_name),
                         self.value_to_tokens(inner_value, None)?
                     )
@@ -398,20 +397,29 @@ impl Rasn {
                 self.to_rust_title_case(enumerated),
                 self.to_rust_enum_identifier(enumerable)
             ),
-            ASN1Value::Time(_) if ty == GENERALIZED_TIME => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(GeneralizedTime),
-                self.value_to_tokens(&tld.value, Some(&quote!(GeneralizedTime)))?
-            ),
-            ASN1Value::Time(_) if ty == UTC_TIME => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(UtcTime),
-                self.value_to_tokens(&tld.value, Some(&quote!(UtcTime)))?
-            ),
+            ASN1Value::Time(_) if ty.is_builtin_type() => {
+                match ty {
+                    ASN1Type::GeneralizedTime(_) => call_template!(
+                        self,
+                        lazy_static_value_template,
+                        tld,
+                        quote!(GeneralizedTime),
+                        self.value_to_tokens(&tld.value, Some(&quote!(GeneralizedTime)))?
+                    ),
+                    ASN1Type::UTCTime(_) => call_template!(
+                        self,
+                        lazy_static_value_template,
+                        tld,
+                        quote!(UtcTime),
+                        self.value_to_tokens(&tld.value, Some(&quote!(UtcTime)))?
+                    ),
+                    _ => Err(GeneratorError::new(
+                        Some(ToplevelDefinition::Value(tld)),
+                        "Time value does not match expected type",
+                        GeneratorErrorType::Asn1TypeMismatch,
+                    )),
+                }
+            }
             ASN1Value::LinkedStructLikeValue(s) => {
                 let members = s
                     .iter()
@@ -423,7 +431,7 @@ impl Rasn {
                     self,
                     sequence_or_set_value_template,
                     tld,
-                    self.to_rust_title_case(&tld.associated_type.as_str()),
+                    self.to_rust_title_case(&ty.as_str()),
                     quote!(#(#members),*)
                 )
             }
@@ -434,10 +442,10 @@ impl Rasn {
                         self,
                         primitive_value_template,
                         tld,
-                        self.to_rust_title_case(&tld.associated_type.as_str()),
+                        self.to_rust_title_case(&ty.as_str()),
                         assignment!(
                             self,
-                            &tld.associated_type.as_str(),
+                            &ty.as_str(),
                             self.value_to_tokens(&tld.value, parent.as_ref())?
                         )
                     )
@@ -446,95 +454,63 @@ impl Rasn {
                         self,
                         lazy_static_value_template,
                         tld,
-                        self.to_rust_title_case(&tld.associated_type.as_str()),
+                        self.to_rust_title_case(&ty.as_str()),
                         assignment!(
                             self,
-                            &tld.associated_type.as_str(),
+                            &ty.as_str(),
                             self.value_to_tokens(&tld.value, parent.as_ref())?
                         )
                     )
                 }
             }
-            ASN1Value::ObjectIdentifier(_) if ty == OBJECT_IDENTIFIER => call_template!(
+            ASN1Value::ObjectIdentifier(_) if ty.is_builtin_type() => call_template!(
                 self,
                 lazy_static_value_template,
                 tld,
                 quote!(ObjectIdentifier),
                 self.value_to_tokens(&tld.value, None)?
             ),
-            ASN1Value::LinkedCharStringValue(_, _) if ty == NUMERIC_STRING => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(NumericString),
-                self.value_to_tokens(&tld.value, None)?
-            ),
-            ASN1Value::LinkedCharStringValue(_, _) if ty == VISIBLE_STRING => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(VisibleString),
-                self.value_to_tokens(&tld.value, None)?
-            ),
-            ASN1Value::LinkedCharStringValue(_, _) if ty == IA5_STRING => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(IA5String),
-                self.value_to_tokens(&tld.value, None)?
-            ),
-            ASN1Value::LinkedCharStringValue(_, _) if ty == UTF8_STRING => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(UTF8String),
-                self.value_to_tokens(&tld.value, None)?
-            ),
-            ASN1Value::LinkedCharStringValue(_, _) if ty == BMP_STRING => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(BMPString),
-                self.value_to_tokens(&tld.value, None)?
-            ),
-            ASN1Value::LinkedCharStringValue(_, _) if ty == PRINTABLE_STRING => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(PrintableString),
-                self.value_to_tokens(&tld.value, None)?
-            ),
-            ASN1Value::LinkedCharStringValue(_, _) if ty == GENERAL_STRING => call_template!(
-                self,
-                lazy_static_value_template,
-                tld,
-                quote!(GeneralString),
-                self.value_to_tokens(&tld.value, None)?
-            ),
-            ASN1Value::LinkedArrayLikeValue(s) if ty.contains(SEQUENCE_OF) => {
-                let item_type = self.format_sequence_or_set_of_item_type(
-                    match tld.associated_type {
-                        ASN1Type::SequenceOf(seq) => seq.element_type.as_str().into_owned(),
-                        _ => unreachable!(),
-                    },
-                    s.first().map(|i| &**i),
-                );
+            ASN1Value::LinkedCharStringValue(cs_ty, _) if ty.is_builtin_type() => {
+                let ty_ts = match cs_ty {
+                    CharacterStringType::NumericString => quote!(NumericString),
+                    CharacterStringType::VisibleString => quote!(VisibleString),
+                    CharacterStringType::IA5String => quote!(IA5String),
+                    CharacterStringType::UTF8String => quote!(UTF8String),
+                    CharacterStringType::BMPString => quote!(BMPString),
+                    CharacterStringType::PrintableString => quote!(PrintableString),
+                    CharacterStringType::GeneralString => quote!(GeneralString),
+                    CharacterStringType::GraphicString
+                    | CharacterStringType::TeletexString
+                    | CharacterStringType::VideotexString
+                    | CharacterStringType::UniversalString => {
+                        return Err(GeneratorError::new(
+                           None,
+                           &format!("{:?} values are currently unsupported", cs_ty),
+                           GeneratorErrorType::NotYetInplemented,
+                        ))
+                    }
+                };
                 call_template!(
                     self,
                     lazy_static_value_template,
                     tld,
-                    quote!(Vec<#item_type>),
+                    ty_ts,
                     self.value_to_tokens(&tld.value, None)?
                 )
             }
-            ASN1Value::LinkedArrayLikeValue(s) if ty.contains(SET_OF) => {
+            ASN1Value::LinkedArrayLikeValue(s) if ty.is_builtin_type() => {
                 let item_type = self.format_sequence_or_set_of_item_type(
-                    match tld.associated_type {
-                        ASN1Type::SetOf(set) => set.element_type.as_str().into_owned(),
-                        _ => unreachable!(),
+                    match ty {
+                        ASN1Type::SequenceOf(seq) => &*seq.element_type,
+                        ASN1Type::SetOf(set) => &*set.element_type,
+                        _ => return Err(GeneratorError::new(
+                            Some(ToplevelDefinition::Value(tld)),
+                            "LinkedArrayLikeValue does not match SEQUENCE/SET OF type",
+                            GeneratorErrorType::Asn1TypeMismatch,
+                        ))
                     },
                     s.first().map(|i| &**i),
-                );
+                )?;
                 call_template!(
                     self,
                     lazy_static_value_template,
@@ -553,10 +529,10 @@ impl Rasn {
                 self,
                 lazy_static_value_template,
                 tld,
-                self.to_rust_title_case(&tld.associated_type.as_str()),
+                self.to_rust_title_case(&ty.as_str()),
                 assignment!(
                     self,
-                    &tld.associated_type.as_str(),
+                    &ty.as_str(),
                     self.value_to_tokens(&tld.value, None)?
                 )
             ),

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -126,9 +126,12 @@ impl Rasn {
         &self,
         tld: ToplevelValueDefinition,
     ) -> Result<TokenStream, GeneratorError> {
-        if let ASN1Value::LinkedIntValue { integer_type, .. } = tld.value {
+        if let ASN1Value::LinkedIntValue { mut integer_type, .. } = tld.value {
             let formatted_value = self.value_to_tokens(&tld.value, None)?;
             let ty = self.to_rust_title_case(&tld.associated_type.as_str());
+            if let ASN1Type::Integer(i) = &tld.associated_type {
+                integer_type = i.int_type();
+            }
             if tld.associated_type.is_builtin_type() {
                 Ok(lazy_static_value_template(
                     self.format_comments(&tld.comments)?,

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -135,7 +135,7 @@ impl Rasn {
                 Ok(lazy_static_value_template(
                     self.format_comments(&tld.comments)?,
                     self.to_rust_const_case(&tld.name),
-                    quote!(Integer),
+                    integer_type.to_token_stream(),
                     formatted_value,
                 ))
             } else if integer_type.is_unbounded() {

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -874,24 +874,23 @@ impl Rasn {
         first_item: Option<&ASN1Value>,
     ) -> Result<TokenStream, GeneratorError> {
         if ty.is_builtin_type() {
-        match ty {
-            ASN1Type::Null => Ok(quote!(())),
-            ASN1Type::Boolean(_) => Ok(quote!(bool)),
-            ASN1Type::Integer(_) => {
-                match first_item {
-                    Some(ASN1Value::LinkedIntValue { integer_type, .. }) => {
-                        Ok(integer_type.to_token_stream())
+            match ty {
+                ASN1Type::Null => Ok(quote!(())),
+                ASN1Type::Boolean(_) => Ok(quote!(bool)),
+                ASN1Type::Integer(_) => {
+                    match first_item {
+                        Some(ASN1Value::LinkedIntValue { integer_type, .. }) => {
+                            Ok(integer_type.to_token_stream())
+                        }
+                        _ => Ok(quote!(Integer)), // best effort
                     }
-                    _ => Ok(quote!(Integer)), // best effort
                 }
-            }
-            ASN1Type::BitString(_) => Ok(quote!(BitString)),
-            ASN1Type::OctetString(_) => Ok(quote!(OctetString)),
-            ASN1Type::GeneralizedTime(_) => Ok(quote!(GeneralizedTime)),
-            ASN1Type::UTCTime(_) => Ok(quote!(UtcTime)),
-            ASN1Type::ObjectIdentifier(_) => Ok(quote!(ObjectIdentifier)),
-            ASN1Type::CharacterString(cs) => {
-                match cs.ty {
+                ASN1Type::BitString(_) => Ok(quote!(BitString)),
+                ASN1Type::OctetString(_) => Ok(quote!(OctetString)),
+                ASN1Type::GeneralizedTime(_) => Ok(quote!(GeneralizedTime)),
+                ASN1Type::UTCTime(_) => Ok(quote!(UtcTime)),
+                ASN1Type::ObjectIdentifier(_) => Ok(quote!(ObjectIdentifier)),
+                ASN1Type::CharacterString(cs) => match cs.ty {
                     CharacterStringType::NumericString => Ok(quote!(NumericString)),
                     CharacterStringType::VisibleString => Ok(quote!(VisibleString)),
                     CharacterStringType::IA5String => Ok(quote!(IA5String)),
@@ -907,10 +906,9 @@ impl Rasn {
                         &format!("{:?} values are currently unsupported!", cs.ty),
                         GeneratorErrorType::NotYetInplemented,
                     )),
-                }
-            },
-            _ => Ok(self.to_rust_title_case(&ty.as_str())),
-        }
+                },
+                _ => Ok(self.to_rust_title_case(&ty.as_str())),
+            }
         } else {
             Ok(self.to_rust_title_case(&ty.as_str()))
         }

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -652,10 +652,24 @@ impl From<(&str, ASN1Value, ASN1Type)> for ToplevelValueDefinition {
     }
 }
 
-impl From<(Vec<&str>, &str, Option<Parameterization>, ASN1Type, ASN1Value)>
-    for ToplevelValueDefinition
+impl
+    From<(
+        Vec<&str>,
+        &str,
+        Option<Parameterization>,
+        ASN1Type,
+        ASN1Value,
+    )> for ToplevelValueDefinition
 {
-    fn from(value: (Vec<&str>, &str, Option<Parameterization>, ASN1Type, ASN1Value)) -> Self {
+    fn from(
+        value: (
+            Vec<&str>,
+            &str,
+            Option<Parameterization>,
+            ASN1Type,
+            ASN1Value,
+        ),
+    ) -> Self {
         Self {
             comments: value.0.join("\n"),
             name: value.1.into(),

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -607,7 +607,10 @@ impl ToplevelDefinition {
     ///             comments: String::from("Comments from the ASN.1 spec"),
     ///             parameterization: None,
     ///             name: String::from("the-answer"),
-    ///             associated_type: String::from("INTEGER"),
+    ///             associated_type: ASN1Type::Integer(Integer {
+    ///                 constraints: vec![],
+    ///                 distinguished_values: None,
+    ///             }),
     ///             value: ASN1Value::Integer(42),
     ///             index: None,
     ///         }
@@ -630,14 +633,14 @@ impl ToplevelDefinition {
 pub struct ToplevelValueDefinition {
     pub comments: String,
     pub name: String,
-    pub associated_type: String,
+    pub associated_type: ASN1Type,
     pub parameterization: Option<Parameterization>,
     pub value: ASN1Value,
     pub index: Option<(Rc<RefCell<ModuleReference>>, usize)>,
 }
 
-impl From<(&str, ASN1Value, &str)> for ToplevelValueDefinition {
-    fn from(value: (&str, ASN1Value, &str)) -> Self {
+impl From<(&str, ASN1Value, ASN1Type)> for ToplevelValueDefinition {
+    fn from(value: (&str, ASN1Value, ASN1Type)) -> Self {
         Self {
             comments: String::new(),
             name: value.0.to_owned(),
@@ -649,10 +652,10 @@ impl From<(&str, ASN1Value, &str)> for ToplevelValueDefinition {
     }
 }
 
-impl From<(Vec<&str>, &str, Option<Parameterization>, &str, ASN1Value)>
+impl From<(Vec<&str>, &str, Option<Parameterization>, ASN1Type, ASN1Value)>
     for ToplevelValueDefinition
 {
-    fn from(value: (Vec<&str>, &str, Option<Parameterization>, &str, ASN1Value)) -> Self {
+    fn from(value: (Vec<&str>, &str, Option<Parameterization>, ASN1Type, ASN1Value)) -> Self {
         Self {
             comments: value.0.join("\n"),
             name: value.1.into(),

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -197,15 +197,19 @@ fn top_level_value_declaration(input: &str) -> IResult<&str, ToplevelValueDefini
             skip_ws(many0(comment)),
             skip_ws(value_identifier),
             skip_ws_and_comments(opt(parameterization)),
-            skip_ws(alt((
-                // Cover built-in types with spaces
-                tag(OBJECT_IDENTIFIER),
-                tag(OCTET_STRING),
-                tag(BIT_STRING),
-                recognize(pair(tag(SEQUENCE_OF), skip_ws_and_comments(identifier))),
-                recognize(pair(tag(SET_OF), skip_ws_and_comments(identifier))),
-                identifier,
-            ))),
+            terminated(
+                skip_ws(alt((
+                    // Cover built-in types with spaces
+                    tag(OBJECT_IDENTIFIER),
+                    tag(OCTET_STRING),
+                    tag(BIT_STRING),
+                    recognize(pair(tag(SEQUENCE_OF), skip_ws_and_comments(identifier))),
+                    recognize(pair(tag(SET_OF), skip_ws_and_comments(identifier))),
+                    identifier,
+                ))),
+                // Ignore possible constraint
+                skip_ws_and_comments(opt(constraint))
+            ),
             preceded(assignment, skip_ws_and_comments(asn1_value)),
         ))),
         enumerated_value,

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -197,6 +197,7 @@ fn top_level_value_declaration(input: &str) -> IResult<&str, ToplevelValueDefini
             skip_ws(many0(comment)),
             skip_ws(value_identifier),
             skip_ws_and_comments(opt(parameterization)),
+            // TODO full type parsing
             terminated(
                 skip_ws(alt((
                     // Cover built-in types with spaces

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -197,20 +197,7 @@ fn top_level_value_declaration(input: &str) -> IResult<&str, ToplevelValueDefini
             skip_ws(many0(comment)),
             skip_ws(value_identifier),
             skip_ws_and_comments(opt(parameterization)),
-            // TODO full type parsing
-            terminated(
-                skip_ws(alt((
-                    // Cover built-in types with spaces
-                    tag(OBJECT_IDENTIFIER),
-                    tag(OCTET_STRING),
-                    tag(BIT_STRING),
-                    recognize(pair(tag(SEQUENCE_OF), skip_ws_and_comments(identifier))),
-                    recognize(pair(tag(SET_OF), skip_ws_and_comments(identifier))),
-                    identifier,
-                ))),
-                // Ignore possible constraint
-                skip_ws_and_comments(opt(constraint))
-            ),
+            skip_ws_and_comments(asn1_type),
             preceded(assignment, skip_ws_and_comments(asn1_value)),
         ))),
         enumerated_value,

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -18,7 +18,8 @@ use nom::{
 
 use super::{
     common::{in_braces, in_parentheses, skip_ws, skip_ws_and_comments, value_identifier},
-    constraint::constraint, RELATIVE_OID,
+    constraint::constraint,
+    RELATIVE_OID,
 };
 
 /// Tries to parse an ASN1 OBJECT IDENTIFIER

--- a/rasn-compiler/src/lib.rs
+++ b/rasn-compiler/src/lib.rs
@@ -82,22 +82,25 @@ pub fn compile_to_typescript(asn1: &str) -> Result<Generated, JsValue> {
 
 #[cfg(target_family = "wasm")]
 #[wasm_bindgen]
-pub fn compile_to_rust(asn1: &str, config: crate::prelude::RasnConfig) -> Result<Generated, JsValue> {
+pub fn compile_to_rust(
+    asn1: &str,
+    config: crate::prelude::RasnConfig,
+) -> Result<Generated, JsValue> {
     Compiler::<crate::prelude::RasnBackend, _>::new_with_config(config)
-            .add_asn_literal(asn1)
-            .compile_to_string()
-            .map(|result| Generated {
-                rust: result.generated,
-                warnings: result
-                    .warnings
-                    .into_iter()
-                    .fold(String::new(), |mut acc, w| {
-                        acc += &w.to_string();
-                        acc += "\n";
-                        acc
-                    }),
-            })
-            .map_err(|e| JsValue::from(e.to_string()))
+        .add_asn_literal(asn1)
+        .compile_to_string()
+        .map(|result| Generated {
+            rust: result.generated,
+            warnings: result
+                .warnings
+                .into_iter()
+                .fold(String::new(), |mut acc, w| {
+                    acc += &w.to_string();
+                    acc += "\n";
+                    acc
+                }),
+        })
+        .map_err(|e| JsValue::from(e.to_string()))
 }
 
 /// The rasn compiler

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -216,14 +216,10 @@ impl ToplevelValueDefinition {
         &mut self,
         tlds: &BTreeMap<String, ToplevelDefinition>,
     ) -> Result<(), GrammarError> {
-        if let Some(ToplevelDefinition::Type(tld)) = tlds.get(&self.associated_type) {
+        if let Some(ToplevelDefinition::Type(tld)) = tlds.get(&self.associated_type.as_str().into_owned()) {
             self.value.link_with_type(tlds, &tld.ty, Some(&tld.name))
         } else {
-            let ty = match built_in_type(self.associated_type.as_str()) {
-                Some(value) => value,
-                None => return Ok(()),
-            };
-            self.value.link_with_type(tlds, &ty, None)
+            self.value.link_with_type(tlds, &self.associated_type, None)
         }
     }
 }
@@ -478,7 +474,7 @@ impl ASN1Type {
                                     ToplevelDefinition::Value(ToplevelValueDefinition::from((
                                         dummy_reference.as_str(),
                                         v.clone(),
-                                        gov.as_str().borrow(),
+                                        gov.clone(),
                                     ))),
                                 );
                             }
@@ -825,7 +821,7 @@ impl ASN1Value {
                 } else if let Some((ToplevelDefinition::Type(ty), ToplevelDefinition::Value(val))) =
                     tlds.get(&e.identifier).zip(tlds.get(identifier))
                 {
-                    if ty.name != val.associated_type {
+                    if ty.name != val.associated_type.as_str() {
                         // When it comes to `DEFAULT` values, the ASN.1 type system
                         // is more lenient than Rust's. For example, the it is acceptable
                         // to pass `int-value` as a `DEFAULT` value for `Int-Like-Type` in
@@ -1431,7 +1427,11 @@ mod tests {
             comments: String::new(),
             name: "exampleValue".into(),
             parameterization: None,
-            associated_type: "BaseChoice".into(),
+            associated_type: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                parent: None,
+                identifier: "BaseChoice".into(),
+                constraints: vec![],
+            }),
             index: None,
             value: ASN1Value::Choice {
                 type_name: None,
@@ -1445,7 +1445,11 @@ mod tests {
             ToplevelValueDefinition {
                 comments: "".into(),
                 name: "exampleValue".into(),
-                associated_type: "BaseChoice".into(),
+                associated_type: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                    parent: None,
+                    identifier: "BaseChoice".into(),
+                    constraints: vec![]
+                }),
                 parameterization: None,
                 value: ASN1Value::Choice {
                     type_name: Some("BaseChoice".into()),

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -216,7 +216,7 @@ impl ToplevelValueDefinition {
         &mut self,
         tlds: &BTreeMap<String, ToplevelDefinition>,
     ) -> Result<(), GrammarError> {
-        if let Some(ToplevelDefinition::Type(tld)) = tlds.get(&self.associated_type.as_str().into_owned()) {
+        if let Some(ToplevelDefinition::Type(tld)) = tlds.get(self.associated_type.as_str().as_ref()) {
             self.value.link_with_type(tlds, &tld.ty, Some(&tld.name))
         } else {
             self.value.link_with_type(tlds, &self.associated_type, None)

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -216,7 +216,9 @@ impl ToplevelValueDefinition {
         &mut self,
         tlds: &BTreeMap<String, ToplevelDefinition>,
     ) -> Result<(), GrammarError> {
-        if let Some(ToplevelDefinition::Type(tld)) = tlds.get(self.associated_type.as_str().as_ref()) {
+        if let Some(ToplevelDefinition::Type(tld)) =
+            tlds.get(self.associated_type.as_str().as_ref())
+        {
             self.value.link_with_type(tlds, &tld.ty, Some(&tld.name))
         } else {
             self.value.link_with_type(tlds, &self.associated_type, None)

--- a/rasn-compiler/src/validator/mod.rs
+++ b/rasn-compiler/src/validator/mod.rs
@@ -212,7 +212,7 @@ impl Validator {
                                 ..
                             })) => {
                                 self.associated_import_type(
-                                    &associated_type.as_str().into_owned(),
+                                    associated_type.as_str().as_ref(),
                                     mod_ref.clone(),
                                     &mut associated_type_imports,
                                 );
@@ -244,7 +244,7 @@ impl Validator {
 
     fn associated_import_type(
         &self,
-        associated_type: &String,
+        associated_type: &str,
         mod_ref: Rc<RefCell<ModuleReference>>,
         associated_type_imports: &mut Vec<Import>,
     ) {

--- a/rasn-compiler/src/validator/mod.rs
+++ b/rasn-compiler/src/validator/mod.rs
@@ -212,7 +212,7 @@ impl Validator {
                                 ..
                             })) => {
                                 self.associated_import_type(
-                                    associated_type,
+                                    &associated_type.as_str().into_owned(),
                                     mod_ref.clone(),
                                     &mut associated_type_imports,
                                 );


### PR DESCRIPTION
Fixes the parsing of value assignments with a constraint, e.g.: `test-int INTEGER(0..255) = 4`. 
Constraints are ignored as I'm not sure if they are really required for anything.

Relevant standard/sections: X.680 2021 16, 17, 49
Example (at the ~end of file): https://standards.iso.org/iso/14816/ISO14816%20ASN.1%20repository/ISO14816_AVIAEINumberingAndDataStructures.asn

Probably the compiler/derive crate version should also be bumped. 