### PR TITLE
feat(error): implement Error for CompilerError

### DIFF
--- a/rasn-compiler/src/error.rs
+++ b/rasn-compiler/src/error.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fmt::Display;
 
 use crate::{
@@ -33,6 +34,8 @@ impl Display for CompilerError {
         }
     }
 }
+
+impl Error for CompilerError {}
 
 impl From<LexerError> for CompilerError {
     fn from(value: LexerError) -> Self {


### PR DESCRIPTION
Addresses #89 for `rasn-compiler` so we can do something like:

```rust
fn main() -> Result<(), Box<dyn Error>> {
    Compiler::<RasnBackend, _>::new()
        .add_asn_by_path("test.asn")
        .set_output_path("./test.rs")
        .compile()?;

    Ok(())
}
```