### PR TITLE
feat(rasn): add custom imports and type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,26 @@ The compiler backends can be configured by instantiating the compiler using the 
 
 The `RasnBackend` configuration supports the following parameters:
 
--   **opaque_open_types**: `bool`: [Default: `false`] ASN.1 Open Types are represented as the `rasn::types::Any` type,
-    which holds a binary `content`. If `opaque_open_types` is `false`, the compiler will generate additional de-/encode methods for
-    all rust types that hold an open type. For example, bindings for a `SEQUENCE` with a field of Open Type value will include a method for explicitly decoding the Open Type field. _Non-opaque open types are still
+-   **opaque_open_types**: `bool`: [Default: `true`] ASN.1 Open Types are represented as the `rasn::types::Any` type,
+    which holds a binary `content`. If `opaque_open_types` is `false`, the compiler will generate additional de-/encode
+    methods for all rust types that hold an open type. For example, bindings for a `SEQUENCE` with a field of Open Type
+    value will include a method for explicitly decoding the Open Type field. _Non-opaque open types are still
     experimental. If you have trouble generating correct bindings, switch back to opaque open types._
 -   **default_wildcard_imports**: `bool`: [Default: `false`] The compiler will try to match module import dependencies
     of the ASN.1 module as close as possible, importing only those types from other modules that are imported in the
     ASN.1 module. If the `default_wildcard_imports` is set to `true` , the compiler will instead always import the
     entire module using the wildcard `*` for each module that the input ASN.1 module imports from.
+-   **generate_from_impls**: `bool`: [Default: `false`] To make working with the generated types a bit more ergonomic,
+    the compiler can generate `From` impls for the wrapper inner types in a `CHOICE`, as long as the generated impls are
+    not ambiguous.
+-   **custom_imports**: `Vec<String>`: Stringified paths to items that will be imported into all generated modules with
+    a [use declaration](https://doc.rust-lang.org/reference/items/use-declarations.html). For example
+    `vec![String::from("my::module::*"), String::from("path::to::my::Struct")]`.
+-   **type_annotations**: `Vec<String>`: [Default:
+    `vec![String::from("#[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]")]`] Annotations to be
+    added to all generated rust types of the bindings. Each vector element will generate a new line of annotations. Note
+    that the compiler will automatically add all pound-derives needed by `rasn` **except** `Eq` and `Hash`, which are
+    needed only when working with `SET`s.
 
 ### Creating a Custom Backend
 
@@ -160,6 +172,8 @@ Currently, `rasn` supports the following encoding rules:
 -   Aligned Packed Encoding Rules (APER)
 -   Unaligned Packed Encoding Rules (UPER)
 -   JSON Encoding Rules (JER)
+-   Octet Encoding Rules (OER)
+-   XML Encoding Rules (XER)
 
 `rasn` and the `rasn-compiler` support the following ASN1 features:
 
@@ -167,9 +181,11 @@ Currently, `rasn` supports the following encoding rules:
 
 -   `NULL` type and value
 -   `BOOLEAN` type and value
+-   `REAL` type and value
 -   `NumericString` type and value
 -   `VisibleString` type and value
 -   `IA5String` type and value
+-   `GraphicString` type and value
 -   `GeneralString` type and value
 -   `UTF8String` type and value
 -   `BMPString` type and value
@@ -212,5 +228,7 @@ Currently, `rasn` supports the following encoding rules:
 ## Troubleshooting
 
 If you have trouble generating correct bindings:
- * try playing around with the compiler configuration that can be passed to the `Compiler::new_with_config` constructor
- * open an issue [here](https://github.com/librasn/compiler/issues), if possible with a sample of the problematic ASN.1 spec
+
+-   try playing around with the compiler configuration that can be passed to the `Compiler::new_with_config` constructor
+-   open an issue [here](https://github.com/librasn/compiler/issues), if possible with a sample of the problematic ASN.1
+    spec

--- a/rasn-compiler-tests/tests/edge_cases.rs
+++ b/rasn-compiler-tests/tests/edge_cases.rs
@@ -114,7 +114,7 @@ e2e_pdu!(
         }
     "#,
     r#"
-        #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(enumerated)]
         pub enum EnumWithDefault {
             first = 1,

--- a/rasn-compiler-tests/tests/information_objects.rs
+++ b/rasn-compiler-tests/tests/information_objects.rs
@@ -66,7 +66,7 @@ e2e_pdu!(
         local(Integer),
         global(ObjectIdentifier),
     }
-    #[derive(Debug, Clone, PartialEq, AsnType, Decode, Encode)]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(size("4"), delegate)]
     pub struct Inner_Errors_ParameterType_2(pub BitString);
     #[derive(Debug, Clone, PartialEq)]

--- a/rasn-compiler-tests/tests/nested_types.rs
+++ b/rasn-compiler-tests/tests/nested_types.rs
@@ -6,7 +6,7 @@ e2e_pdu!(
     r#" Test-Boolean ::= BOOLEAN
         Wrapping-Boolean ::= Test-Boolean
         value Wrapping-Boolean ::= FALSE"#,
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(delegate, identifier = "Test-Boolean")]
         pub struct TestBoolean(pub bool);
 
@@ -44,7 +44,7 @@ e2e_pdu!(
             boolean Wrapping-Boolean,
         }
         value Test-Sequence ::= { boolean TRUE }"#,
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(delegate, identifier = "Test-Boolean")]
         pub struct TestBoolean(pub bool);
 

--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -4,7 +4,7 @@ use rasn_compiler_tests::e2e_pdu;
 e2e_pdu!(
     boolean,
     "Test-Boolean ::= BOOLEAN",
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(delegate, identifier = "Test-Boolean")]
         pub struct TestBoolean(pub bool);                                 "#
 );
@@ -118,7 +118,7 @@ e2e_pdu!(
 e2e_pdu!(
     null,
     "Test-Int ::= NULL",
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(delegate, identifier = "Test-Int")]
         pub struct TestInt(pub ());                                 "#
 );
@@ -287,7 +287,7 @@ e2e_pdu!(
             test-2(7)
         }
         test-enum-val Test-Enum ::= test-2          "#,
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(enumerated, identifier = "Test-Enum")]
         pub enum TestEnum {
             #[rasn(identifier = "test-1")]
@@ -305,7 +305,7 @@ e2e_pdu!(
             test-2(-7)
         }
         test-enum-val Test-Enum ::= test-2          "#,
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(enumerated, identifier = "Test-Enum")]
         pub enum TestEnum {
             #[rasn(identifier = "test-1")]
@@ -320,7 +320,7 @@ e2e_pdu!(
     empty_enumerated,
     r#" Test-Enum ::= ENUMERATED {
         }                           "#,
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(enumerated, identifier = "Test-Enum")]
         pub enum TestEnum {
         }                                               "#
@@ -334,7 +334,7 @@ e2e_pdu!(
             test-2(7),
         }
         test-enum-val Test-Enum ::= test-2          "#,
-    r#" #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(enumerated, identifier = "Test-Enum")]
         #[non_exhaustive]
         pub enum TestEnum {

--- a/rasn-compiler-tests/tests/structured_types.rs
+++ b/rasn-compiler-tests/tests/structured_types.rs
@@ -340,7 +340,7 @@ e2e_pdu!(
     }
     "#,
     r#"
-        #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
+        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
         #[rasn(enumerated)]
         #[non_exhaustive]
         pub enum Passenger{

--- a/rasn-compiler-tests/tests/system_tests.rs
+++ b/rasn-compiler-tests/tests/system_tests.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types)]
-use rasn_compiler::prelude::{LexerError, LexerErrorType, ReportData};
+use rasn_compiler::prelude::{LexerError, LexerErrorType, RasnConfig, ReportData};
 use rasn_compiler_derive::asn1;
 #[allow(unused_imports)]
 use rasn_compiler_tests::e2e_pdu;
@@ -50,5 +50,88 @@ fn multi_module_error() {
         rasn_compiler::prelude::CompilerError::Lexer(LexerError {
             kind: LexerErrorType::MatchingError(ReportData { line: 12, .. })
         })
+    ))
+}
+
+#[test]
+fn custom_imports() {
+    let bindings =
+        rasn_compiler::Compiler::<rasn_compiler::prelude::RasnBackend, _>::new_with_config(
+            RasnConfig {
+                custom_imports: vec!["std::fmt::*".into(), "std::error::Error".into()],
+                ..Default::default()
+            },
+        )
+        .add_asn_literal(
+            r#"
+            TestModuleA DEFINITIONS AUTOMATIC TAGS::= BEGIN
+                Hello ::= INTEGER (4..8)
+            END
+        "#,
+        )
+        .compile_to_string()
+        .unwrap()
+        .generated;
+    assert!(bindings.contains("use std::error::Error;"));
+    assert!(bindings.contains("use std::fmt::*;"));
+}
+
+#[test]
+fn custom_derives_without_any_required() {
+    let bindings =
+        rasn_compiler::Compiler::<rasn_compiler::prelude::RasnBackend, _>::new_with_config(
+            RasnConfig {
+                type_annotations: vec![
+                    r#"#[serde(rename = "camelCase")]"#.into(),
+                    "#[derive(Serialize)]".into(),
+                ],
+                ..Default::default()
+            },
+        )
+        .add_asn_literal(
+            r#"
+            TestModuleA DEFINITIONS AUTOMATIC TAGS::= BEGIN
+                Hello ::= INTEGER (4..8)
+            END
+        "#,
+        )
+        .compile_to_string()
+        .unwrap()
+        .generated;
+    assert!(bindings.contains(
+        r#"#[serde(rename = "camelCase")]
+    #[derive(Serialize, Debug, AsnType, Encode, Decode, PartialEq, Clone)]
+    #[rasn(delegate, value("4..=8"))]
+    pub struct Hello(pub u8);"#
+    ))
+}
+
+#[test]
+fn custom_derives_without_some_required() {
+    let bindings =
+        rasn_compiler::Compiler::<rasn_compiler::prelude::RasnBackend, _>::new_with_config(
+            RasnConfig {
+                type_annotations: vec![
+                    r#"#[serde(rename = "camelCase")]"#.into(),
+                    "#[derive(Serialize, AsnType, Encode)]".into(),
+                ],
+                ..Default::default()
+            },
+        )
+        .add_asn_literal(
+            r#"
+            TestModuleA DEFINITIONS AUTOMATIC TAGS::= BEGIN
+                Hello ::= INTEGER (4..8)
+            END
+        "#,
+        )
+        .compile_to_string()
+        .unwrap()
+        .generated;
+    assert!(bindings.contains(
+        r#"#[serde(rename = "camelCase")]
+    #[derive(Serialize, AsnType, Encode, Debug, Decode, PartialEq, Clone)]
+    #[rasn(delegate, value("4..=8"))]
+    pub struct Hello(pub u8);"#
     ))
 }

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -112,7 +112,7 @@ impl Rasn {
                 self.format_comments(&tld.comments)?,
                 name,
                 self.to_rust_title_case(&dec.identifier),
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, false, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -180,7 +180,7 @@ impl Rasn {
             Ok(integer_template(
                 self.format_comments(&tld.comments)?,
                 name,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, false, true)?,
                 int.int_type().to_token_stream(),
             ))
         } else {
@@ -213,14 +213,14 @@ impl Rasn {
                 Ok(fixed_bit_string_template(
                     self.format_comments(&tld.comments)?,
                     name,
-                    self.join_annotations(annotations),
+                    self.join_annotations(annotations, false, true)?,
                     size.to_token_stream(),
                 ))
             } else {
                 Ok(bit_string_template(
                     self.format_comments(&tld.comments)?,
                     name,
-                    self.join_annotations(annotations),
+                    self.join_annotations(annotations, false, true)?,
                 ))
             }
         } else {
@@ -253,14 +253,14 @@ impl Rasn {
                 Ok(fixed_octet_string_template(
                     self.format_comments(&tld.comments)?,
                     name,
-                    self.join_annotations(annotations),
+                    self.join_annotations(annotations, false, true)?,
                     size.to_token_stream(),
                 ))
             } else {
                 Ok(octet_string_template(
                     self.format_comments(&tld.comments)?,
                     name,
-                    self.join_annotations(annotations),
+                    self.join_annotations(annotations, false, true)?,
                 ))
             }
         } else {
@@ -295,7 +295,7 @@ impl Rasn {
                 self.format_comments(&tld.comments)?,
                 name,
                 self.string_type(&char_str.ty)?,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, false, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -320,7 +320,7 @@ impl Rasn {
             Ok(boolean_template(
                 self.format_comments(&tld.comments)?,
                 name,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, true, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -564,7 +564,7 @@ impl Rasn {
         Ok(any_template(
             self.format_comments(&tld.comments)?,
             name,
-            self.join_annotations(annotations),
+            self.join_annotations(annotations, false, true)?,
         ))
     }
 
@@ -585,7 +585,7 @@ impl Rasn {
             Ok(generalized_time_template(
                 self.format_comments(&tld.comments)?,
                 name,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, false, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -613,7 +613,7 @@ impl Rasn {
             Ok(utc_time_template(
                 self.format_comments(&tld.comments)?,
                 name,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, false, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -645,7 +645,7 @@ impl Rasn {
             Ok(oid_template(
                 self.format_comments(&tld.comments)?,
                 name,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, false, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -673,7 +673,7 @@ impl Rasn {
             Ok(null_template(
                 self.format_comments(&tld.comments)?,
                 name,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, true, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -714,8 +714,8 @@ impl Rasn {
                 self.format_comments(&tld.comments)?,
                 name,
                 extensible,
-                self.format_enum_members(enumerated),
-                self.join_annotations(annotations),
+                self.format_enum_members(enumerated)?,
+                self.join_annotations(annotations, true, true)?,
             ))
         } else {
             Err(GeneratorError::new(
@@ -765,7 +765,7 @@ impl Rasn {
                 extensible,
                 formatted_options.enum_body,
                 formatted_options.nested_anonymous_types,
-                self.join_annotations(annotations),
+                self.join_annotations(annotations, false, true)?,
             );
             if self.config.generate_from_impls {
                 let mut map = BTreeMap::new();
@@ -897,7 +897,7 @@ impl Rasn {
                     extensible,
                     formatted_members.struct_body,
                     formatted_members.nested_anonymous_types,
-                    self.join_annotations(annotations),
+                    self.join_annotations(annotations, false, true)?,
                     self.format_default_methods(&seq.members, &name.to_string())?,
                     self.format_new_impl(&name, formatted_members.name_types),
                     class_fields,
@@ -962,7 +962,7 @@ impl Rasn {
             name,
             anonymous_item,
             member_type,
-            self.join_annotations(annotations),
+            self.join_annotations(annotations, false, true)?,
         ))
     }
 
@@ -1124,14 +1124,13 @@ impl Rasn {
                                 .ok()
                             })
                             .unwrap_or_default();
-                        let annotations = self.join_annotations(vec![
-                            range_constraints,
-                            alphabet_constraints,
-                            quote!(delegate),
-                        ]);
+                        let annotations = self.join_annotations(
+                            vec![range_constraints, alphabet_constraints, quote!(delegate)],
+                            false,
+                            true,
+                        )?;
                         ids.push((variant_name, delegate_id.clone(), identifier_value));
                         inner_types.push(quote! {
-                            #[derive(Debug, Clone, PartialEq, AsnType, Decode, Encode)]
                             #annotations
                             pub struct #delegate_id (pub #type_id);
 

--- a/rasn-compiler/src/generator/rasn/mod.rs
+++ b/rasn-compiler/src/generator/rasn/mod.rs
@@ -57,6 +57,16 @@ pub struct Config {
     /// This is disabled by default to generate less code, but can be enabled with
     /// `generate_from_impls` set to `true`.
     pub generate_from_impls: bool,
+    /// Stringified paths to items that will be imported into all generated modules with a
+    /// [use declaration](https://doc.rust-lang.org/reference/items/use-declarations.html).
+    /// For example `vec![String::from("my::module::*"), String::from("path::to::my::Struct")]`.
+    pub custom_imports: Vec<String>,
+    /// Annotations to be added to all generated rust types of the bindings. Each vector element
+    /// will generate a new line of annotations. Note that the compiler will automatically add all pound-derives
+    /// needed by `rasn` __except__ `Eq` and `Hash`, which are needed only when working with `SET`s.
+    ///
+    /// Default: `vec![String::from("#[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]")]`
+    pub type_annotations: Vec<String>,
 }
 
 #[cfg(target_family = "wasm")]
@@ -67,11 +77,15 @@ impl Config {
         opaque_open_types: bool,
         default_wildcard_imports: bool,
         generate_from_impls: Option<bool>,
+        custom_imports: Option<Vec<String>>,
+        type_annotations: Option<Vec<String>>,
     ) -> Self {
         Self {
             opaque_open_types,
             default_wildcard_imports,
             generate_from_impls: generate_from_impls.unwrap_or(false),
+            custom_imports: custom_imports.unwrap_or_default(),
+            type_annotations: type_annotations.unwrap_or(Config::default().type_annotations),
         }
     }
 }
@@ -82,6 +96,10 @@ impl Default for Config {
             opaque_open_types: true,
             default_wildcard_imports: false,
             generate_from_impls: false,
+            custom_imports: Vec::default(),
+            type_annotations: vec![String::from(
+                "#[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]",
+            )],
         }
     }
 }
@@ -123,6 +141,16 @@ impl Backend for Rasn {
             self.tagging_environment = module.tagging_environment;
             self.extensibility_environment = module.extensibility_environment;
             let name = self.to_rust_snake_case(&module.name);
+            let custom_imports = self
+                .config
+                .custom_imports
+                .iter()
+                .map(|i| TokenStream::from_str(i.as_str()).map(|i| quote!(use #i;)))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| GeneratorError {
+                    details: e.to_string(),
+                    ..Default::default()
+                })?;
             let imports = module.imports.iter().map(|import| {
                 let module =
                     self.to_rust_snake_case(&import.global_module_reference.module_reference);
@@ -171,7 +199,7 @@ impl Backend for Rasn {
                     use core::borrow::Borrow;
                     use rasn::prelude::*;
                     use lazy_static::lazy_static;
-
+                    #(#custom_imports)*
                     #(#imports)*
 
                     #(#pdus)*

--- a/rasn-compiler/src/generator/rasn/template.rs
+++ b/rasn-compiler/src/generator/rasn/template.rs
@@ -9,7 +9,6 @@ pub fn typealias_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name (pub #alias);
     }
@@ -49,7 +48,6 @@ pub fn integer_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name (pub #integer_type);
 
@@ -63,7 +61,6 @@ pub fn generalized_time_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub GeneralizedTime);
     }
@@ -76,7 +73,6 @@ pub fn utc_time_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub UtcTime);
     }
@@ -89,7 +85,6 @@ pub fn bit_string_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub BitString);
     }
@@ -103,7 +98,6 @@ pub fn fixed_bit_string_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub FixedBitString<#size>);
     }
@@ -116,7 +110,6 @@ pub fn octet_string_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub OctetString);
     }
@@ -130,7 +123,6 @@ pub fn fixed_octet_string_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub FixedOctetString<#size>);
     }
@@ -144,7 +136,6 @@ pub fn char_string_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub #string_type);
     }
@@ -157,7 +148,6 @@ pub fn boolean_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub bool);
     }
@@ -194,7 +184,6 @@ pub fn null_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub ());
     }
@@ -207,7 +196,6 @@ pub fn any_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub Any);
     }
@@ -220,7 +208,6 @@ pub fn oid_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         pub struct #name(pub ObjectIdentifier);
     }
@@ -235,7 +222,6 @@ pub fn enumerated_template(
 ) -> TokenStream {
     quote! {
         #comments
-        #[derive(AsnType, Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         #extensible
         pub enum #name {
@@ -275,7 +261,6 @@ pub fn sequence_or_set_template(
     quote! {
         #(#nested_members)*
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         #extensible
         pub struct #name {
@@ -304,7 +289,6 @@ pub fn sequence_or_set_of_template(
     quote! {
             #anonymous_item
             #comments
-            #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
             #annotations
             pub struct #name(pub #generic_type<#member_type>);
     }
@@ -349,7 +333,6 @@ pub fn choice_template(
     quote! {
         #(#nested_options)*
         #comments
-        #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #annotations
         #extensible
         pub enum #name {


### PR DESCRIPTION
- add two configuration parameters for the `Rasn` backend
- allow user to specify custom `use` imports that will be added to generated modules
- allow user to override annotations such as `#[derive]`s on generated types