### PR TITLE
fix(linker): link defaults in nested choices

### DIFF
--- a/rasn-compiler-tests/tests/parse_test.rs
+++ b/rasn-compiler-tests/tests/parse_test.rs
@@ -56,7 +56,7 @@ fn compile_etsi() {
             // .add_asn_by_path("../rasn-compiler/test_asn1/ngap_container.asn")
             // .add_asn_by_path("../rasn-compiler/test_asn1/ngap_ies.asn")
             // .add_asn_by_path("../rasn-compiler/test_asn1/ngap_pdus.asn")
-            .add_asn_by_path("../rasn-compiler/test_asn1/test.asn")
+            .add_asn_by_path("../rasn-compiler/test_asn1/rrc.asn")
             .set_output_path("./tests")
             .compile()
     );

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -253,6 +253,10 @@ impl ASN1Type {
                         .unwrap_or(Ok(()))
                 })
             }
+            ASN1Type::Choice(ref mut c) => c
+                .options
+                .iter_mut()
+                .try_for_each(|o| o.ty.collect_supertypes(tlds)),
             _ => Ok(()),
         }
     }


### PR DESCRIPTION
Correctly links `DEFAULT` values in `SEQUENCE`s or `SET`s that are nested within a `CHOICE`'s options.
Closes #54 