### PR TITLE
Some CLI ergonomics

### DIFF
--- a/rasn-compiler/src/bin.rs
+++ b/rasn-compiler/src/bin.rs
@@ -1,3 +1,5 @@
-fn main() {
-    rasn_compiler::cli::CompilerArgs::drive();
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    rasn_compiler::cli::CompilerArgs::drive()
 }

--- a/rasn-compiler/src/cli.rs
+++ b/rasn-compiler/src/cli.rs
@@ -50,14 +50,14 @@ impl CompilerArgs {
                 let entry = match entry {
                     Ok(entry) => entry,
                     Err(err) => {
-                        println!("{}", format!("Warning: {}", err).yellow());
+                        println!("{}: {err}", "warning".yellow());
                         continue;
                     }
                 };
                 let file_name = entry.file_name().to_string_lossy();
 
                 if file_name.ends_with(".asn") || file_name.ends_with(".asn1") {
-                    println!("Found ASN1 module {} in directory", file_name);
+                    println!("{}: Found ASN1 module {}", "info".blue(), file_name);
                     modules.push(entry.into_path());
                     module_found = true;
                 }
@@ -65,10 +65,16 @@ impl CompilerArgs {
 
             if !module_found {
                 println!(
-                    "{}",
-                    format!("No modules where found in '{}'", dir.display()).yellow()
+                    "{}: No modules where found in '{}'",
+                    "warning".yellow(),
+                    dir.display(),
                 );
             }
+        }
+
+        if modules.is_empty() {
+            println!("{}: No modules", "error".red());
+            return;
         }
 
         let results = if args.backend == "typescript" {
@@ -86,19 +92,11 @@ impl CompilerArgs {
         match results {
             Ok(warnings) => {
                 for warning in warnings {
-                    println!(
-                        "{}\n{}",
-                        "Rasn compiler warning:".yellow(),
-                        warning.to_string().yellow()
-                    )
+                    println!("{}: {warning}", "warning".yellow())
                 }
             }
             Err(error) => {
-                println!(
-                    "{}\n{}",
-                    "Rasn compiler error:".red(),
-                    error.to_string().red()
-                )
+                println!("{}: {error}", "error".red());
             }
         }
     }

--- a/rasn-compiler/src/cli.rs
+++ b/rasn-compiler/src/cli.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::process::ExitCode;
 
 use crate::prelude::*;
 
@@ -37,7 +38,7 @@ pub struct SourceArgsGroup {
 }
 
 impl CompilerArgs {
-    pub fn drive() {
+    pub fn drive() -> ExitCode {
         let args = CompilerArgs::parse();
 
         // Read module paths
@@ -74,7 +75,7 @@ impl CompilerArgs {
 
         if modules.is_empty() {
             println!("{}: No modules", "error".red());
-            return;
+            return ExitCode::FAILURE;
         }
 
         let results = if args.backend == "typescript" {
@@ -94,9 +95,11 @@ impl CompilerArgs {
                 for warning in warnings {
                     println!("{}: {warning}", "warning".yellow())
                 }
+                ExitCode::SUCCESS
             }
             Err(error) => {
                 println!("{}: {error}", "error".red());
+                ExitCode::FAILURE
             }
         }
     }


### PR DESCRIPTION
Prefix all output with blue "info", yellow "warning" or red "error", and do not color the full message. Kind of like how rustc does it.

Report warnings when walking with --directory.

Move the arguments --directory/-d and --module/-m into a required argument group, so that at least one have to be specified. This makes error reporting and --help nicer.