### PR TITLE
feat(parser): add support for value set syntax (X.680-2021 sec 16.6-16.8)

### DIFF
--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -950,6 +950,7 @@ impl ASN1Type {
             ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => Some(s.constraints()),
             ASN1Type::ElsewhereDeclaredType(e) => Some(e.constraints()),
             ASN1Type::InformationObjectFieldReference(f) => Some(f.constraints()),
+            ASN1Type::ObjectIdentifier(o) => Some(&o.constraints),
             _ => None,
         }
     }
@@ -969,6 +970,7 @@ impl ASN1Type {
             ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => Some(s.constraints_mut()),
             ASN1Type::ElsewhereDeclaredType(e) => Some(e.constraints_mut()),
             ASN1Type::InformationObjectFieldReference(f) => Some(f.constraints_mut()),
+            ASN1Type::ObjectIdentifier(o) => Some(&mut o.constraints),
             _ => None,
         }
     }

--- a/rasn-compiler/src/lexer/constraint.rs
+++ b/rasn-compiler/src/lexer/constraint.rs
@@ -59,7 +59,7 @@ pub fn set_operator(input: Input<'_>) -> ParserResult<'_, SetOperator> {
     )))(input)
 }
 
-fn element_set(input: Input<'_>) -> ParserResult<'_, ElementSet> {
+pub fn element_set(input: Input<'_>) -> ParserResult<'_, ElementSet> {
     into(pair(
         alt((
             map(set_operation, ElementOrSetOperation::SetOperation),

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -20,7 +20,7 @@ use nom::{
 
 use crate::{
     input::{context_boundary, Input},
-    intermediate::{information_object::*, *},
+    intermediate::{information_object::*, constraints::Constraint, *},
 };
 
 use self::{
@@ -94,6 +94,7 @@ pub(crate) fn asn_module(
                     ToplevelDefinition::Information,
                 ),
                 map(top_level_type_declaration, ToplevelDefinition::Type),
+                map(top_level_valueset_declaration, ToplevelDefinition::Type),
                 map(top_level_value_declaration, ToplevelDefinition::Value),
             )))),
             context_boundary(skip_ws_and_comments(alt((end, encoding_control)))),
@@ -231,6 +232,32 @@ fn top_level_value_declaration(input: Input<'_>) -> ParserResult<'_, ToplevelVal
     ))(input)
 }
 
+fn top_level_valueset_declaration(input: Input<'_>) -> ParserResult<'_, ToplevelTypeDefinition> {
+    map(
+        tuple((
+            skip_ws(many0(comment)),
+            skip_ws(context_boundary(title_case_identifier)),
+            skip_ws_and_comments(opt(parameterization)),
+            skip_ws_and_comments(asn1_type),
+            preceded(assignment, in_braces(element_set))
+        )),
+        |mut value| {
+            if let Some(constraints) = value.3.constraints_mut() {
+                constraints.push(Constraint::SubtypeConstraint(value.4))
+            } else {
+                eprintln!("{name}: unable to push constraints to {ty:?}", name=value.1, ty=value.3);
+            }
+            ToplevelTypeDefinition{
+                comments: value.0.join("\n"),
+                tag: None,
+                name: value.1.to_string(),
+                ty: value.3,
+                parameterization: value.2,
+                index: None,
+            }
+        }
+    )(input)
+}
 fn top_level_information_object_declaration(
     input: Input<'_>,
 ) -> ParserResult<'_, ToplevelInformationDefinition> {


### PR DESCRIPTION
This is a first step towards making the X.500 series of ASN.1 specs compile as provided by upstream. 

After this change, 2 additional modules from the test suite parse successfully:
- itu-t_x_x509_2016_AlgorithmObjectIdentifiers.asn
- itu-t_x_x509_2019_AlgorithmObjectIdentifiers.asn

However, this does drastically slow down the parser - my test suite that runs the compiler with a null backend runs in 19s instead of 2s. I've not yet figured out why