### PR TITLE
Fixes multiple character subsets parsing

### DIFF
--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -900,3 +900,11 @@ e2e_pdu!(
             );
         }                                                           "#
 );
+
+e2e_pdu!(
+    visible_from,
+    r#" FQDN ::= VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | ".-")) (SIZE (1..255))"#,
+    r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+        #[rasn(delegate, size("1..=255"), from("\u{2d}", "\u{2e}", "\u{30}..\u{39}", "\u{41}..\u{5a}", "\u{61}..\u{7a}"))]
+        pub struct FQDN(pub VisibleString);                             "#
+);

--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -905,6 +905,6 @@ e2e_pdu!(
     visible_from,
     r#" FQDN ::= VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | ".-")) (SIZE (1..255))"#,
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
-        #[rasn(delegate, size("1..=255"), from("\u{2d}", "\u{2e}", "\u{30}..\u{39}", "\u{41}..\u{5a}", "\u{61}..\u{7a}"))]
+        #[rasn(delegate, size("1..=255"), from("\u{2d}", "\u{2e}", "\u{30}..=\u{39}", "\u{41}..=\u{5a}", "\u{61}..=\u{7a}"))]
         pub struct FQDN(pub VisibleString);                             "#
 );

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -233,19 +233,22 @@ impl Rasn {
             .charset_subsets()
             .iter()
             .map(|subset| match subset {
-                CharsetSubset::Single(c) => format!("{}", c.escape_unicode()),
+                CharsetSubset::Single(c) => format!("\"{}\"", c.escape_unicode()),
                 CharsetSubset::Range { from, to } => format!(
-                    "{}..{}",
+                    "\"{}..{}\"",
                     from.map_or(String::from(""), |c| format!("{}", c.escape_unicode())),
                     to.map_or(String::from(""), |c| format!("{}", c.escape_unicode()))
                 ),
             })
-            .collect::<Vec<String>>()
+            .collect::<Vec<_>>()
             .join(", ");
         Ok(if alphabet_unicode.is_empty() {
             TokenStream::new()
         } else {
-            quote!(from(#alphabet_unicode))
+            let alphabet_ts: TokenStream = alphabet_unicode
+                .parse()                           // turn the text into *tokens*
+                .expect("internal error: cannot parse generated unicode list");
+            quote!(from(#alphabet_ts))
         })
     }
 

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -234,8 +234,9 @@ impl Rasn {
             .iter()
             .map(|subset| match subset {
                 CharsetSubset::Single(c) => format!("\"{}\"", c.escape_unicode()),
+                // ITU-T Rec. X.680 (07/2002) 47.4.1, E.2.2.2. range endpoints are inclusive
                 CharsetSubset::Range { from, to } => format!(
-                    "\"{}..{}\"",
+                    "\"{}..={}\"",
                     from.map_or(String::from(""), |c| format!("{}", c.escape_unicode())),
                     to.map_or(String::from(""), |c| format!("{}", c.escape_unicode()))
                 ),


### PR DESCRIPTION
**With this fix this**

```asn1
FQDN ::=
  VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | ".-"))(SIZE (1..255))
```

**Is compiled correctly as:**

```rust
    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
    #[rasn(
        delegate,
        size("1..=255"),
        from(
            "\u{2d}",
            "\u{2e}",
            "\u{30}..=\u{39}",
            "\u{41}..=\u{5a}",
            "\u{61}..=\u{7a}"
        )
    )]
    pub struct FQDN(pub VisibleString);
```

Without this fix, the "from" is missing and thus the decoding fails.

✅ All tests are passing