### PR TITLE
feat:enable graphic string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,29 @@ dependencies = [
  "num-integer",
  "num-traits",
  "once_cell",
- "rasn-derive",
+ "rasn-derive 0.22.0",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
+name = "rasn"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc2d7ef9630c50239937d1eeb07e4fd3129c016441c5276b087f7975eb4e2c2"
+dependencies = [
+ "bitvec",
+ "bitvec-nom2",
+ "bytes",
+ "chrono",
+ "either",
+ "hashbrown",
+ "nom",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "rasn-derive 0.24.0",
  "serde_json",
  "snafu",
 ]
@@ -515,7 +537,7 @@ dependencies = [
  "bytes",
  "lazy_static",
  "num-bigint",
- "rasn",
+ "rasn 0.24.0",
  "rasn-compiler",
  "rasn-compiler-derive",
  "rasn-kerberos",
@@ -528,7 +550,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f2c367bf1b9a9bc34d40b9c140b52d26b585d0c7755b18496ba061f50639082"
 dependencies = [
  "proc-macro2",
- "rasn-derive-impl",
+ "rasn-derive-impl 0.22.0",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "rasn-derive"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5c332ddd8ace677cf246699782a34b79cbfa484c73523578f3c7d883dc8813"
+dependencies = [
+ "proc-macro2",
+ "rasn-derive-impl 0.24.0",
  "syn 2.0.90",
 ]
 
@@ -547,12 +580,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rasn-derive-impl"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb5b4227db5fc7d1743a6089f4f43617b76b636d2d4293aade6144bc64a4c90"
+dependencies = [
+ "either",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "uuid",
+]
+
+[[package]]
 name = "rasn-kerberos"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7673d436cfa354be88234726bd0e2a811da6ca12d5dc6479b9537c769dc01380"
 dependencies = [
- "rasn",
+ "rasn 0.22.0",
 ]
 
 [[package]]

--- a/rasn-compiler-tests/Cargo.toml
+++ b/rasn-compiler-tests/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 [dependencies]
 rasn-compiler-derive = { path = "../rasn-compiler-derive" }
 rasn-compiler = { path = "../rasn-compiler" }
-rasn = { version = "0.22.0" }
+rasn = { version = "0.24.0" }
 
 [dev-dependencies]
 bitvec = { version = "1" }

--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -694,6 +694,76 @@ e2e_pdu!(
 );
 
 e2e_pdu!(
+    graphic,
+    r#" Test-String ::= GraphicString
+        test-string-val Test-String ::= "012345""#,
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #[rasn(delegate, identifier = "Test-String")]
+        pub struct TestString(pub GraphicString);
+        lazy_static!{
+            pub static ref TEST_STRING_VAL: TestString = TestString(
+                GraphicString::try_from(String::from("012345")).unwrap()
+            );
+        }                                                           "#
+);
+
+e2e_pdu!(
+    graphic_strict,
+    r#" Test-String ::= GraphicString SIZE (4)
+        test-string-val Test-String ::= "012345""#,
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #[rasn(delegate, size("4"), identifier = "Test-String")]
+        pub struct TestString(pub GraphicString);
+        lazy_static!{
+            pub static ref TEST_STRING_VAL: TestString = TestString(
+                GraphicString::try_from(String::from("012345")).unwrap()
+            );
+        }                                                           "#
+);
+
+e2e_pdu!(
+    graphic_strict_ext,
+    r#" Test-String ::= GraphicString SIZE (4,...)
+        test-string-val Test-String ::= "012345""#,
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #[rasn(delegate, size("4", extensible), identifier = "Test-String")]
+        pub struct TestString(pub GraphicString);
+        lazy_static!{
+            pub static ref TEST_STRING_VAL: TestString = TestString(
+                GraphicString::try_from(String::from("012345")).unwrap()
+            );
+        }                                                           "#
+);
+
+e2e_pdu!(
+    graphic_range,
+    r#" Test-String ::= GraphicString SIZE (4..6)
+        test-string-val Test-String ::= "012345""#,
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #[rasn(delegate, size("4..=6"), identifier = "Test-String")]
+        pub struct TestString(pub GraphicString);
+        lazy_static!{
+            pub static ref TEST_STRING_VAL: TestString = TestString(
+                GraphicString::try_from(String::from("012345")).unwrap()
+            );
+        }                                                           "#
+);
+
+e2e_pdu!(
+    graphic_range_ext,
+    r#" Test-String ::= GraphicString SIZE (4..6,...)
+        test-string-val Test-String ::= "012345""#,
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #[rasn(delegate, size("4..=6", extensible), identifier = "Test-String")]
+        pub struct TestString(pub GraphicString);
+        lazy_static!{
+            pub static ref TEST_STRING_VAL: TestString = TestString(
+                GraphicString::try_from(String::from("012345")).unwrap()
+            );
+        }                                                           "#
+);
+
+e2e_pdu!(
     utf8,
     r#" Test-String ::= UTF8String
         test-string-val Test-String ::= "012345""#,

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -493,8 +493,8 @@ impl Rasn {
                     CharacterStringType::BMPString => quote!(BMPString),
                     CharacterStringType::PrintableString => quote!(PrintableString),
                     CharacterStringType::GeneralString => quote!(GeneralString),
-                    CharacterStringType::GraphicString
-                    | CharacterStringType::TeletexString
+                    CharacterStringType::GraphicString => quote!(GraphicString),
+                    CharacterStringType::TeletexString
                     | CharacterStringType::VideotexString
                     | CharacterStringType::UniversalString => {
                         return Err(GeneratorError::new(

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -587,11 +587,7 @@ impl Rasn {
                 details: "VideotexString is currently unsupported!".into(),
                 top_level_declaration: None,
             }),
-            CharacterStringType::GraphicString => Err(GeneratorError {
-                kind: GeneratorErrorType::NotYetInplemented,
-                details: "GraphicString is currently unsupported!".into(),
-                top_level_declaration: None,
-            }),
+            CharacterStringType::GraphicString => Ok(quote!(GraphicString)),
             CharacterStringType::GeneralString => Ok(quote!(GeneralString)),
             CharacterStringType::UniversalString => Err(GeneratorError {
                 kind: GeneratorErrorType::NotYetInplemented,
@@ -871,8 +867,10 @@ impl Rasn {
                     CharacterStringType::GeneralString => {
                         Ok(quote!(GeneralString::try_from(String::from(#val)).unwrap()))
                     }
+                    CharacterStringType::GraphicString => {
+                        Ok(quote!(GraphicString::try_from(String::from(#val)).unwrap()))
+                    }
                     CharacterStringType::VideotexString
-                    | CharacterStringType::GraphicString
                     | CharacterStringType::UniversalString
                     | CharacterStringType::TeletexString => Err(GeneratorError::new(
                         None,
@@ -948,8 +946,8 @@ impl Rasn {
                     CharacterStringType::BMPString => Ok(quote!(BMPString)),
                     CharacterStringType::PrintableString => Ok(quote!(PrintableString)),
                     CharacterStringType::GeneralString => Ok(quote!(GeneralString)),
+                    CharacterStringType::GraphicString => Ok(quote!(GraphicString)),
                     CharacterStringType::VideotexString
-                    | CharacterStringType::GraphicString
                     | CharacterStringType::UniversalString
                     | CharacterStringType::TeletexString => Err(GeneratorError::new(
                         None,


### PR DESCRIPTION
Adds GraphicString support the ASN.1 compiler.

Graphic string support was added to rasn in this commit: https://github.com/librasn/rasn/commit/d97c44d4a58076738a2eab345101cc763ccb2178