### PR TITLE
Use `nom_locate::LocatedSpan` as lexer input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +449,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +603,7 @@ dependencies = [
  "colored",
  "internal_macros",
  "nom",
+ "nom_locate",
  "num",
  "proc-macro2",
  "quote",

--- a/rasn-compiler/Cargo.toml
+++ b/rasn-compiler/Cargo.toml
@@ -33,6 +33,7 @@ chrono = "0.4.31"
 clap = { version = "4.4.4", optional = true, features = ["derive"] }
 colored = { version = "2", optional = true }
 nom = "7.1.3"
+nom_locate = "4.2.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 walkdir = { version = "2.4", optional = true }

--- a/rasn-compiler/src/intermediate/parameterization.rs
+++ b/rasn-compiler/src/intermediate/parameterization.rs
@@ -1,3 +1,5 @@
+use crate::lexer::Span;
+
 use super::ASN1Type;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,29 +19,29 @@ pub struct ParameterizationArgument {
     pub param_governor: ParameterGovernor,
 }
 
-impl From<&str> for ParameterizationArgument {
-    fn from(value: &str) -> Self {
+impl From<Span<'_>> for ParameterizationArgument {
+    fn from(value: Span) -> Self {
         Self {
-            dummy_reference: value.to_owned(),
+            dummy_reference: value.to_string(),
             param_governor: ParameterGovernor::None,
         }
     }
 }
 
-impl From<(ASN1Type, &str)> for ParameterizationArgument {
-    fn from(value: (ASN1Type, &str)) -> Self {
+impl From<(ASN1Type, Span<'_>)> for ParameterizationArgument {
+    fn from(value: (ASN1Type, Span)) -> Self {
         Self {
-            dummy_reference: value.1.to_owned(),
+            dummy_reference: value.1.to_string(),
             param_governor: ParameterGovernor::TypeOrClass(value.0),
         }
     }
 }
 
-impl From<(&str, &str)> for ParameterizationArgument {
-    fn from(value: (&str, &str)) -> Self {
+impl From<(Span<'_>, Span<'_>)> for ParameterizationArgument {
+    fn from(value: (Span, Span)) -> Self {
         Self {
-            dummy_reference: value.1.to_owned(),
-            param_governor: ParameterGovernor::Class(value.0.to_owned()),
+            dummy_reference: value.1.to_string(),
+            param_governor: ParameterGovernor::Class(value.0.to_string()),
         }
     }
 }

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -114,14 +114,14 @@ impl From<(Option<i128>, Option<i128>, bool)> for Integer {
 
 impl
     From<(
-        &str,
+        Span<'_>,
         Option<Vec<DistinguishedValue>>,
         Option<Vec<Constraint>>,
     )> for Integer
 {
     fn from(
         value: (
-            &str,
+            Span,
             Option<Vec<DistinguishedValue>>,
             Option<Vec<Constraint>>,
         ),
@@ -242,8 +242,8 @@ pub struct CharacterString {
     pub ty: CharacterStringType,
 }
 
-impl From<(&str, Option<Vec<Constraint>>)> for CharacterString {
-    fn from(value: (&str, Option<Vec<Constraint>>)) -> Self {
+impl From<(Span<'_>, Option<Vec<Constraint>>)> for CharacterString {
+    fn from(value: (Span, Option<Vec<Constraint>>)) -> Self {
         CharacterString {
             constraints: value.1.unwrap_or_default(),
             ty: value.0.into(),
@@ -442,7 +442,7 @@ pub struct SequenceOrSetMember {
 
 impl
     From<(
-        &str,
+        Span<'_>,
         Option<AsnTag>,
         ASN1Type,
         Option<Vec<Constraint>>,
@@ -452,7 +452,7 @@ impl
 {
     fn from(
         value: (
-            &str,
+            Span,
             Option<AsnTag>,
             ASN1Type,
             Option<Vec<Constraint>>,
@@ -461,7 +461,7 @@ impl
         ),
     ) -> Self {
         SequenceOrSetMember {
-            name: value.0.into(),
+            name: value.0.to_string(),
             tag: value.1,
             ty: value.2,
             is_optional: value.4.is_some() || value.5.is_some(),
@@ -539,10 +539,10 @@ pub struct ChoiceOption {
     pub constraints: Vec<Constraint>,
 }
 
-impl From<(&str, Option<AsnTag>, ASN1Type, Option<Vec<Constraint>>)> for ChoiceOption {
-    fn from(value: (&str, Option<AsnTag>, ASN1Type, Option<Vec<Constraint>>)) -> Self {
+impl From<(Span<'_>, Option<AsnTag>, ASN1Type, Option<Vec<Constraint>>)> for ChoiceOption {
+    fn from(value: (Span, Option<AsnTag>, ASN1Type, Option<Vec<Constraint>>)) -> Self {
         ChoiceOption {
-            name: value.0.into(),
+            name: value.0.to_string(),
             tag: value.1,
             ty: value.2,
             constraints: value.3.unwrap_or_default(),
@@ -620,10 +620,10 @@ pub struct DistinguishedValue {
     pub value: i128,
 }
 
-impl From<(&str, i128)> for DistinguishedValue {
-    fn from(value: (&str, i128)) -> Self {
+impl From<(Span<'_>, i128)> for DistinguishedValue {
+    fn from(value: (Span, i128)) -> Self {
         Self {
-            name: value.0.into(),
+            name: value.0.to_string(),
             value: value.1,
         }
     }
@@ -637,11 +637,11 @@ pub struct ChoiceSelectionType {
     pub selected_option: String,
 }
 
-impl From<(&str, &str)> for ChoiceSelectionType {
-    fn from(value: (&str, &str)) -> Self {
+impl From<(Span<'_>, Span<'_>)> for ChoiceSelectionType {
+    fn from(value: (Span, Span)) -> Self {
         Self {
-            choice_name: value.1.into(),
-            selected_option: value.0.into(),
+            choice_name: value.1.to_string(),
+            selected_option: value.0.to_string(),
         }
     }
 }

--- a/rasn-compiler/src/lexer/boolean.rs
+++ b/rasn-compiler/src/lexer/boolean.rs
@@ -3,14 +3,13 @@ use nom::{
     bytes::complete::tag,
     combinator::{into, map, opt, value},
     sequence::preceded,
-    IResult,
 };
 
 use crate::intermediate::{ASN1Type, ASN1Value, BOOLEAN, FALSE, TRUE};
 
-use super::{common::skip_ws_and_comments, constraint::constraint};
+use super::{common::skip_ws_and_comments, constraint::constraint, LexerResult, Span};
 
-pub fn boolean_value(input: &str) -> IResult<&str, ASN1Value> {
+pub fn boolean_value(input: Span) -> LexerResult<ASN1Value> {
     alt((
         value(ASN1Value::Boolean(true), skip_ws_and_comments(tag(TRUE))),
         value(ASN1Value::Boolean(false), skip_ws_and_comments(tag(FALSE))),
@@ -25,7 +24,7 @@ pub fn boolean_value(input: &str) -> IResult<&str, ASN1Value> {
 /// If the match succeeds, the lexer will consume the match and return the remaining string
 /// and an `ASN1Type::Boolean` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
-pub fn boolean(input: &str) -> IResult<&str, ASN1Type> {
+pub fn boolean(input: Span) -> LexerResult<ASN1Type> {
     map(
         into(skip_ws_and_comments(preceded(
             tag(BOOLEAN),
@@ -44,7 +43,7 @@ mod tests {
     #[test]
     fn parses_boolean() {
         assert_eq!(
-            boolean(" --who would put a comment here?--BOOLEAN")
+            boolean(Span::new(" --who would put a comment here?--BOOLEAN"))
                 .unwrap()
                 .1,
             ASN1Type::Boolean(Boolean {

--- a/rasn-compiler/src/lexer/common.rs
+++ b/rasn-compiler/src/lexer/common.rs
@@ -8,14 +8,14 @@ use nom::{
     error::Error,
     multi::{many0, many1},
     sequence::{delimited, pair, preceded, terminated},
-    IResult,
 };
 
 use crate::intermediate::{constraints::*, types::*, *};
 
 use super::{
     asn1_value,
-    util::{map_into, opt_delimited, take_until_or, take_until_unbalanced},
+    util::{opt_delimited, take_until_or, take_until_unbalanced},
+    LexerResult, Span,
 };
 
 /// Parses an ASN1 comment.
@@ -29,11 +29,11 @@ use super::{
 /// _The lexical item "comment" can have two forms:_
 ///    * _One-line comments which begin with "--" as defined in 12.6.3;_
 ///    * _Multiple-line comments which begin with "/*" as defined in 12.6.4._
-pub fn comment(input: &str) -> IResult<&str, &str> {
+pub fn comment(input: Span) -> LexerResult<Span> {
     skip_ws(alt((block_comment, line_comment)))(input)
 }
 
-pub fn line_comment(input: &str) -> IResult<&str, &str> {
+pub fn line_comment(input: Span) -> LexerResult<Span> {
     delimited(
         tag(LINE_COMMENT),
         take_until_or("\n", LINE_COMMENT),
@@ -41,7 +41,7 @@ pub fn line_comment(input: &str) -> IResult<&str, &str> {
     )(input)
 }
 
-pub fn block_comment(input: &str) -> IResult<&str, &str> {
+pub fn block_comment(input: Span) -> LexerResult<Span> {
     delimited(
         tag(BLOCK_COMMENT_START),
         take_until_unbalanced(BLOCK_COMMENT_START, BLOCK_COMMENT_END),
@@ -60,21 +60,21 @@ pub fn block_comment(input: &str) -> IResult<&str, &str> {
 /// _12.3 An "identifier" shall consist of an arbitrary number (one or more) of letters, digits,
 /// and hyphens. The initial character shall be a lower-case letter. A hyphen shall not be the
 /// last character. A hyphen shall not be immediately followed by another hyphen._
-pub fn identifier(input: &str) -> IResult<&str, &str> {
+pub fn identifier(input: Span) -> LexerResult<Span> {
     skip_ws_and_comments(recognize(pair(
         alpha1,
         many0(alt((preceded(char('-'), alphanumeric1), alphanumeric1))),
     )))(input)
 }
 
-pub fn title_case_identifier(input: &str) -> IResult<&str, &str> {
+pub fn title_case_identifier(input: Span) -> LexerResult<Span> {
     map_res(
         recognize(pair(
             one_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"),
             many0(alt((preceded(char('-'), alphanumeric1), alphanumeric1))),
         )),
-        |identifier| {
-            if ASN1_KEYWORDS.contains(&identifier) {
+        |identifier: Span| {
+            if ASN1_KEYWORDS.contains(&*identifier) {
                 Err(nom::Err::Error(Error {
                     input,
                     code: nom::error::ErrorKind::Tag,
@@ -86,30 +86,30 @@ pub fn title_case_identifier(input: &str) -> IResult<&str, &str> {
     )(input)
 }
 
-pub fn value_identifier(input: &str) -> IResult<&str, &str> {
+pub fn value_identifier(input: Span) -> LexerResult<Span> {
     recognize(pair(
         one_of("abcdefghijklmnopqrstuvwxyz"),
         many0(alt((preceded(char('-'), alphanumeric1), alphanumeric1))),
     ))(input)
 }
 
-pub fn skip_ws<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn skip_ws<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> LexerResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> LexerResult<'a, O>,
 {
     preceded(multispace0, inner)
 }
 
-pub fn skip_ws_and_comments<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn skip_ws_and_comments<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> LexerResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> LexerResult<'a, O>,
 {
     preceded(many0(alt((comment, multispace1))), inner)
 }
 
-pub fn in_parentheses<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn in_parentheses<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> LexerResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> LexerResult<'a, O>,
 {
     delimited(
         skip_ws_and_comments(char(LEFT_PARENTHESIS)),
@@ -118,9 +118,9 @@ where
     )
 }
 
-pub fn in_brackets<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn in_brackets<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> LexerResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> LexerResult<'a, O>,
 {
     delimited(
         skip_ws_and_comments(char(LEFT_BRACKET)),
@@ -129,9 +129,9 @@ where
     )
 }
 
-pub fn in_version_brackets<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn in_version_brackets<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> LexerResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> LexerResult<'a, O>,
 {
     delimited(
         skip_ws_and_comments(tag("[[")),
@@ -140,9 +140,9 @@ where
     )
 }
 
-pub fn opt_parentheses<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn opt_parentheses<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> LexerResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> LexerResult<'a, O>,
 {
     opt_delimited::<char, O, char, _, _, _>(
         skip_ws_and_comments(char(LEFT_BRACKET)),
@@ -151,9 +151,9 @@ where
     )
 }
 
-pub fn in_braces<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn in_braces<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> LexerResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> LexerResult<'a, O>,
 {
     delimited(
         skip_ws_and_comments(char(LEFT_BRACE)),
@@ -162,11 +162,11 @@ where
     )
 }
 
-pub fn all_value(input: &str) -> IResult<&str, ASN1Value> {
+pub fn all_value(input: Span) -> LexerResult<ASN1Value> {
     value(ASN1Value::All, skip_ws_and_comments(tag(ALL)))(input)
 }
 
-pub fn asn_tag(input: &str) -> IResult<&str, AsnTag> {
+pub fn asn_tag(input: Span) -> LexerResult<AsnTag> {
     into(pair(
         in_brackets(pair(
             opt(skip_ws_and_comments(alt((
@@ -183,19 +183,19 @@ pub fn asn_tag(input: &str) -> IResult<&str, AsnTag> {
     ))(input)
 }
 
-pub fn range_seperator(input: &str) -> IResult<&str, RangeSeperator> {
+pub fn range_seperator(input: Span) -> LexerResult<RangeSeperator> {
     skip_ws_and_comments(tag(RANGE))(input).map(|(remaining, _)| (remaining, RangeSeperator()))
 }
 
-pub fn extension_marker(input: &str) -> IResult<&str, ExtensionMarker> {
+pub fn extension_marker(input: Span) -> LexerResult<ExtensionMarker> {
     skip_ws_and_comments(tag(ELLIPSIS))(input).map(|(remaining, _)| (remaining, ExtensionMarker()))
 }
 
-pub fn assignment(input: &str) -> IResult<&str, &str> {
+pub fn assignment(input: Span) -> LexerResult<Span> {
     skip_ws_and_comments(tag(ASSIGN))(input)
 }
 
-pub fn distinguished_values(input: &str) -> IResult<&str, Vec<DistinguishedValue>> {
+pub fn distinguished_values(input: Span) -> LexerResult<Vec<DistinguishedValue>> {
     delimited(
         skip_ws_and_comments(char(LEFT_BRACE)),
         many0(terminated(
@@ -206,26 +206,26 @@ pub fn distinguished_values(input: &str) -> IResult<&str, Vec<DistinguishedValue
     )(input)
 }
 
-pub fn distinguished_val(input: &str) -> IResult<&str, DistinguishedValue> {
-    map_into(pair(skip_ws_and_comments(identifier), in_parentheses(i128)))(input)
+pub fn distinguished_val(input: Span) -> LexerResult<DistinguishedValue> {
+    into(pair(skip_ws_and_comments(identifier), in_parentheses(i128)))(input)
 }
 
-pub fn optional_comma(input: &str) -> IResult<&str, Option<char>> {
+pub fn optional_comma(input: Span) -> LexerResult<Option<char>> {
     skip_ws_and_comments(opt(char(COMMA)))(input)
 }
 
-pub fn optional_marker(input: &str) -> IResult<&str, Option<OptionalMarker>> {
+pub fn optional_marker(input: Span) -> LexerResult<Option<OptionalMarker>> {
     opt(into(skip_ws_and_comments(tag(OPTIONAL))))(input)
 }
 
-pub fn default(input: &str) -> IResult<&str, Option<ASN1Value>> {
+pub fn default(input: Span) -> LexerResult<Option<ASN1Value>> {
     opt(preceded(
         skip_ws_and_comments(tag(DEFAULT)),
         skip_ws_and_comments(asn1_value),
     ))(input)
 }
 
-pub fn uppercase_identifier(input: &str) -> IResult<&str, &str> {
+pub fn uppercase_identifier(input: Span) -> LexerResult<Span> {
     alt((
         recognize(pair(
             one_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"),
@@ -243,14 +243,17 @@ pub fn uppercase_identifier(input: &str) -> IResult<&str, &str> {
 
 #[cfg(test)]
 mod tests {
+    use nom::{error::ErrorKind, Err, Slice as _};
 
     use super::*;
 
     #[test]
     fn parses_line_comment() {
-        let line = r#"-- Test, one, two, three/
-"#;
-        assert_eq!(" Test, one, two, three/", comment(line).unwrap().1);
+        let line = Span::new(
+            r#"-- Test, one, two, three/
+"#,
+        );
+        assert_eq!(" Test, one, two, three/", *comment(line).unwrap().1);
     }
 
     #[test]
@@ -258,10 +261,10 @@ mod tests {
         assert_eq!(
             r#" Test, one, two, three
 and one "#,
-            comment(
+            *comment(Span::new(
                 r#"/* Test, one, two, three
 and one */"#
-            )
+            ))
             .unwrap()
             .1
         );
@@ -269,23 +272,23 @@ and one */"#
             r#"*
        * Hello
        "#,
-            comment(
+            *comment(Span::new(
                 r#"/**
        * Hello
        */"#
-            )
+            ))
             .unwrap()
             .1
         );
         assert_eq!(
             " Very annoying! ",
-            comment("-- Very annoying! --").unwrap().1
+            *comment(Span::new("-- Very annoying! --")).unwrap().1
         )
     }
 
     #[test]
     fn parses_multiline_block_comment() {
-        assert_eq!(comment(r#"/**
+        assert_eq!(*comment(Span::new(r#"/**
       * This DE indicates a change of acceleration.
       *
       * The value shall be set to:
@@ -295,7 +298,7 @@ and one */"#
       * @category: Kinematic information
       * @revision: Created in V2.1.1
      */
-    StartOfDeclaration"#).unwrap().1,
+    StartOfDeclaration"#)).unwrap().1,
       "*\n      * This DE indicates a change of acceleration.\n      *\n      * The value shall be set to:\n      * - 0 - `accelerate` - if the magnitude of the horizontal velocity vector increases.\n      * - 1 - `decelerate` - if the magnitude of the horizontal velocity vector decreases.\n      *\n      * @category: Kinematic information\n      * @revision: Created in V2.1.1\n     "
     )
     }
@@ -306,10 +309,10 @@ and one */"#
     #[test]
     fn parses_block_comment_with_nested_comments() {
         assert_eq!(
-            comment(
+            *comment(Span::new(
                 r#"/*this is a comment /*
         this is a nested comment */ this text should be parsed*/"#
-            )
+            ))
             .unwrap()
             .1,
             "this is a comment /*
@@ -319,72 +322,193 @@ and one */"#
 
     #[test]
     fn parses_ambiguous_asn1_comment() {
-        assert_eq!(
-            comment(
-                r#" -- This means backward
-      unavailable"#
-            ),
-            Ok(("\n      unavailable", " This means backward",),)
-        );
-        assert_eq!(
-            comment(
-                r#"-- This means forward
-        backward    (2), -- This means backward"#
-            ),
-            Ok((
-                "\n        backward    (2), -- This means backward",
-                " This means forward",
-            ),)
-        )
+        {
+            let input = Span::new(" -- This means backward\n      unavailable");
+            let expect_rest = input.slice(23..);
+            let expect_value = input.slice(3..23);
+            assert_eq!(*expect_rest, "\n      unavailable");
+            assert_eq!(*expect_value, " This means backward");
+            assert_eq!(comment(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input =
+                Span::new("-- This means forward\n        backward    (2), -- This means backward");
+            let expect_rest = input.slice(21..);
+            let expect_value = input.slice(2..21);
+            assert_eq!(
+                *expect_rest,
+                "\n        backward    (2), -- This means backward"
+            );
+            assert_eq!(*expect_value, " This means forward");
+            assert_eq!(comment(input), Ok((expect_rest, expect_value)))
+        }
     }
 
     #[test]
     fn parses_valid_identifiers() {
-        assert_eq!(identifier("EEE-DDD"), Ok(("", "EEE-DDD")));
-        assert_eq!(identifier("GenericLane "), Ok((" ", "GenericLane")));
-        assert_eq!(identifier("regional "), Ok((" ", "regional")));
-        assert_eq!(identifier("NodeXY64"), Ok(("", "NodeXY64")));
-        assert_eq!(identifier("Sub-Cause-Code  "), Ok(("  ", "Sub-Cause-Code")));
+        {
+            let input = Span::new("EEE-DDD");
+            let expect_rest = input.slice(7..);
+            let expect_value = input.slice(0..7);
+            assert_eq!(*expect_rest, "");
+            assert_eq!(*expect_value, "EEE-DDD");
+            assert_eq!(identifier(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("GenericLane ");
+            let expect_rest = input.slice(11..);
+            let expect_value = input.slice(0..11);
+            assert_eq!(*expect_rest, " ");
+            assert_eq!(*expect_value, "GenericLane");
+            assert_eq!(identifier(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("regional ");
+            let expect_rest = input.slice(8..);
+            let expect_value = input.slice(0..8);
+            assert_eq!(*expect_rest, " ");
+            assert_eq!(*expect_value, "regional");
+            assert_eq!(identifier(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("NodeXY64");
+            let expect_rest = input.slice(8..);
+            let expect_value = input.slice(0..8);
+            assert_eq!(*expect_rest, "");
+            assert_eq!(*expect_value, "NodeXY64");
+            assert_eq!(identifier(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("Sub-Cause-Code  ");
+            let expect_rest = input.slice(14..);
+            let expect_value = input.slice(0..14);
+            assert_eq!(*expect_rest, "  ");
+            assert_eq!(*expect_value, "Sub-Cause-Code");
+            assert_eq!(identifier(input), Ok((expect_rest, expect_value)));
+        }
     }
 
     #[test]
     fn handles_invalid_identifiers() {
-        assert_eq!(identifier("EEE--DDD"), Ok(("--DDD", "EEE")));
-        assert!(identifier("-GenericLane").is_err());
-        assert!(identifier("64NodeXY").is_err());
-        assert!(identifier("&regional").is_err());
-        assert_eq!(identifier("Sub-Cause-Code-"), Ok(("-", "Sub-Cause-Code")));
+        {
+            let input = Span::new("EEE--DDD");
+            let expect_rest = input.slice(3..);
+            let expect_value = input.slice(0..3);
+            assert_eq!(*expect_rest, "--DDD");
+            assert_eq!(*expect_value, "EEE");
+            assert_eq!(identifier(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("-GenericLane");
+            let expect_rest = input.slice(0..);
+            assert_eq!(*expect_rest, "-GenericLane");
+            assert_eq!(
+                identifier(input),
+                Err(Err::Error(Error {
+                    input: expect_rest,
+                    code: ErrorKind::Alpha
+                }))
+            );
+        }
+        {
+            let input = Span::new("64NodeXY");
+            let expect_rest = input.slice(0..);
+            assert_eq!(*expect_rest, "64NodeXY");
+            assert_eq!(
+                identifier(Span::new("64NodeXY")),
+                Err(Err::Error(Error {
+                    input: expect_rest,
+                    code: ErrorKind::Alpha
+                }))
+            );
+        }
+        {
+            let input = Span::new("&regional");
+            let expect_rest = input.slice(0..);
+            assert_eq!(*expect_rest, "&regional");
+            assert_eq!(
+                identifier(Span::new("&regional")),
+                Err(Err::Error(Error {
+                    input: expect_rest,
+                    code: ErrorKind::Alpha
+                }))
+            );
+        }
+        {
+            let input = Span::new("Sub-Cause-Code-");
+            let expect_rest = input.slice(14..);
+            let expect_value = input.slice(0..14);
+            assert_eq!(*expect_rest, "-");
+            assert_eq!(*expect_value, "Sub-Cause-Code");
+            assert_eq!(identifier(input), Ok((expect_rest, expect_value)));
+        }
     }
 
     #[test]
     fn discards_whitespace() {
-        assert_eq!(skip_ws(identifier)(" EEE-DDD"), Ok(("", "EEE-DDD")));
-        assert_eq!(
-            skip_ws(identifier)("\nGenericLane "),
-            Ok((" ", "GenericLane"))
-        );
-        assert_eq!(skip_ws(identifier)("\t regional "), Ok((" ", "regional")));
-        assert_eq!(skip_ws(identifier)("   NodeXY64"), Ok(("", "NodeXY64")));
-        assert_eq!(
-            skip_ws(identifier)("\r\n\nSub-Cause-Code  "),
-            Ok(("  ", "Sub-Cause-Code"))
-        );
+        {
+            let input = Span::new(" EEE-DDD");
+            let expect_rest = input.slice(8..);
+            let expect_value = input.slice(1..8);
+            assert_eq!(*expect_rest, "");
+            assert_eq!(*expect_value, "EEE-DDD");
+            assert_eq!(skip_ws(identifier)(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("\nGenericLane ");
+            let expect_rest = input.slice(12..);
+            let expect_value = input.slice(1..12);
+            assert_eq!(*expect_rest, " ");
+            assert_eq!(*expect_value, "GenericLane");
+            assert_eq!(skip_ws(identifier)(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("\t regional ");
+            let expect_rest = input.slice(10..);
+            let expect_value = input.slice(2..10);
+            assert_eq!(*expect_rest, " ");
+            assert_eq!(*expect_value, "regional");
+            assert_eq!(skip_ws(identifier)(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("   NodeXY64");
+            let expect_rest = input.slice(11..);
+            let expect_value = input.slice(3..11);
+            assert_eq!(*expect_rest, "");
+            assert_eq!(*expect_value, "NodeXY64");
+            assert_eq!(skip_ws(identifier)(input), Ok((expect_rest, expect_value)));
+        }
+        {
+            let input = Span::new("\r\n\nSub-Cause-Code  ");
+            let expect_rest = input.slice(17..);
+            let expect_value = input.slice(3..17);
+            assert_eq!(*expect_rest, "  ");
+            assert_eq!(*expect_value, "Sub-Cause-Code");
+            assert_eq!(skip_ws(identifier)(input), Ok((expect_rest, expect_value)));
+        }
     }
 
     #[test]
     fn discards_whitespace_and_comments() {
+        let input = Span::new(" -- comment --EEE-DDD");
+        let expect_rest = input.slice(21..);
+        let expect_value = input.slice(14..21);
+        assert_eq!(*expect_rest, "");
+        assert_eq!(*expect_value, "EEE-DDD");
         assert_eq!(
-            skip_ws_and_comments(identifier)(" -- comment --EEE-DDD"),
-            Ok(("", "EEE-DDD"))
+            skip_ws_and_comments(identifier)(input),
+            Ok((expect_rest, expect_value))
         );
     }
 
     #[test]
     fn parses_distinguished_values() {
-        let sample = r#"{
+        let sample = Span::new(
+            r#"{
     positiveOutOfRange (160),
     unavailable        (161)
-}"#;
+}"#,
+        );
         assert_eq!(
             distinguished_values(sample).unwrap().1,
             [
@@ -402,11 +526,13 @@ and one */"#
 
     #[test]
     fn parses_distinguished_values_with_line_comments() {
-        let sample = r#"{
+        let sample = Span::new(
+            r#"{
     negativeOutOfRange (159), -- ignore this comment
     positiveOutOfRange (160), -- ignore this comment, too
     unavailable        (161)
-}"#;
+}"#,
+        );
         assert_eq!(
             distinguished_values(sample).unwrap().1,
             [

--- a/rasn-compiler/src/lexer/embedded_pdv.rs
+++ b/rasn-compiler/src/lexer/embedded_pdv.rs
@@ -1,8 +1,8 @@
-use nom::{bytes::complete::tag, combinator::value, IResult};
+use nom::{bytes::complete::tag, combinator::value};
 
 use crate::intermediate::*;
 
-use super::common::skip_ws_and_comments;
+use super::{common::skip_ws_and_comments, LexerResult, Span};
 
 /// Tries to parse an ASN1 EMBEDDED PDV
 ///
@@ -20,7 +20,7 @@ use super::common::skip_ws_and_comments;
 /// _"Embedded Presentation Data Value" from its use in the OSI_
 /// _Presentation Layer, but this expansion is not used today,_
 /// _and it should be interpreted as "embedded value"._
-pub fn embedded_pdv(input: &str) -> IResult<&str, ASN1Type> {
+pub fn embedded_pdv(input: Span) -> LexerResult<ASN1Type> {
     value(
         ASN1Type::EmbeddedPdv,
         skip_ws_and_comments(tag(EMBEDDED_PDV)),

--- a/rasn-compiler/src/lexer/error.rs
+++ b/rasn-compiler/src/lexer/error.rs
@@ -1,25 +1,27 @@
 use core::fmt::{Display, Formatter, Result};
 use std::error::Error;
 
+use super::Span;
+
 #[derive(Debug, Clone)]
 pub struct LexerError {
     pub details: String,
     pub kind: LexerErrorType,
 }
 
-impl<'a> From<nom::Err<nom::error::Error<&'a str>>> for LexerError {
-    fn from(value: nom::Err<nom::error::Error<&'a str>>) -> Self {
+impl From<nom::Err<nom::error::Error<Span<'_>>>> for LexerError {
+    fn from(value: nom::Err<nom::error::Error<Span>>) -> Self {
         match value {
             nom::Err::Incomplete(_) => Self {
                 details: "Unexpected end of input!".into(),
                 kind: LexerErrorType::NotEnoughData,
             },
             nom::Err::Error(e) => Self {
-                details: "Error matching ASN syntax while parsing:".to_owned() + e.input,
+                details: format!("Error matching ASN syntax while parsing: {}", e.input),
                 kind: LexerErrorType::MatchingError(e.code),
             },
             nom::Err::Failure(e) => Self {
-                details: "Unrecoverable error while parsing:".to_owned() + e.input,
+                details: format!("Unrecoverable error while parsing: {}", e.input),
                 kind: LexerErrorType::Failure(e.code),
             },
         }

--- a/rasn-compiler/src/lexer/external.rs
+++ b/rasn-compiler/src/lexer/external.rs
@@ -1,8 +1,8 @@
-use nom::{bytes::complete::tag, combinator::value, IResult};
+use nom::{bytes::complete::tag, combinator::value};
 
 use crate::intermediate::*;
 
-use super::common::skip_ws_and_comments;
+use super::{common::skip_ws_and_comments, LexerResult, Span};
 
 /// Tries to parse an ASN1 EXTERNAL
 ///
@@ -12,6 +12,6 @@ use super::common::skip_ws_and_comments;
 /// If the match succeeds, the lexer will consume the match and return the remaining string
 /// and an `ASN1Type::External` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
-pub fn external(input: &str) -> IResult<&str, ASN1Type> {
+pub fn external(input: Span) -> LexerResult<ASN1Type> {
     value(ASN1Type::External, skip_ws_and_comments(tag(EMBEDDED_PDV)))(input)
 }

--- a/rasn-compiler/src/lexer/null.rs
+++ b/rasn-compiler/src/lexer/null.rs
@@ -1,10 +1,10 @@
-use nom::{bytes::complete::tag, combinator::value, IResult};
+use nom::{bytes::complete::tag, combinator::value};
 
 use crate::intermediate::{ASN1Type, ASN1Value, NULL};
 
-use super::common::skip_ws_and_comments;
+use super::{common::skip_ws_and_comments, LexerResult, Span};
 
-pub fn null_value(input: &str) -> IResult<&str, ASN1Value> {
+pub fn null_value(input: Span) -> LexerResult<ASN1Value> {
     value(ASN1Value::Null, skip_ws_and_comments(tag(NULL)))(input)
 }
 
@@ -16,7 +16,7 @@ pub fn null_value(input: &str) -> IResult<&str, ASN1Value> {
 /// If the match succeeds, the lexer will consume the match and return the remaining string
 /// and an `ASN1Type::Null` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
-pub fn null(input: &str) -> IResult<&str, ASN1Type> {
+pub fn null(input: Span) -> LexerResult<ASN1Type> {
     value(ASN1Type::Null, skip_ws_and_comments(tag(NULL)))(input)
 }
 
@@ -27,7 +27,9 @@ mod tests {
     #[test]
     fn parses_null() {
         assert_eq!(
-            null(" --who would put a comment here?--NULL").unwrap().1,
+            null(Span::new(" --who would put a comment here?--NULL"))
+                .unwrap()
+                .1,
             ASN1Type::Null
         )
     }

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -13,13 +13,12 @@ use nom::{
     combinator::{into, map, opt},
     multi::many1,
     sequence::{pair, preceded},
-    IResult,
 };
 
 use super::{
     common::{in_braces, in_parentheses, skip_ws, skip_ws_and_comments, value_identifier},
     constraint::constraint,
-    RELATIVE_OID,
+    LexerResult, Span, RELATIVE_OID,
 };
 
 /// Tries to parse an ASN1 OBJECT IDENTIFIER
@@ -33,7 +32,7 @@ use super::{
 /// If the match succeeds, the lexer will consume the match and return the remaining string
 /// and an `ObjectIdentifier` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
-pub fn object_identifier_value(input: &str) -> IResult<&str, ObjectIdentifierValue> {
+pub fn object_identifier_value(input: Span) -> LexerResult<ObjectIdentifierValue> {
     into(skip_ws_and_comments(preceded(
         // TODO: store info whether the object id is relative
         opt(alt((tag(OBJECT_IDENTIFIER), tag(RELATIVE_OID)))),
@@ -41,7 +40,7 @@ pub fn object_identifier_value(input: &str) -> IResult<&str, ObjectIdentifierVal
     )))(input)
 }
 
-pub fn object_identifier(input: &str) -> IResult<&str, ASN1Type> {
+pub fn object_identifier(input: Span) -> LexerResult<ASN1Type> {
     map(
         into(preceded(
             skip_ws_and_comments(alt((tag(OBJECT_IDENTIFIER), tag(RELATIVE_OID)))),
@@ -51,7 +50,7 @@ pub fn object_identifier(input: &str) -> IResult<&str, ASN1Type> {
     )(input)
 }
 
-fn object_identifier_arc(input: &str) -> IResult<&str, ObjectIdentifierArc> {
+fn object_identifier_arc(input: Span) -> LexerResult<ObjectIdentifierArc> {
     skip_ws(alt((
         numeric_id,
         into(pair(value_identifier, skip_ws(in_parentheses(u128)))),
@@ -59,7 +58,7 @@ fn object_identifier_arc(input: &str) -> IResult<&str, ObjectIdentifierArc> {
     )))(input)
 }
 
-fn numeric_id(input: &str) -> IResult<&str, ObjectIdentifierArc> {
+fn numeric_id(input: Span) -> LexerResult<ObjectIdentifierArc> {
     map(u128, |i| i.into())(input)
 }
 
@@ -70,9 +69,11 @@ mod tests {
     #[test]
     fn parses_ansi_x9_62() {
         assert_eq!(
-            object_identifier_value(r#"{iso(1) member-body(2) us(840) 10045 modules(0) 2}"#)
-                .unwrap()
-                .1,
+            object_identifier_value(Span::new(
+                r#"{iso(1) member-body(2) us(840) 10045 modules(0) 2}"#
+            ))
+            .unwrap()
+            .1,
             ObjectIdentifierValue(vec![
                 ObjectIdentifierArc {
                     name: Some("iso".into()),

--- a/rasn-compiler/src/lexer/real.rs
+++ b/rasn-compiler/src/lexer/real.rs
@@ -5,15 +5,15 @@ use nom::{
     character::complete::{char, i32, i64, u64},
     combinator::{map, opt, value},
     sequence::{delimited, preceded, separated_pair, tuple},
-    IResult,
 };
 
 use super::{
     common::{in_braces, skip_ws_and_comments},
     constraint::constraint,
+    LexerResult, Span,
 };
 
-pub fn real_value(input: &str) -> IResult<&str, ASN1Value> {
+pub fn real_value(input: Span) -> LexerResult<ASN1Value> {
     map(
         skip_ws_and_comments(alt((dot_notation, mbe_notation))),
         ASN1Value::Real,
@@ -28,7 +28,7 @@ pub fn real_value(input: &str) -> IResult<&str, ASN1Value> {
 /// If the match succeeds, the lexer will consume the match and return the remaining string
 /// and a wrapped `Real` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
-pub fn real(input: &str) -> IResult<&str, ASN1Type> {
+pub fn real(input: Span) -> LexerResult<ASN1Type> {
     map(
         preceded(
             skip_ws_and_comments(tag(REAL)),
@@ -38,7 +38,7 @@ pub fn real(input: &str) -> IResult<&str, ASN1Type> {
     )(input)
 }
 
-fn dot_notation(input: &str) -> IResult<&str, f64> {
+fn dot_notation(input: Span) -> LexerResult<f64> {
     map(
         skip_ws_and_comments(separated_pair(i64, char('.'), u64)),
         |(wholes, decimals)| {
@@ -55,7 +55,7 @@ fn dot_notation(input: &str) -> IResult<&str, f64> {
     )(input)
 }
 
-fn mbe_notation(input: &str) -> IResult<&str, f64> {
+fn mbe_notation(input: Span) -> LexerResult<f64> {
     map(
         in_braces(tuple((
             delimited(
@@ -88,17 +88,17 @@ mod tests {
         ASN1Type, ASN1Value,
     };
 
-    use crate::lexer::real::real_value;
+    use crate::lexer::{real::real_value, Span};
 
     use super::real;
 
     #[test]
     fn parses_simple_real_type() {
         assert_eq!(
-            real(
+            real(Span::new(
                 r#" REAL -- Nothing here
         NextType ::= TestType"#
-            )
+            ))
             .unwrap()
             .1,
             ASN1Type::Real(Real {
@@ -110,12 +110,12 @@ mod tests {
     #[test]
     fn parses_constraint_real_type() {
         assert_eq!(
-            real(
+            real(Span::new(
                 r#"REAL (WITH COMPONENTS {
                     mantissa (-16777215..16777215),
                     base (2),
                     exponent (-125..128) } )"#
-            )
+            ))
             .unwrap()
             .1,
             ASN1Type::Real(Real {
@@ -176,16 +176,19 @@ mod tests {
 
     #[test]
     fn parses_dot_notation_real_value() {
-        assert_eq!(real_value("2.23412").unwrap().1, ASN1Value::Real(2.23412));
         assert_eq!(
-            real_value("-12.23412").unwrap().1,
+            real_value(Span::new("2.23412")).unwrap().1,
+            ASN1Value::Real(2.23412)
+        );
+        assert_eq!(
+            real_value(Span::new("-12.23412")).unwrap().1,
             ASN1Value::Real(-12.23412)
         )
     }
 
     #[test]
     fn parses_mbe_notation_real_value() {
-        if let ASN1Value::Real(r) = real_value("{mantissa 334159, base 10, exponent -5}")
+        if let ASN1Value::Real(r) = real_value(Span::new("{mantissa 334159, base 10, exponent -5}"))
             .unwrap()
             .1
         {
@@ -193,7 +196,10 @@ mod tests {
         } else {
             unreachable!()
         }
-        if let ASN1Value::Real(r) = real_value("{mantissa 0, base 2, exponent 100}").unwrap().1 {
+        if let ASN1Value::Real(r) = real_value(Span::new("{mantissa 0, base 2, exponent 100}"))
+            .unwrap()
+            .1
+        {
             assert!(r < 0.0000001 && r > -0.000001);
         } else {
             unreachable!()

--- a/rasn-compiler/src/lexer/set.rs
+++ b/rasn-compiler/src/lexer/set.rs
@@ -4,7 +4,6 @@ use nom::{
     combinator::opt,
     multi::many0,
     sequence::{terminated, tuple},
-    IResult,
 };
 
 use crate::intermediate::*;
@@ -21,7 +20,7 @@ use super::{common::optional_comma, constraint::constraint, sequence::sequence_c
 /// contains anonymous built-in types as members, these nested built-in types will be represented as
 /// structs within the same global scope.
 /// If the match fails, the lexer will not consume the input and will return an error.
-pub fn set(input: &str) -> IResult<&str, ASN1Type> {
+pub fn set(input: Span) -> LexerResult<ASN1Type> {
     map(
         preceded(
             skip_ws_and_comments(tag(SET)),
@@ -53,10 +52,12 @@ mod tests {
     #[test]
     fn issue_2_test() {
         assert_eq!(
-            set(r#"SET {
+            set(Span::new(
+                r#"SET {
             title VisibleString,
             children SEQUENCE OF VisibleString DEFAULT {}
-        }"#)
+        }"#
+            ))
             .unwrap()
             .1,
             ASN1Type::Set(SequenceOrSet {

--- a/rasn-compiler/src/lexer/set_of.rs
+++ b/rasn-compiler/src/lexer/set_of.rs
@@ -3,13 +3,13 @@ use nom::{
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::{pair, preceded},
-    IResult,
 };
 
 use super::{
     asn1_type,
     common::{opt_parentheses, skip_ws_and_comments, value_identifier},
     constraint::constraint,
+    LexerResult, Span,
 };
 
 /// Tries to parse an ASN1 SET OF
@@ -20,7 +20,7 @@ use super::{
 /// If the match succeeds, the lexer will consume the match and return the remaining string
 /// and a wrapped `SetOf` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
-pub fn set_of(input: &str) -> IResult<&str, ASN1Type> {
+pub fn set_of(input: Span) -> LexerResult<ASN1Type> {
     map(
         pair(
             preceded(
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn parses_simple_set_of() {
         assert_eq!(
-            set_of("SET OF BOOLEAN").unwrap().1,
+            set_of(Span::new("SET OF BOOLEAN")).unwrap().1,
             ASN1Type::SetOf(SequenceOrSetOf {
                 constraints: vec![],
                 element_type: Box::new(ASN1Type::Boolean(Boolean {
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn parses_simple_set_of_elsewhere_declared_type() {
         assert_eq!(
-            set_of("SET OF Things").unwrap().1,
+            set_of(Span::new("SET OF Things")).unwrap().1,
             ASN1Type::SetOf(SequenceOrSetOf {
                 constraints: vec![],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn parses_constraint_set_of_elsewhere_declared_type() {
         assert_eq!(
-            set_of("SET SIZE (1..13,...) OF CorrelationCellValue  ")
+            set_of(Span::new("SET SIZE (1..13,...) OF CorrelationCellValue  "))
                 .unwrap()
                 .1,
             ASN1Type::SetOf(SequenceOrSetOf {
@@ -103,9 +103,11 @@ mod tests {
     #[test]
     fn parses_constraint_set_of_with_extra_parentheses() {
         assert_eq!(
-            set_of("SET (SIZE (1..13, ...)) OF CorrelationCellValue  ")
-                .unwrap()
-                .1,
+            set_of(Span::new(
+                "SET (SIZE (1..13, ...)) OF CorrelationCellValue  "
+            ))
+            .unwrap()
+            .1,
             ASN1Type::SetOf(SequenceOrSetOf {
                 constraints: vec![Constraint::SubtypeConstraint(ElementSet {
                     set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
@@ -129,11 +131,11 @@ mod tests {
     #[test]
     fn parses_constraint_set_of_constraint_integer() {
         assert_eq!(
-            set_of(
+            set_of(Span::new(
                 r#"SET SIZE (1..13,...) OF INTEGER {
               one-distinguished-value (12)
             } (1..13,...) "#
-            )
+            ))
             .unwrap()
             .1,
             ASN1Type::SetOf(SequenceOrSetOf {
@@ -168,10 +170,10 @@ mod tests {
     #[test]
     fn parses_parameterized_constrained_set_of() {
         assert_eq!(
-            set_of(
+            set_of(Span::new(
                 r#"SET (SIZE(1..4)) OF
       RegionalExtension {{Reg-MapData}} OPTIONAL,"#
-            )
+            ))
             .unwrap()
             .1,
             ASN1Type::SetOf(SequenceOrSetOf {
@@ -203,12 +205,12 @@ mod tests {
     fn handles_object_field_ref() {
         println!(
             "{:?}",
-            set_of(
+            set_of(Span::new(
                 r#"SET (SIZE(1..MAX)) OF
         IEEE1609DOT2-HEADERINFO-CONTRIBUTED-EXTENSION.&Extn({
         Ieee1609Dot2HeaderInfoContributedExtensions
       }{@.contributorId})"#
-            )
+            ))
             .unwrap()
             .1
         )

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -14,7 +14,7 @@ use crate::lexer::top_level_information_declaration;
 
 #[test]
 fn parses_toplevel_simple_integer_declaration() {
-    let tld = top_level_type_declaration(
+    let tld = top_level_type_declaration(Span::new(
         "/**
           * The DE represents a cardinal number that counts the size of a set.
           *
@@ -22,7 +22,7 @@ fn parses_toplevel_simple_integer_declaration() {
           * @revision: Created in V2.1.1
          */
          CardinalNumber3b ::= INTEGER(1..8)",
-    )
+    ))
     .unwrap()
     .1;
     assert_eq!(tld.name, String::from("CardinalNumber3b"));
@@ -47,7 +47,7 @@ fn parses_toplevel_simple_integer_declaration() {
 
 #[test]
 fn parses_toplevel_macro_integer_declaration() {
-    let tld = top_level_type_declaration(r#"/**
+    let tld = top_level_type_declaration(Span::new(r#"/**
         * This DE represents the magnitude of the acceleration vector in a defined coordinate system.
         *
         * The value shall be set to:
@@ -63,7 +63,7 @@ fn parses_toplevel_macro_integer_declaration() {
       AccelerationMagnitudeValue ::= INTEGER {
           positiveOutOfRange (160),
           unavailable        (161)
-      } (0.. 161, ...)"#).unwrap().1;
+      } (0.. 161, ...)"#)).unwrap().1;
     assert_eq!(tld.name, String::from("AccelerationMagnitudeValue"));
     assert!(tld.comments.contains("@unit 0,1 m/s^2"));
     if let ASN1Type::Integer(int) = tld.ty {
@@ -94,13 +94,13 @@ fn parses_toplevel_macro_integer_declaration() {
 
 #[test]
 fn parses_toplevel_enumerated_declaration() {
-    let tld = top_level_type_declaration(
+    let tld = top_level_type_declaration(Span::new(
         r#"-- Coverage Enhancement level encoded according to TS 36.331 [16] --
         CE-mode-B-SupportIndicator ::= ENUMERATED {
            supported,
            ...
         }"#,
-    )
+    ))
     .unwrap()
     .1;
     assert_eq!(tld.name, String::from("CE-mode-B-SupportIndicator"));
@@ -127,14 +127,14 @@ fn parses_toplevel_enumerated_declaration() {
 #[test]
 fn parses_toplevel_boolean_declaration() {
     let tld = top_level_type_declaration(
-            r#"/**
+            Span::new(r#"/**
             * This DE indicates whether a vehicle (e.g. public transport vehicle, truck) is under the embarkation process.
             * If that is the case, the value is *TRUE*, otherwise *FALSE*.
             *
             * @category: Vehicle information
             * @revision: editorial update in V2.1.1
             */
-           EmbarkationStatus ::= BOOLEAN"#,
+           EmbarkationStatus ::= BOOLEAN"#,)
         )
         .unwrap()
         .1;
@@ -152,13 +152,13 @@ fn parses_toplevel_boolean_declaration() {
 
 #[test]
 fn parses_toplevel_crossrefering_declaration() {
-    let tld = top_level_type_declaration(
+    let tld = top_level_type_declaration(Span::new(
         r#"-- Comments go here
         EventZone::= EventHistory
         ((WITH COMPONENT (WITH COMPONENTS {..., eventDeltaTime PRESENT})) |
          (WITH COMPONENT (WITH COMPONENTS {..., eventDeltaTime ABSENT})))
          }"#,
-    )
+    ))
     .unwrap()
     .1;
     assert_eq!(
@@ -203,10 +203,10 @@ fn parses_toplevel_crossrefering_declaration() {
 
 #[test]
 fn parses_anonymous_sequence_of_declaration() {
-    let tld = top_level_type_declaration(
+    let tld = top_level_type_declaration(Span::new(
         r#"--Comments
         InterferenceManagementZones ::= SEQUENCE (SIZE(1..16), ...) OF InterferenceManagementZone"#,
-    )
+    ))
     .unwrap()
     .1;
     assert_eq!(
@@ -241,14 +241,14 @@ fn parses_anonymous_sequence_of_declaration() {
 #[test]
 fn parses_object_set_value() {
     assert_eq!(
-        top_level_information_declaration(
+        top_level_information_declaration(Span::new(
             r#"--comments
         CpmContainers CPM-CONTAINER-ID-AND-TYPE ::= {
         {OriginatingVehicleContainer IDENTIFIED BY originatingVehicleContainer} |
         {PerceivedObjectContainer IDENTIFIED BY perceivedObjectContainer},
         ...
     }"#
-        )
+        ))
         .unwrap()
         .1,
         ToplevelInformationDefinition {
@@ -311,9 +311,9 @@ fn parses_object_set_value() {
 #[test]
 fn parses_empty_extensible_object_set() {
     assert_eq!(
-        top_level_information_declaration(
+        top_level_information_declaration(Span::new(
             r#"Reg-AdvisorySpeed	            REG-EXT-ID-AND-TYPE ::= { ... }"#
-        )
+        ))
         .unwrap()
         .1,
         ToplevelInformationDefinition {
@@ -333,12 +333,12 @@ fn parses_empty_extensible_object_set() {
 #[test]
 fn parses_class_declaration() {
     assert_eq!(
-        top_level_information_declaration(
+        top_level_information_declaration(Span::new(
             r#"REG-EXT-ID-AND-TYPE ::= CLASS {
                   &id     RegionId UNIQUE,
                   &Type
                 } WITH SYNTAX {&Type IDENTIFIED BY &id}"#
-        )
+        ))
         .unwrap()
         .1,
         ToplevelInformationDefinition {
@@ -388,12 +388,12 @@ fn parses_class_declaration() {
 #[test]
 fn parses_parameterized_declaration() {
     assert_eq!(
-        top_level_type_declaration(
+        top_level_type_declaration(Span::new(
             r#"RegionalExtension {REG-EXT-ID-AND-TYPE : Set} ::= SEQUENCE {
                   regionId     REG-EXT-ID-AND-TYPE.&id( {Set} ),
                   regExtValue  REG-EXT-ID-AND-TYPE.&Type( {Set}{@regionId} )
                 }"#
-        )
+        ))
         .unwrap()
         .1,
         ToplevelTypeDefinition {
@@ -466,13 +466,13 @@ fn parses_parameterized_declaration() {
 #[test]
 fn parses_choice() {
     assert_eq!(
-        top_level_type_declaration(
+        top_level_type_declaration(Span::new(
             r#"Choice-example ::= CHOICE
                 {normal NULL,
                 high NULL,
                 ...,
                 medium NULL }"#
-        )
+        ))
         .unwrap()
         .1,
         ToplevelTypeDefinition {
@@ -513,17 +513,21 @@ fn parses_choice() {
 fn parses_sequence_of_value() {
     println!(
         "{:?}",
-        top_level_value_declaration(r#"test-Sequence SEQUENCE OF INTEGER ::= { 1, 2, 3 }"#)
-            .unwrap()
-            .1
+        top_level_value_declaration(Span::new(
+            r#"test-Sequence SEQUENCE OF INTEGER ::= { 1, 2, 3 }"#
+        ))
+        .unwrap()
+        .1
     )
 }
 
 #[test]
 fn parses_comment_after_end() {
-    assert!(end(r#"
+    assert!(end(Span::new(
+        r#"
         END
 
-        -- Generated by Asnp, the ASN.1 pretty-printer of France Telecom R&D"#)
+        -- Generated by Asnp, the ASN.1 pretty-printer of France Telecom R&D"#
+    ))
     .is_ok())
 }

--- a/rasn-compiler/src/lib.rs
+++ b/rasn-compiler/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
 
 use generator::Backend;
 use intermediate::ToplevelDefinition;
-use lexer::asn_spec;
+use lexer::{asn_spec, Span};
 use validator::Validator;
 
 pub mod prelude {
@@ -389,7 +389,7 @@ impl<B: Backend> Compiler<B, CompilerSourcesSet> {
                 AsnSource::Literal(l) => l.clone(),
             };
             modules.append(
-                &mut asn_spec(&stringified_src)?
+                &mut asn_spec(Span::new(&stringified_src))?
                     .into_iter()
                     .flat_map(|(header, tlds)| {
                         let header_ref = Rc::new(RefCell::new(header));

--- a/rasn-compiler/src/tests.rs
+++ b/rasn-compiler/src/tests.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, io::Write, rc::Rc};
 
 use nom::FindSubstring;
 
-use crate::validator::Validator;
+use crate::{lexer::Span, validator::Validator};
 
 /// This function generates a stepwise-end-to-end test for a given ASN.1 module,
 /// i.e. it generates test functions with corresponding inputs and expected outputs for
@@ -142,11 +142,11 @@ fn as_decl_string<I: std::fmt::Debug>(input: I) -> String {
 }
 
 fn expected_lexer_result(literal: &str) -> String {
-    as_decl_string(crate::lexer::asn_spec(literal).unwrap())
+    as_decl_string(crate::lexer::asn_spec(Span::new(literal)).unwrap())
 }
 
 fn validator_io(literal: &str) -> (String, String) {
-    let input = crate::lexer::asn_spec(literal)
+    let input = crate::lexer::asn_spec(Span::new(literal))
         .unwrap()
         .into_iter()
         .flat_map(|(header, tlds)| {

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -6,14 +6,12 @@ mod information_object;
 mod types;
 mod utils;
 
-use std::{
-    borrow::BorrowMut,
-    collections::BTreeMap,
-};
+use std::{borrow::BorrowMut, collections::BTreeMap};
 
 use crate::{
     common::INTERNAL_NESTED_TYPE_NAME_PREFIX,
     intermediate::{error::*, information_object::*, types::*, utils::*, *},
+    lexer::Span,
     validator::{
         linking::utils::bit_string_to_octet_string,
         parameterization::{Parameterization, ParameterizationArgument},
@@ -474,7 +472,7 @@ impl ASN1Type {
                                 impl_tlds.insert(
                                     dummy_reference.clone(),
                                     ToplevelDefinition::Value(ToplevelValueDefinition::from((
-                                        dummy_reference.as_str(),
+                                        Span::new(dummy_reference),
                                         v.clone(),
                                         gov.clone(),
                                     ))),
@@ -484,7 +482,7 @@ impl ASN1Type {
                                 impl_tlds.insert(
                                     dummy_reference.clone(),
                                     ToplevelDefinition::Type(ToplevelTypeDefinition::from((
-                                        dummy_reference.as_str(),
+                                        Span::new(dummy_reference),
                                         t.clone(),
                                     ))),
                                 );
@@ -501,7 +499,7 @@ impl ASN1Type {
                                 let mut info = ASN1Information::ObjectSet(o.clone());
                                 info.link_object_set_reference(tlds);
                                 let mut tld = ToplevelInformationDefinition::from((
-                                    dummy_reference.as_str(),
+                                    Span::new(dummy_reference),
                                     info,
                                     c.as_str()
                                 ));

--- a/rasn-compiler/src/validator/linking/utils.rs
+++ b/rasn-compiler/src/validator/linking/utils.rs
@@ -6,9 +6,8 @@ use crate::{
         information_object::*,
         *,
     },
-    lexer::asn1_value,
+    lexer::{asn1_value, Span},
 };
-
 
 pub(crate) fn find_tld_or_enum_value_by_name(
     type_name: &String,
@@ -159,7 +158,7 @@ pub fn resolve_custom_syntax(
                                     index,
                                     InformationObjectField::FixedValueField(FixedValueField {
                                         identifier: token.name_or_empty().to_owned(),
-                                        value: match asn1_value(&t.identifier) {
+                                        value: match asn1_value(Span::new(&t.identifier)) {
                                             Ok((_, v)) => Ok(v),
                                             Err(e) => Err(GrammarError {
                                                 details: format!("Syntax mismatch while resolving information object: {e:?}"),


### PR DESCRIPTION
[`nom_locate`](https://docs.rs/nom_locate/latest/nom_locate/) keeps track of source file location of parsed input. This opens the future possibility to include source file location in error messages.

It could also be used to include source file location of parsed objects, for example to include it in generated output comments or for more details in later error messages.