### PR TITLE
fix: Take into account comma after ellipsis in parsing extended Object Set

### DIFF
--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -132,13 +132,16 @@ pub fn object_set(input: &str) -> IResult<&str, ObjectSet> {
             opt(char(COMMA)),
             extension_marker,
         ))),
-        opt(separated_list1(
-            skip_ws_and_comments(alt((tag(PIPE), tag(UNION)))),
-            skip_ws_and_comments(alt((
-                into(information_object),
-                into(skip_ws_and_comments(identifier)),
-            ))),
-        )),
+        opt(skip_ws_and_comments(preceded(
+            char(COMMA),
+            separated_list1(
+                skip_ws_and_comments(alt((tag(PIPE), tag(UNION)))),
+                skip_ws_and_comments(alt((
+                    into(information_object),
+                    into(skip_ws_and_comments(identifier)),
+                ))),
+            )
+        ))),
     ))))(input)
 }
 


### PR DESCRIPTION
Fixes the missing parsing of the comma in `...,` in an extended Object Set.
Related with #14.