### PR TITLE
Fix COMPONENTS OF

### DIFF
--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -17,6 +17,7 @@ use super::{
     TaggingEnvironment,
 };
 use crate::generator::error::{GeneratorError, GeneratorErrorType};
+use crate::prelude::ir::SequenceComponent;
 
 pub(crate) const INNER_ARRAY_LIKE_PREFIX: &str = "Anonymous_";
 
@@ -681,17 +682,11 @@ impl Rasn {
         match tld.ty {
             ASN1Type::Sequence(ref seq) | ASN1Type::Set(ref seq) => {
                 let name = self.to_rust_title_case(&tld.name);
-                let extensible = seq
-                    .extensible
-                    .or(
-                        (self.extensibility_environment == ExtensibilityEnvironment::Implied)
-                            .then_some(seq.members.len()),
-                    )
-                    .map(|_| {
-                        quote! {
-                        #[non_exhaustive]}
-                    })
-                    .unwrap_or_default();
+                let extensible = if seq.extensible || self.extensibility_environment == ExtensibilityEnvironment::Implied {
+                    quote! {#[non_exhaustive]}
+                } else {
+                    TokenStream::new()
+                };
                 let set_annotation = if let ASN1Type::Set(_) = tld.ty {
                     quote!(set)
                 } else {
@@ -700,7 +695,8 @@ impl Rasn {
                 let class_fields = if self.config.opaque_open_types {
                     TokenStream::new()
                 } else {
-                    seq.members.iter().fold(
+                    seq.direct_members()
+                        .fold(
                     TokenStream::new(),
                     |mut acc, m| {
                         [
@@ -747,7 +743,7 @@ impl Rasn {
                     self.format_tag(
                         tld.tag.as_ref(),
                         self.tagging_environment == TaggingEnvironment::Automatic
-                            && !seq.members.iter().any(|m| m.tag.is_some()),
+                            && !seq.direct_members().any(|m| m.tag.is_some()),
                     ),
                 ];
                 if name.to_string() != tld.name {
@@ -764,7 +760,7 @@ impl Rasn {
                     formatted_members.struct_body,
                     formatted_members.nested_anonymous_types,
                     self.join_annotations(annotations, false, true)?,
-                    self.format_default_methods(&seq.members, &name.to_string())?,
+                    self.format_default_methods(&seq.direct_members().cloned().collect(), &name.to_string())?,
                     self.format_new_impl(&name, formatted_members.name_types),
                     class_fields,
                 ))

--- a/rasn-compiler/src/generator/typescript/utils.rs
+++ b/rasn-compiler/src/generator/typescript/utils.rs
@@ -1,7 +1,6 @@
 use num::pow::Pow;
 
 use crate::generator::error::GeneratorError;
-
 use super::{
     types::{BitString, Choice, SequenceOrSet},
     ASN1Type, ASN1Value,
@@ -62,8 +61,7 @@ pub fn format_sequence_or_set_members(se: &SequenceOrSet) -> String {
         r#"{{
             {}{}
         }}"#,
-        se.members
-            .iter()
+        se.direct_members()
             .map(|m| format!(
                 r#"{}{}: {},"#,
                 to_jer_identifier(&m.name),
@@ -72,8 +70,11 @@ pub fn format_sequence_or_set_members(se: &SequenceOrSet) -> String {
             ))
             .collect::<Vec<_>>()
             .join("\n"),
-        se.extensible
-            .map_or(String::new(), |_| String::from("\n\t[key: string]: any"))
+        if se.extensible {
+            String::from("\n\t[key: string]: any")
+        } else {
+            String::new()
+        }
     )
 }
 

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -950,6 +950,7 @@ impl ASN1Type {
             ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => Some(s.constraints()),
             ASN1Type::ElsewhereDeclaredType(e) => Some(e.constraints()),
             ASN1Type::InformationObjectFieldReference(f) => Some(f.constraints()),
+            ASN1Type::ObjectIdentifier(o) => Some(&o.constraints),
             _ => None,
         }
     }
@@ -969,6 +970,7 @@ impl ASN1Type {
             ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => Some(s.constraints_mut()),
             ASN1Type::ElsewhereDeclaredType(e) => Some(e.constraints_mut()),
             ASN1Type::InformationObjectFieldReference(f) => Some(f.constraints_mut()),
+            ASN1Type::ObjectIdentifier(o) => Some(&mut o.constraints),
             _ => None,
         }
     }

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -578,13 +578,20 @@ impl ToplevelDefinition {
                 id: t.id,
             });
             match &mut ty.ty {
-                ASN1Type::Sequence(s) | ASN1Type::Set(s) => s.members.iter_mut().for_each(|m| {
-                    m.tag = m.tag.as_ref().map(|t| AsnTag {
-                        environment: env + &t.environment,
-                        tag_class: t.tag_class,
-                        id: t.id,
-                    });
-                }),
+                ASN1Type::Sequence(s) | ASN1Type::Set(s) => {
+                    for s in [&mut s.fixed_components, &mut s.suffix_components, &mut s.extension_components] {
+                        s.iter_mut().for_each(|m| {
+                            if let SequenceComponent::Member(m) = m {
+                                m.tag = m.tag.as_ref().map(|t| AsnTag {
+                                    environment: env + &t.environment,
+                                    tag_class: t.tag_class,
+                                    id: t.id,
+                                });
+                            }
+                        })
+                        
+                    }
+                },
                 ASN1Type::Choice(c) => c.options.iter_mut().for_each(|o| {
                     o.tag = o.tag.as_ref().map(|t| AsnTag {
                         environment: env + &t.environment,

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -315,15 +315,86 @@ impl From<(Option<Vec<Constraint>>, (Option<AsnTag>, ASN1Type))> for SequenceOrS
 /// *As defined in Rec. ITU-T X.680 (02/2021) §25 and §27*
 #[derive(Debug, Clone, PartialEq)]
 pub struct SequenceOrSet {
-    pub components_of: Vec<String>,
-    pub extensible: Option<usize>,
+    pub fixed_components: Vec<SequenceComponent>,
+    pub extension_components: Vec<SequenceComponent>,
+    pub suffix_components: Vec<SequenceComponent>,
+    pub extensible: bool,
     pub constraints: Vec<Constraint>,
-    pub members: Vec<SequenceOrSetMember>,
+}
+
+impl SequenceOrSet {
+    pub fn direct_members(&self) -> impl Iterator<Item=&SequenceOrSetMember> {
+        [&self.fixed_components, &self.extension_components, &self.suffix_components]
+            .into_iter()
+            .flat_map(|x| x)
+            .flat_map(|x| {
+                if let SequenceComponent::Member(m) = x {
+                    Some(m)
+                } else {
+                    None
+                }
+            })
+    }
+
+    pub fn direct_members_mut(&mut self) -> impl Iterator<Item=&mut SequenceOrSetMember> {
+        [&mut self.fixed_components, &mut self.extension_components, &mut self.suffix_components]
+            .into_iter()
+            .flat_map(|x| x)
+            .flat_map(|x| {
+                if let SequenceComponent::Member(m) = x {
+                    Some(m)
+                } else {
+                    None
+                }
+            })
+    }
+
+    pub fn extension_range(&self) -> std::ops::Range<usize> {
+        self.fixed_components.len() .. self.fixed_components.len() + self.extension_components.len()
+    }
 }
 
 impl IterNameTypes for SequenceOrSet {
     fn iter_name_types(&self) -> impl Iterator<Item = (&str, &ASN1Type)> {
-        self.members.iter().map(|m| (m.name.as_str(), &m.ty))
+        self.direct_members()
+            .map(|m| (m.name.as_str(), &m.ty))
+    }
+}
+
+impl
+    From<(
+        (
+            Vec<SequenceComponent>,
+            Option<(
+                Vec<SequenceComponent>,
+                Vec<SequenceComponent>,
+            )>,
+        ),
+        Option<Vec<Constraint>>,
+    )> for SequenceOrSet
+{
+    fn from(
+        mut value: (
+            (
+                Vec<SequenceComponent>,
+                Option<(
+                    Vec<SequenceComponent>,
+                    Vec<SequenceComponent>,
+                )>,
+            ),
+            Option<Vec<Constraint>>,
+        ),
+    ) -> Self {
+        let extensible = value.0 .1.is_some();
+        let (extension_components, suffix_components) = value.0 .1.unwrap_or_default();
+
+        SequenceOrSet {
+            fixed_components: value.0 .0,
+            extension_components,
+            suffix_components,
+            constraints: value.1.unwrap_or_default(),
+            extensible,
+        }
     }
 }
 
@@ -347,52 +418,12 @@ impl
             Option<Vec<Constraint>>,
         ),
     ) -> Self {
-        let index_of_first_extension = value.0 .0.len();
-        value.0 .0.append(&mut value.0 .2.unwrap_or_default());
-        let mut components_of = vec![];
-        let mut members = vec![];
-        for comp in value.0 .0 {
-            match comp {
-                SequenceComponent::Member(m) => members.push(m),
-                SequenceComponent::ComponentsOf(c) => components_of.push(c),
-            }
-        }
         SequenceOrSet {
-            components_of,
+            fixed_components: value.0 .0.into_iter().collect(),
+            extension_components: value.0 .2.into_iter().flat_map(|x| x).collect(),
+            suffix_components: vec![],
             constraints: value.1.unwrap_or_default(),
-            extensible: value.0 .1.map(|_| index_of_first_extension),
-            members,
-        }
-    }
-}
-
-impl
-    From<(
-        (
-            Vec<SequenceOrSetMember>,
-            Option<ExtensionMarker>,
-            Option<Vec<SequenceOrSetMember>>,
-        ),
-        Option<Vec<Constraint>>,
-    )> for SequenceOrSet
-{
-    fn from(
-        mut value: (
-            (
-                Vec<SequenceOrSetMember>,
-                Option<ExtensionMarker>,
-                Option<Vec<SequenceOrSetMember>>,
-            ),
-            Option<Vec<Constraint>>,
-        ),
-    ) -> Self {
-        let index_of_first_extension = value.0 .0.len();
-        value.0 .0.append(&mut value.0 .2.unwrap_or_default());
-        SequenceOrSet {
-            components_of: vec![],
-            constraints: value.1.unwrap_or_default(),
-            extensible: value.0 .1.map(|_| index_of_first_extension),
-            members: value.0 .0,
+            extensible: value.0 .1.is_some(),
         }
     }
 }

--- a/rasn-compiler/src/lexer/constraint.rs
+++ b/rasn-compiler/src/lexer/constraint.rs
@@ -59,7 +59,7 @@ pub fn set_operator(input: Input<'_>) -> ParserResult<'_, SetOperator> {
     )))(input)
 }
 
-fn element_set(input: Input<'_>) -> ParserResult<'_, ElementSet> {
+pub fn element_set(input: Input<'_>) -> ParserResult<'_, ElementSet> {
     into(pair(
         alt((
             map(set_operation, ElementOrSetOperation::SetOperation),

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -20,7 +20,7 @@ use nom::{
 
 use crate::{
     input::{context_boundary, Input},
-    intermediate::{information_object::*, *},
+    intermediate::{information_object::*, constraints::Constraint, *},
 };
 
 use self::{
@@ -94,6 +94,7 @@ pub(crate) fn asn_module(
                     ToplevelDefinition::Information,
                 ),
                 map(top_level_type_declaration, ToplevelDefinition::Type),
+                map(top_level_valueset_declaration, ToplevelDefinition::Type),
                 map(top_level_value_declaration, ToplevelDefinition::Value),
             )))),
             context_boundary(skip_ws_and_comments(alt((end, encoding_control)))),
@@ -231,6 +232,32 @@ fn top_level_value_declaration(input: Input<'_>) -> ParserResult<'_, ToplevelVal
     ))(input)
 }
 
+fn top_level_valueset_declaration(input: Input<'_>) -> ParserResult<'_, ToplevelTypeDefinition> {
+    map(
+        tuple((
+            skip_ws(many0(comment)),
+            skip_ws(context_boundary(title_case_identifier)),
+            skip_ws_and_comments(opt(parameterization)),
+            skip_ws_and_comments(asn1_type),
+            preceded(assignment, in_braces(element_set))
+        )),
+        |mut value| {
+            if let Some(constraints) = value.3.constraints_mut() {
+                constraints.push(Constraint::SubtypeConstraint(value.4))
+            } else {
+                eprintln!("{name}: unable to push constraints to {ty:?}", name=value.1, ty=value.3);
+            }
+            ToplevelTypeDefinition{
+                comments: value.0.join("\n"),
+                tag: None,
+                name: value.1.to_string(),
+                ty: value.3,
+                parameterization: value.2,
+                index: None,
+            }
+        }
+    )(input)
+}
 fn top_level_information_object_declaration(
     input: Input<'_>,
 ) -> ParserResult<'_, ToplevelInformationDefinition> {

--- a/rasn-compiler/src/lexer/set.rs
+++ b/rasn-compiler/src/lexer/set.rs
@@ -46,7 +46,7 @@ pub fn set(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
 #[cfg(test)]
 mod tests {
     use set::types::{CharacterString, SequenceOrSet, SequenceOrSetMember, SequenceOrSetOf};
-
+    use crate::intermediate::types::SequenceComponent;
     use super::*;
 
     #[test]
@@ -60,11 +60,10 @@ mod tests {
             .unwrap()
             .1,
             ASN1Type::Set(SequenceOrSet {
-                components_of: vec![],
-                extensible: None,
+                extensible: false,
                 constraints: vec![],
-                members: vec![
-                    SequenceOrSetMember {
+                fixed_components: vec![
+                    SequenceComponent::Member(SequenceOrSetMember {
                         is_recursive: false,
                         name: "title".into(),
                         tag: None,
@@ -75,8 +74,8 @@ mod tests {
                         default_value: None,
                         is_optional: false,
                         constraints: vec![],
-                    },
-                    SequenceOrSetMember {
+                    }),
+                    SequenceComponent::Member(SequenceOrSetMember {
                         is_recursive: false,
                         name: "children".into(),
                         tag: None,
@@ -92,8 +91,10 @@ mod tests {
                         default_value: Some(ASN1Value::SequenceOrSet(vec![])),
                         is_optional: true,
                         constraints: vec![]
-                    }
-                ]
+                    }),
+                ],
+                extension_components: vec![],
+                suffix_components: vec![],
             })
         );
     }

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -426,11 +426,10 @@ fn parses_parameterized_declaration() {
             index: None,
             name: "RegionalExtension".into(),
             ty: ASN1Type::Sequence(SequenceOrSet {
-                extensible: None,
-                components_of: vec![],
+                extensible: false,
                 constraints: vec![],
-                members: vec![
-                    SequenceOrSetMember {
+                fixed_components: vec![
+                    SequenceComponent::Member(SequenceOrSetMember {
                         is_recursive: false,
                         name: "regionId".into(),
                         tag: None,
@@ -450,8 +449,8 @@ fn parses_parameterized_declaration() {
                         default_value: None,
                         is_optional: false,
                         constraints: vec![]
-                    },
-                    SequenceOrSetMember {
+                    }),
+                    SequenceComponent::Member(SequenceOrSetMember {
                         is_recursive: false,
                         name: "regExtValue".into(),
                         tag: None,
@@ -476,8 +475,10 @@ fn parses_parameterized_declaration() {
                         default_value: None,
                         is_optional: false,
                         constraints: vec![]
-                    }
-                ]
+                    })
+                ],
+                extension_components: vec![],
+                suffix_components: vec![],
             }),
             parameterization: Some(Parameterization {
                 parameters: vec![ParameterizationArgument {


### PR DESCRIPTION
This fixes the two issues described in #115. This allows 16 new modules to parse, but breaks the parsing of 21 modules. Further, there are a bunch of tests that still need to be fixed. I'll get to diagnosing the regressions and fixing up the test cases tomorrow evening (CEST), but feel free to look over and comment on the general shape of my changes.

