### PR TITLE
fix(generator): use single underscore in kebab to snake case conversion

### DIFF
--- a/rasn-compiler-tests/tests/parameterization.rs
+++ b/rasn-compiler-tests/tests/parameterization.rs
@@ -113,18 +113,18 @@ e2e_pdu! {
     #[non_exhaustive]
     pub struct A2XPC5FlowBitRates {
         #[rasn(identifier = "a2X-GuaranteedFlowBitRate")]
-        pub a2_x__guaranteed_flow_bit_rate: bool,
+        pub a2_x_guaranteed_flow_bit_rate: bool,
         #[rasn(identifier = "iE-Extensions")]
-        pub i_e__extensions: Option<A2XPC5FlowBitRatesIEExtensions>,
+        pub i_e_extensions: Option<A2XPC5FlowBitRatesIEExtensions>,
     }
     impl A2XPC5FlowBitRates {
         pub fn new(
-            a2_x__guaranteed_flow_bit_rate: bool,
-            i_e__extensions: Option<A2XPC5FlowBitRatesIEExtensions>,
+            a2_x_guaranteed_flow_bit_rate: bool,
+            i_e_extensions: Option<A2XPC5FlowBitRatesIEExtensions>,
         ) -> Self {
             Self {
-                a2_x__guaranteed_flow_bit_rate,
-                i_e__extensions,
+                a2_x_guaranteed_flow_bit_rate,
+                i_e_extensions,
             }
         }
     }

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -1105,7 +1105,7 @@ impl Rasn {
         while let Some(c) = peekable.next() {
             if c.is_lowercase() || c == '_' || c.is_numeric() {
                 lowercase.push(c);
-                if peekable.peek().map_or(false, |next| next.is_uppercase()) {
+                if c != '_' && peekable.peek().map_or(false, |next| next.is_uppercase()) {
                     lowercase.push('_');
                 }
             } else {
@@ -1140,10 +1140,7 @@ impl Rasn {
         let input = input.drain(..).fold(String::new(), |mut acc, c| {
             if acc.is_empty() && c.is_lowercase() {
                 acc.push(c.to_ascii_uppercase());
-            } else if acc.ends_with(|last: char| last == '_') && c.is_uppercase() {
-                acc.pop();
-                acc.push(c);
-            } else if acc.ends_with(|last: char| last == '_') {
+            } else if acc.ends_with('_') {
                 acc.pop();
                 acc.push(c.to_ascii_uppercase());
             } else {
@@ -1499,7 +1496,7 @@ is_recursive: false,
         assert_eq!(generator.to_rust_snake_case("hello-world"), "hello_world");
         assert_eq!(generator.to_rust_snake_case("HELLOWORLD"), "helloworld");
         assert_eq!(generator.to_rust_snake_case("HelloWORLD"), "hello_world");
-        assert_eq!(generator.to_rust_snake_case("HELLO-WORLD"), "hello__world");
+        assert_eq!(generator.to_rust_snake_case("HELLO-WORLD"), "hello_world");
         assert_eq!(generator.to_rust_snake_case("struct"), "r_struct");
         assert_eq!(generator.to_rust_snake_case("STRUCT"), "r_struct");
     }


### PR DESCRIPTION
Addresses the case where "Kebab-Case" was converted to "kebab__case". After the change, we get "kebab_case".

issue: #88