### PR TITLE
refactor(rasn): use fixed variant for strictly constrained

### DIFF
--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -162,16 +162,16 @@ e2e_pdu!(
             last(1),
         } SIZE(2)                                           "#,
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
-        #[rasn(delegate, size("2"), identifier = "Test-Bits")]
-        pub struct TestBits(pub BitString);                     "#
+        #[rasn(delegate, identifier = "Test-Bits")]
+        pub struct TestBits(pub FixedBitString<2usize>);                     "#
 );
 
 e2e_pdu!(
     bit_string_strict,
     "Test-Bits ::= BIT STRING SIZE(4)",
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
-        #[rasn(delegate, size("4"), identifier = "Test-Bits")]
-        pub struct TestBits(pub BitString);                                 "#
+        #[rasn(delegate, identifier = "Test-Bits")]
+        pub struct TestBits(pub FixedBitString<4usize>);                                 "#
 );
 
 e2e_pdu!(
@@ -240,8 +240,8 @@ e2e_pdu!(
     octet_string_strict,
     "Test-Octets ::= OCTET STRING SIZE(4)",
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
-        #[rasn(delegate, size("4"), identifier = "Test-Octets")]
-        pub struct TestOctets(pub OctetString);                                 "#
+        #[rasn(delegate, identifier = "Test-Octets")]
+        pub struct TestOctets(pub FixedOctetString<4usize>);                                 "#
 );
 
 e2e_pdu!(

--- a/rasn-compiler/src/generator/rasn/template.rs
+++ b/rasn-compiler/src/generator/rasn/template.rs
@@ -95,6 +95,20 @@ pub fn bit_string_template(
     }
 }
 
+pub fn fixed_bit_string_template(
+    comments: TokenStream,
+    name: TokenStream,
+    annotations: TokenStream,
+    size: TokenStream,
+) -> TokenStream {
+    quote! {
+        #comments
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #annotations
+        pub struct #name(pub FixedBitString<#size>);
+    }
+}
+
 pub fn octet_string_template(
     comments: TokenStream,
     name: TokenStream,
@@ -105,6 +119,20 @@ pub fn octet_string_template(
         #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub OctetString);
+    }
+}
+
+pub fn fixed_octet_string_template(
+    comments: TokenStream,
+    name: TokenStream,
+    annotations: TokenStream,
+    size: TokenStream,
+) -> TokenStream {
+    quote! {
+        #comments
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #annotations
+        pub struct #name(pub FixedOctetString<#size>);
     }
 }
 


### PR DESCRIPTION
Uses `rasn`s `FixedBitString` and `FixedOctetString` for strictly size-constrained `BIT STRING`s and `OCTET STRING`s. Closes #42 