### PR TITLE
Set MSRV to 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.82"
 license = "MIT/Apache-2.0"
 version = "0.10.1"
 repository = "https://github.com/librasn/compiler.git"

--- a/rasn-compiler-derive/Cargo.toml
+++ b/rasn-compiler-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "rasn-compiler-derive"
 workspace = ".."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/rasn-compiler-tests/Cargo.toml
+++ b/rasn-compiler-tests/Cargo.toml
@@ -4,6 +4,7 @@ workspace = ".."
 publish = false
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/rasn-compiler/Cargo.toml
+++ b/rasn-compiler/Cargo.toml
@@ -3,6 +3,7 @@ name = "rasn-compiler"
 workspace = ".."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true


### PR DESCRIPTION
MSRV is determined by using cargo-msrv, which fails on 1.81.0 with:

```
Compatibility Check #7: Rust 1.81.0
  [FAIL]   Is incompatible 
                                                                                                                        
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │    Compiling rasn-compiler v0.10.1 (/home/mawa/projects/rasn-compiler/rasn-compiler)                               │
  │     Checking rasn v0.26.5                                                                                          │
  │ error[E0658]: use of unstable library feature 'iter_repeat_n'                                                      │
  │    --> /home/mawa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rasn-0.26.5/src/oer/enc.rs:516:28           │
  │     |                                                                                                              │
  │ 516 |         self.output.extend(core::iter::repeat_n(                                                             │
  │     |                            ^^^^^^^^^^^^^^^^^^^^                                                              │
  │     |                                                                                                              │
  │     = note: see issue #104434 <https://github.com/rust-lang/rust/issues/104434> for more information               │
  │                                                                                                                    │
  │ error[E0658]: use of unstable library feature 'iter_repeat_n'                                                      │
  │    --> /home/mawa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rasn-0.26.5/src/oer/enc.rs:681:52           │
  │     |                                                                                                              │
  │ 681 |                         bit_string_encoding.extend(core::iter::repeat_n(false, missing_bits));               │
  │     |                                                    ^^^^^^^^^^^^^^^^^^^^                                      │
  │     |                                                                                                              │
  │     = note: see issue #104434 <https://github.com/rust-lang/rust/issues/104434> for more information               │
  │                                                                                                                    │
  │ error[E0658]: use of unstable library feature 'is_none_or'                                                         │
  │    --> /home/mawa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rasn-0.26.5/src/types/constraints.rs:824:32 │
  │     |                                                                                                              │
  │ 824 |                 start.as_ref().is_none_or(|&start| {                                                         │
  │     |                                ^^^^^^^^^^                                                                    │
  │     |                                                                                                              │
  │     = note: see issue #126383 <https://github.com/rust-lang/rust/issues/126383> for more information               │
  │                                                                                                                    │
  │ error[E0658]: use of unstable library feature 'is_none_or'                                                         │
  │    --> /home/mawa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rasn-0.26.5/src/types/constraints.rs:832:36 │
  │     |                                                                                                              │
  │ 832 |                 }) && end.as_ref().is_none_or(|&end| {                                                       │
  │     |                                    ^^^^^^^^^^                                                                │
  │     |                                                                                                              │
  │     = note: see issue #126383 <https://github.com/rust-lang/rust/issues/126383> for more information               │
  │                                                                                                                    │
  │ error[E0658]: use of unstable library feature 'is_none_or'                                                         │
  │    --> /home/mawa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rasn-0.26.5/src/types/constraints.rs:882:32 │
  │     |                                                                                                              │
  │ 882 |                 start.as_ref().is_none_or(|start| element >= start)                                          │
  │     |                                ^^^^^^^^^^                                                                    │
  │     |                                                                                                              │
  │     = note: see issue #126383 <https://github.com/rust-lang/rust/issues/126383> for more information               │
  │                                                                                                                    │
  │ error[E0658]: use of unstable library feature 'is_none_or'                                                         │
  │    --> /home/mawa/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rasn-0.26.5/src/types/constraints.rs:883:37 │
  │     |                                                                                                              │
  │ 883 |                     && end.as_ref().is_none_or(|end| element <= end)                                         │
  │     |                                     ^^^^^^^^^^                                                               │
  │     |                                                                                                              │
  │     = note: see issue #126383 <https://github.com/rust-lang/rust/issues/126383> for more information               │
  │                                                                                                                    │
  │ For more information about this error, try `rustc --explain E0658`.                                                │
  │ error: could not compile `rasn` (lib) due to 6 previous errors                                                     │
  │ warning: build failed, waiting for other jobs to finish...                                                         │
  │                                                                                                                    │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
















