### PR TITLE
fix(linker): build reference graph to stop at circular references in recursion detection

### DIFF
--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -1077,7 +1077,7 @@ impl IntegerType {
     /// Returns the Integer type with more restrictions
     /// - an IntegerType with a smaller set of values is considered more restrictive
     /// - an unsigned IntegerType is considered more restrictive if the size of the set of values is equal
-    /// if equal, `self` is returned
+    ///   if equal, `self` is returned
     pub fn max_restrictive(self, rhs: IntegerType) -> IntegerType {
         match (self, rhs) {
             (x, y) if x == y => x,

--- a/rasn-compiler/src/lexer/enumerated.rs
+++ b/rasn-compiler/src/lexer/enumerated.rs
@@ -30,7 +30,7 @@ pub fn enumerated_value(input: Input<'_>) -> ParserResult<'_, ToplevelValueDefin
             }),
             name: n.to_string(),
             parameterization: params,
-            associated_type: p.clone().into(),
+            associated_type: p.clone(),
             value: ASN1Value::EnumeratedValue {
                 enumerated: p.as_str().into_owned(),
                 enumerable: e.to_string(),

--- a/rasn-compiler/src/lexer/error.rs
+++ b/rasn-compiler/src/lexer/error.rs
@@ -229,7 +229,7 @@ impl<'a> ErrorTree<'a> {
         match self {
             ErrorTree::Leaf { kind, .. } => kind == &ErrorKind::Nom(nom::error::ErrorKind::Eof),
             ErrorTree::Branch { tip, .. } => tip.is_eof_error(),
-            ErrorTree::Fork { branches } => branches.back().map_or(false, |b| b.is_eof_error()),
+            ErrorTree::Fork { branches } => branches.back().is_some_and(|b| b.is_eof_error()),
         }
     }
 }

--- a/rasn-compiler/src/validator/linking/constraints.rs
+++ b/rasn-compiler/src/validator/linking/constraints.rs
@@ -97,8 +97,8 @@ impl SubtypeElement {
                 max,
                 extensible: _,
             } => {
-                min.as_ref().map_or(false, |s| s.is_elsewhere_declared())
-                    || max.as_ref().map_or(false, |s| s.is_elsewhere_declared())
+                min.as_ref().is_some_and(|s| s.is_elsewhere_declared())
+                    || max.as_ref().is_some_and(|s| s.is_elsewhere_declared())
             }
             SubtypeElement::SizeConstraint(s) => s.has_cross_reference(),
             SubtypeElement::TypeConstraint(t) => t.references_class_by_name(),

--- a/rasn-compiler/src/validator/mod.rs
+++ b/rasn-compiler/src/validator/mod.rs
@@ -334,7 +334,7 @@ impl Validator {
             .get(key)
             .map(|t| match t {
                 ToplevelDefinition::Type(t) => t.ty.references_class_by_name(),
-                ToplevelDefinition::Information(i) => i.class.as_ref().map_or(false, |c| match c {
+                ToplevelDefinition::Information(i) => i.class.as_ref().is_some_and(|c| match c {
                     ClassLink::ByReference(_) => false,
                     ClassLink::ByName(_) => true,
                 }),


### PR DESCRIPTION
Fixes #98
Recursion detection is traveling down the reference graph to detect recursive types. Since this graph is not necessarily acyclic, the compiler needs to keep track of visited nodes in order to detect circular references. A circular reference consists a recursion boundary for the recursion check, because the compiler can safely assume that the recursion present in the circular reference will be detected in a later step.