### PR TITLE
Typescript: Fix issue on enumerated comment descriptions

### DIFF
--- a/rasn-compiler/src/generator/typescript/builder.rs
+++ b/rasn-compiler/src/generator/typescript/builder.rs
@@ -166,11 +166,11 @@ impl Typescript {
                     .into_iter()
                     .fold(String::new(), |mut acc, en| {
                         acc.push_str(&format!(
-                            r#"{}{} = "{}",
+                            r#"{} = "{}", {}
                         "#,
-                            en.description.map_or(String::default(), |d| d + "\n"),
                             to_jer_identifier(&en.name),
                             en.name,
+                            en.description.map_or(String::default(), |d| format!("//{}", d)),
                         ));
                         acc
                     }),


### PR DESCRIPTION
This PR fixes a problem which generates invalid TS code when an ASN.1 enumerated definition contains comments in its elements. For example, with the following ASN.1 descriptions:

```
CopValue::= ENUMERATED {
	noEntry (0),
	co2class1 (1), -- below 101 g/km
	co2class2 (2), -- 101 to 120 g/km
	co2class3 (3), -- 121 to 140 g/km
	co2class4 (4), -- 141 to 160 g/km
	co2class5 (5), -- 161 to 200 g/km
	co2class6 (6), -- 201 to 250 g/km
	co2class7 (7), -- above 250 g/km
	reservedforUse (8) -- reserved for future CEN and ISO use
} 
```

The output of the compiler incorrectly messes up the variables with the comments.
```js
export enum CopValue {
        noEntry = "noEntry",
        below 101 g/km
co2class1 = "co2class1",
        101 to 120 g / km
co2class2 = "co2class2",
        121 to 140 g / km
co2class3 = "co2class3",
        141 to 160 g / km
co2class4 = "co2class4",
        161 to 200 g / km
co2class5 = "co2class5",
        201 to 250 g / km
co2class6 = "co2class6",
        above 250 g / km
co2class7 = "co2class7",
        reserved for future CEN and ISO use
reservedforUse = "reservedforUse",
};
```

With this fix it now outputs correct TS code, as follows:
```js
export enum CopValue {
        noEntry = "noEntry",
        co2class1 = "co2class1", // below 101 g/km
        co2class2 = "co2class2", // 101 to 120 g/km
        co2class3 = "co2class3", // 121 to 140 g/km
        co2class4 = "co2class4", // 141 to 160 g/km
        co2class5 = "co2class5", // 161 to 200 g/km
        co2class6 = "co2class6", // 201 to 250 g/km
        co2class7 = "co2class7", // above 250 g/km
        reservedforUse = "reservedforUse", // reserved for future CEN and ISO use
};
```