### PR TITLE
Allow the too_many_arguments clippy lint

### DIFF
--- a/rasn-compiler-tests/src/helpers/mod.rs
+++ b/rasn-compiler-tests/src/helpers/mod.rs
@@ -19,7 +19,7 @@ macro_rules! e2e_pdu {
                     .unwrap()
                     .generated
                     .replace(|c: char| c.is_whitespace(), "")
-                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;uselazy_static::lazy_static;userasn::prelude::*;", ""),
+                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused,clippy::too_many_arguments)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;uselazy_static::lazy_static;userasn::prelude::*;", ""),
                 format!("{}}}", $expected)
                     .to_string()
                     .replace(|c: char| c.is_whitespace(), ""),
@@ -37,7 +37,7 @@ macro_rules! e2e_pdu {
                     .unwrap()
                     .generated
                     .replace(|c: char| c.is_whitespace(), "")
-                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;uselazy_static::lazy_static;userasn::prelude::*;", ""),
+                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused,clippy::too_many_arguments)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;uselazy_static::lazy_static;userasn::prelude::*;", ""),
                 format!("{}}}", $expected)
                     .to_string()
                     .replace(|c: char| c.is_whitespace(), ""),

--- a/rasn-compiler/src/generator/rasn/mod.rs
+++ b/rasn-compiler/src/generator/rasn/mod.rs
@@ -129,7 +129,8 @@ impl Backend for Rasn {
                 });
             Ok(GeneratedModule {
                 generated: Some(quote! {
-                #[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused)]
+                #[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused,
+                        clippy::too_many_arguments,)]
                 pub mod #name {
                     extern crate alloc;
 

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -140,7 +140,7 @@ pub fn object_set(input: &str) -> IResult<&str, ObjectSet> {
                     into(information_object),
                     into(skip_ws_and_comments(identifier)),
                 ))),
-            )
+            ),
         ))),
     ))))(input)
 }


### PR DESCRIPTION
Fixes issue #23.