### PR TITLE
feat(snmp): Support some SNMP MACROs

### DIFF
--- a/rasn-compiler-tests/tests/snmp-mibs/IANAifType-MIB
+++ b/rasn-compiler-tests/tests/snmp-mibs/IANAifType-MIB
@@ -1,0 +1,702 @@
+   IANAifType-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, mib-2      FROM SNMPv2-SMI
+       TEXTUAL-CONVENTION          FROM SNMPv2-TC;
+
+   ianaifType MODULE-IDENTITY
+       LAST-UPDATED "201703300000Z" -- March 30, 2017
+       ORGANIZATION "IANA"
+       CONTACT-INFO "        Internet Assigned Numbers Authority
+
+                     Postal: ICANN
+                             12025 Waterfront Drive, Suite 300
+                             Los Angeles, CA 90094-2536
+
+                     Tel:    +1 310-301-5800
+                     E-Mail: iana&iana.org"
+       DESCRIPTION  "This MIB module defines the IANAifType Textual
+                     Convention, and thus the enumerated values of
+                     the ifType object defined in MIB-II's ifTable."
+
+       REVISION     "201703300000Z"  -- March 30, 2017
+       DESCRIPTION  "Registration of new IANAifType 290."
+
+       REVISION     "201701190000Z"  -- January 19, 2017
+       DESCRIPTION  "Registration of new IANAifType 289."
+
+       REVISION     "201611230000Z"  -- November 23, 2016
+       DESCRIPTION  "Registration of new IANAifTypes 283-288."
+
+       REVISION     "201606160000Z"  -- June 16, 2016
+       DESCRIPTION  "Updated IANAtunnelType DESCRIPTION per RFC 7870"
+
+       REVISION     "201606090000Z"  -- June 9, 2016
+       DESCRIPTION  "Registration of new IANAifType 282."
+
+       REVISION     "201606080000Z"  -- June 8, 2016
+       DESCRIPTION  "Updated description for tunnelType 17."
+
+       REVISION     "201605190000Z"  -- May 19, 2016
+       DESCRIPTION  "Updated description for tunnelType 16."
+
+       REVISION     "201605030000Z"  -- May 3, 2016
+       DESCRIPTION  "Registration of new IANAifType 281."
+
+       REVISION     "201604290000Z"  -- April 29, 2016
+       DESCRIPTION  "Registration of new tunnelTypes 16 and 17."
+
+       REVISION     "201409240000Z"  -- September 24, 2014
+       DESCRIPTION  "Registration of new IANAifType 280."
+
+       REVISION     "201409190000Z"  -- September 19, 2014
+       DESCRIPTION  "Registration of new IANAifType 279."
+
+       REVISION     "201407030000Z"  -- July 3, 2014
+       DESCRIPTION  "Registration of new IANAifTypes 277-278."
+
+       REVISION     "201405220000Z" -- May 22, 2014
+       DESCRIPTION  "Updated contact info."
+
+       REVISION     "201205170000Z"  -- May 17, 2012
+       DESCRIPTION  "Registration of new IANAifType 272."
+
+       REVISION     "201201110000Z"  -- January 11, 2012
+       DESCRIPTION  "Registration of new IANAifTypes 266-271."
+
+       REVISION     "201112180000Z"  -- December 18, 2011
+       DESCRIPTION  "Registration of new IANAifTypes 263-265."
+
+       REVISION     "201110260000Z"  -- October 26, 2011
+       DESCRIPTION  "Registration of new IANAifType 262."
+
+       REVISION     "201109070000Z"  -- September 7, 2011
+       DESCRIPTION  "Registration of new IANAifTypes 260 and 261."
+
+       REVISION     "201107220000Z"  -- July 22, 2011
+       DESCRIPTION  "Registration of new IANAifType 259."
+
+       REVISION     "201106030000Z"  -- June 03, 2011
+       DESCRIPTION  "Registration of new IANAifType 258."
+
+       REVISION     "201009210000Z"  -- September 21, 2010
+       DESCRIPTION  "Registration of new IANAifTypes 256 and 257."
+
+       REVISION     "201007210000Z"  -- July 21, 2010
+       DESCRIPTION  "Registration of new IANAifType 255."
+
+       REVISION     "201002110000Z"  -- February 11, 2010
+       DESCRIPTION  "Registration of new IANAifType 254."
+
+       REVISION     "201002080000Z"  -- February 08, 2010
+       DESCRIPTION  "Registration of new IANAifTypes 252 and 253."
+
+       REVISION     "200905060000Z"  -- May 06, 2009
+       DESCRIPTION  "Registration of new IANAifType 251."
+
+       REVISION     "200902060000Z"  -- February 06, 2009
+       DESCRIPTION  "Registration of new IANAtunnelType 15."
+
+       REVISION     "200810090000Z"  -- October 09, 2008
+       DESCRIPTION  "Registration of new IANAifType 250."
+
+       REVISION     "200808120000Z"  -- August 12, 2008
+       DESCRIPTION  "Registration of new IANAifType 249."
+
+       REVISION     "200807220000Z"  -- July 22, 2008
+       DESCRIPTION  "Registration of new IANAifTypes 247 and 248."
+
+       REVISION     "200806240000Z"  -- June 24, 2008
+       DESCRIPTION  "Registration of new IANAifType 246."
+
+       REVISION     "200805290000Z"  -- May 29, 2008
+       DESCRIPTION  "Registration of new IANAifType 245."
+
+       REVISION     "200709130000Z"  -- September 13, 2007
+       DESCRIPTION  "Registration of new IANAifTypes 243 and 244."
+
+       REVISION     "200705290000Z"  -- May 29, 2007
+       DESCRIPTION  "Changed the description for IANAifType 228."
+
+       REVISION     "200703080000Z"  -- March 08, 2007
+       DESCRIPTION  "Registration of new IANAifType 242."
+
+       REVISION     "200701230000Z"  -- January 23, 2007
+       DESCRIPTION  "Registration of new IANAifTypes 239, 240, and 241."
+
+       REVISION     "200610170000Z"  -- October 17, 2006
+       DESCRIPTION  "Deprecated/Obsoleted IANAifType 230.  Registration of
+                     IANAifType 238."
+
+       REVISION     "200609250000Z"  -- September 25, 2006
+       DESCRIPTION  "Changed the description for IANA ifType
+                     184 and added new IANA ifType 237."
+
+       REVISION     "200608170000Z"  -- August 17, 2006
+       DESCRIPTION  "Changed the descriptions for IANAifTypes
+                     20 and 21."
+
+       REVISION     "200608110000Z"  -- August 11, 2006
+       DESCRIPTION  "Changed the descriptions for IANAifTypes
+                     7, 11, 62, 69, and 117."
+
+       REVISION     "200607250000Z"  -- July 25, 2006
+       DESCRIPTION  "Registration of new IANA ifType 236."
+
+       REVISION     "200606140000Z"  -- June 14, 2006
+       DESCRIPTION  "Registration of new IANA ifType 235."
+
+       REVISION     "200603310000Z"  -- March 31, 2006
+       DESCRIPTION  "Registration of new IANA ifType 234."
+
+       REVISION     "200603300000Z"  -- March 30, 2006
+       DESCRIPTION  "Registration of new IANA ifType 233."
+
+       REVISION     "200512220000Z"  -- December 22, 2005
+       DESCRIPTION  "Registration of new IANA ifTypes 231 and 232."
+
+       REVISION     "200510100000Z"  -- October 10, 2005
+       DESCRIPTION  "Registration of new IANA ifType 230."
+
+       REVISION     "200509090000Z"  -- September 09, 2005
+       DESCRIPTION  "Registration of new IANA ifType 229."
+
+       REVISION     "200505270000Z"  -- May 27, 2005
+       DESCRIPTION  "Registration of new IANA ifType 228."
+
+       REVISION     "200503030000Z"  -- March 3, 2005
+       DESCRIPTION  "Added the IANAtunnelType TC and deprecated
+                         IANAifType sixToFour (215) per RFC4087."
+
+       REVISION     "200411220000Z"  -- November 22, 2004
+       DESCRIPTION  "Registration of new IANA ifType 227 per RFC4631."
+
+       REVISION     "200406170000Z"  -- June 17, 2004
+       DESCRIPTION  "Registration of new IANA ifType 226."
+
+       REVISION     "200405120000Z"  -- May 12, 2004
+       DESCRIPTION  "Added description for IANAifType 6, and
+                         changed the descriptions for IANAifTypes
+                     180, 181, and 182."
+
+       REVISION     "200405070000Z"  -- May 7, 2004
+       DESCRIPTION  "Registration of new IANAifType 225."
+
+       REVISION     "200308250000Z"  -- Aug 25, 2003
+       DESCRIPTION  "Deprecated IANAifTypes 7 and 11. Obsoleted
+                     IANAifTypes 62, 69, and 117.  ethernetCsmacd (6)
+                     should be used instead of these values"
+
+       REVISION     "200308180000Z"  -- Aug 18, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     224."
+
+       REVISION     "200308070000Z"  -- Aug 7, 2003
+       DESCRIPTION  "Registration of new IANAifTypes
+                     222 and 223."
+
+       REVISION     "200303180000Z"  -- Mar 18, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     221."
+
+       REVISION     "200301130000Z"  -- Jan 13, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     220."
+
+       REVISION     "200210170000Z"  -- Oct 17, 2002
+       DESCRIPTION  "Registration of new IANAifType
+                     219."
+
+       REVISION     "200207160000Z"  -- Jul 16, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     217 and 218."
+
+       REVISION     "200207100000Z"  -- Jul 10, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     215 and 216."
+
+       REVISION     "200206190000Z"  -- Jun 19, 2002
+       DESCRIPTION  "Registration of new IANAifType
+                     214."
+
+       REVISION     "200201040000Z"  -- Jan 4, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     211, 212 and 213."
+
+       REVISION     "200112200000Z"  -- Dec 20, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     209 and 210."
+
+       REVISION     "200111150000Z"  -- Nov 15, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     207 and 208."
+
+       REVISION     "200111060000Z"  -- Nov 6, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     206."
+
+       REVISION     "200111020000Z"  -- Nov 2, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     205."
+
+       REVISION     "200110160000Z"  -- Oct 16, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     199, 200, 201, 202, 203, and 204."
+
+       REVISION     "200109190000Z"  -- Sept 19, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     198."
+
+       REVISION     "200105110000Z"  -- May 11, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     197."
+
+       REVISION     "200101120000Z"  -- Jan 12, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     195 and 196."
+
+       REVISION     "200012190000Z"  -- Dec 19, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     193 and 194."
+
+       REVISION     "200012070000Z"  -- Dec 07, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     191 and 192."
+
+       REVISION     "200012040000Z"  -- Dec 04, 2000
+       DESCRIPTION  "Registration of new IANAifType
+                     190."
+
+       REVISION     "200010170000Z"  -- Oct 17, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     188 and 189."
+
+       REVISION     "200010020000Z"  -- Oct 02, 2000
+       DESCRIPTION  "Registration of new IANAifType 187."
+
+       REVISION     "200009010000Z"  -- Sept 01, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     184, 185, and 186."
+
+       REVISION     "200008240000Z"  -- Aug 24, 2000
+       DESCRIPTION  "Registration of new IANAifType 183."
+
+       REVISION     "200008230000Z"  -- Aug 23, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     174-182."
+
+       REVISION     "200008220000Z"  -- Aug 22, 2000
+       DESCRIPTION  "Registration of new IANAifTypes 170,
+                     171, 172 and 173."
+
+       REVISION     "200004250000Z"  -- Apr 25, 2000
+       DESCRIPTION  "Registration of new IANAifTypes 168 and 169."
+
+       REVISION     "200003060000Z"  -- Mar 6, 2000
+       DESCRIPTION  "Fixed a missing semi-colon in the IMPORT.
+                     Also cleaned up the REVISION log a bit.
+                     It is not complete, but from now on it will
+                     be maintained and kept up to date with each
+                     change to this MIB module."
+
+       REVISION     "199910081430Z"  -- Oct 08, 1999
+       DESCRIPTION  "Include new name assignments up to cnr(85).
+                     This is the first version available via the WWW
+                     at: ftp://ftp.isi.edu/mib/ianaiftype.mib"
+
+       REVISION     "199401310000Z"  -- Jan 31, 1994
+       DESCRIPTION  "Initial version of this MIB as published in
+                     RFC 1573."
+       ::= { mib-2 30 }
+
+   IANAifType ::= TEXTUAL-CONVENTION
+       STATUS       current
+       DESCRIPTION
+               "This data type is used as the syntax of the ifType
+               object in the (updated) definition of MIB-II's
+               ifTable.
+
+               The definition of this textual convention with the
+               addition of newly assigned values is published
+               periodically by the IANA, in either the Assigned
+               Numbers RFC, or some derivative of it specific to
+               Internet Network Management number assignments.  (The
+               latest arrangements can be obtained by contacting the
+               IANA.)
+
+               Requests for new values should be made to IANA via
+               email (iana&iana.org).
+
+               The relationship between the assignment of ifType
+               values and of OIDs to particular media-specific MIBs
+               is solely the purview of IANA and is subject to change
+               without notice.  Quite often, a media-specific MIB's
+               OID-subtree assignment within MIB-II's 'transmission'
+               subtree will be the same as its ifType value.
+               However, in some circumstances this will not be the
+               case, and implementors must not pre-assume any
+               specific relationship between ifType values and
+               transmission subtree OIDs."
+       SYNTAX  INTEGER {
+                   other(1),          -- none of the following
+                   regular1822(2),
+                   hdh1822(3),
+                   ddnX25(4),
+                   rfc877x25(5),
+                   ethernetCsmacd(6), -- for all ethernet-like interfaces,
+                                      -- regardless of speed, as per RFC3635
+                   iso88023Csmacd(7), -- Deprecated via RFC3635
+                                      -- ethernetCsmacd (6) should be used instead
+                   iso88024TokenBus(8),
+                   iso88025TokenRing(9),
+                   iso88026Man(10),
+                   starLan(11), -- Deprecated via RFC3635
+                                -- ethernetCsmacd (6) should be used instead
+                   proteon10Mbit(12),
+                   proteon80Mbit(13),
+                   hyperchannel(14),
+                   fddi(15),
+                   lapb(16),
+                   sdlc(17),
+                   ds1(18),            -- DS1-MIB
+                   e1(19),             -- Obsolete see DS1-MIB
+                   basicISDN(20),              -- no longer used
+                                               -- see also RFC2127
+                   primaryISDN(21),            -- no longer used
+                                               -- see also RFC2127
+                   propPointToPointSerial(22), -- proprietary serial
+                   ppp(23),
+                   softwareLoopback(24),
+                   eon(25),            -- CLNP over IP
+                   ethernet3Mbit(26),
+                   nsip(27),           -- XNS over IP
+                   slip(28),           -- generic SLIP
+                   ultra(29),          -- ULTRA technologies
+                   ds3(30),            -- DS3-MIB
+                   sip(31),            -- SMDS, coffee
+                   frameRelay(32),     -- DTE only.
+                   rs232(33),
+                   para(34),           -- parallel-port
+                   arcnet(35),         -- arcnet
+                   arcnetPlus(36),     -- arcnet plus
+                   atm(37),            -- ATM cells
+                   miox25(38),
+                   sonet(39),          -- SONET or SDH
+                   x25ple(40),
+                   iso88022llc(41),
+                   localTalk(42),
+                   smdsDxi(43),
+                   frameRelayService(44),  -- FRNETSERV-MIB
+                   v35(45),
+                   hssi(46),
+                   hippi(47),
+                   modem(48),          -- Generic modem
+                   aal5(49),           -- AAL5 over ATM
+                   sonetPath(50),
+                   sonetVT(51),
+                   smdsIcip(52),       -- SMDS InterCarrier Interface
+                   propVirtual(53),    -- proprietary virtual/internal
+                   propMultiplexor(54),-- proprietary multiplexing
+                   ieee80212(55),      -- 100BaseVG
+                   fibreChannel(56),   -- Fibre Channel
+                   hippiInterface(57), -- HIPPI interfaces
+                   frameRelayInterconnect(58), -- Obsolete, use either
+                                       -- frameRelay(32) or
+                                       -- frameRelayService(44).
+                   aflane8023(59),     -- ATM Emulated LAN for 802.3
+                   aflane8025(60),     -- ATM Emulated LAN for 802.5
+                   cctEmul(61),        -- ATM Emulated circuit
+                   fastEther(62),      -- Obsoleted via RFC3635
+                                       -- ethernetCsmacd (6) should be used instead
+                   isdn(63),           -- ISDN and X.25
+                   v11(64),            -- CCITT V.11/X.21
+                   v36(65),            -- CCITT V.36
+                   g703at64k(66),      -- CCITT G703 at 64Kbps
+                   g703at2mb(67),      -- Obsolete see DS1-MIB
+                   qllc(68),           -- SNA QLLC
+                   fastEtherFX(69),    -- Obsoleted via RFC3635
+                                       -- ethernetCsmacd (6) should be used instead
+                   channel(70),        -- channel
+                   ieee80211(71),      -- radio spread spectrum
+                   ibm370parChan(72),  -- IBM System 360/370 OEMI Channel
+                   escon(73),          -- IBM Enterprise Systems Connection
+                   dlsw(74),           -- Data Link Switching
+                   isdns(75),          -- ISDN S/T interface
+                   isdnu(76),          -- ISDN U interface
+                   lapd(77),           -- Link Access Protocol D
+                   ipSwitch(78),       -- IP Switching Objects
+                   rsrb(79),           -- Remote Source Route Bridging
+                   atmLogical(80),     -- ATM Logical Port
+                   ds0(81),            -- Digital Signal Level 0
+                   ds0Bundle(82),      -- group of ds0s on the same ds1
+                   bsc(83),            -- Bisynchronous Protocol
+                   async(84),          -- Asynchronous Protocol
+                   cnr(85),            -- Combat Net Radio
+                   iso88025Dtr(86),    -- ISO 802.5r DTR
+                   eplrs(87),          -- Ext Pos Loc Report Sys
+                   arap(88),           -- Appletalk Remote Access Protocol
+                   propCnls(89),       -- Proprietary Connectionless Protocol
+                   hostPad(90),        -- CCITT-ITU X.29 PAD Protocol
+                   termPad(91),        -- CCITT-ITU X.3 PAD Facility
+                   frameRelayMPI(92),  -- Multiproto Interconnect over FR
+                   x213(93),           -- CCITT-ITU X213
+                   adsl(94),           -- Asymmetric Digital Subscriber Loop
+                   radsl(95),          -- Rate-Adapt. Digital Subscriber Loop
+                   sdsl(96),           -- Symmetric Digital Subscriber Loop
+                   vdsl(97),           -- Very H-Speed Digital Subscrib. Loop
+                   iso88025CRFPInt(98), -- ISO 802.5 CRFP
+                   myrinet(99),        -- Myricom Myrinet
+                   voiceEM(100),       -- voice recEive and transMit
+                   voiceFXO(101),      -- voice Foreign Exchange Office
+                   voiceFXS(102),      -- voice Foreign Exchange Station
+                   voiceEncap(103),    -- voice encapsulation
+                   voiceOverIp(104),   -- voice over IP encapsulation
+                   atmDxi(105),        -- ATM DXI
+                   atmFuni(106),       -- ATM FUNI
+                   atmIma (107),       -- ATM IMA
+                   pppMultilinkBundle(108), -- PPP Multilink Bundle
+                   ipOverCdlc (109),   -- IBM ipOverCdlc
+                   ipOverClaw (110),   -- IBM Common Link Access to Workstn
+                   stackToStack (111), -- IBM stackToStack
+                   virtualIpAddress (112), -- IBM VIPA
+                   mpc (113),          -- IBM multi-protocol channel support
+                   ipOverAtm (114),    -- IBM ipOverAtm
+                   iso88025Fiber (115), -- ISO 802.5j Fiber Token Ring
+                   tdlc (116),         -- IBM twinaxial data link control
+                   gigabitEthernet (117), -- Obsoleted via RFC3635
+                                          -- ethernetCsmacd (6) should be used instead
+                   hdlc (118),         -- HDLC
+                   lapf (119),         -- LAP F
+                   v37 (120),          -- V.37
+                   x25mlp (121),       -- Multi-Link Protocol
+                   x25huntGroup (122), -- X25 Hunt Group
+                   transpHdlc (123),   -- Transp HDLC
+                   interleave (124),   -- Interleave channel
+                   fast (125),         -- Fast channel
+                   ip (126),           -- IP (for APPN HPR in IP networks)
+                   docsCableMaclayer (127),  -- CATV Mac Layer
+                   docsCableDownstream (128), -- CATV Downstream interface
+                   docsCableUpstream (129),  -- CATV Upstream interface
+                   a12MppSwitch (130), -- Avalon Parallel Processor
+                   tunnel (131),       -- Encapsulation interface
+                   coffee (132),       -- coffee pot
+                   ces (133),          -- Circuit Emulation Service
+                   atmSubInterface (134), -- ATM Sub Interface
+                   l2vlan (135),       -- Layer 2 Virtual LAN using 802.1Q
+                   l3ipvlan (136),     -- Layer 3 Virtual LAN using IP
+                   l3ipxvlan (137),    -- Layer 3 Virtual LAN using IPX
+                   digitalPowerline (138), -- IP over Power Lines
+                   mediaMailOverIp (139), -- Multimedia Mail over IP
+                   dtm (140),        -- Dynamic syncronous Transfer Mode
+                   dcn (141),    -- Data Communications Network
+                   ipForward (142),    -- IP Forwarding Interface
+                   msdsl (143),       -- Multi-rate Symmetric DSL
+                   ieee1394 (144), -- IEEE1394 High Performance Serial Bus
+                   if-gsn (145),       --   HIPPI-6400
+                   dvbRccMacLayer (146), -- DVB-RCC MAC Layer
+                   dvbRccDownstream (147),  -- DVB-RCC Downstream Channel
+                   dvbRccUpstream (148),  -- DVB-RCC Upstream Channel
+                   atmVirtual (149),   -- ATM Virtual Interface
+                   mplsTunnel (150),   -- MPLS Tunnel Virtual Interface
+                   srp (151),   -- Spatial Reuse Protocol
+                   voiceOverAtm (152),  -- Voice Over ATM
+                   voiceOverFrameRelay (153),   -- Voice Over Frame Relay
+                   idsl (154),          -- Digital Subscriber Loop over ISDN
+                   compositeLink (155),  -- Avici Composite Link Interface
+                   ss7SigLink (156),     -- SS7 Signaling Link
+                   propWirelessP2P (157),  --  Prop. P2P wireless interface
+                   frForward (158),    -- Frame Forward Interface
+                   rfc1483 (159),       -- Multiprotocol over ATM AAL5
+                   usb (160),           -- USB Interface
+                   ieee8023adLag (161),  -- IEEE 802.3ad Link Aggregate
+                   bgppolicyaccounting (162), -- BGP Policy Accounting
+                   frf16MfrBundle (163), -- FRF .16 Multilink Frame Relay
+                   h323Gatekeeper (164), -- H323 Gatekeeper
+                   h323Proxy (165), -- H323 Voice and Video Proxy
+                   mpls (166), -- MPLS
+                   mfSigLink (167), -- Multi-frequency signaling link
+                   hdsl2 (168), -- High Bit-Rate DSL - 2nd generation
+                   shdsl (169), -- Multirate HDSL2
+                   ds1FDL (170), -- Facility Data Link 4Kbps on a DS1
+                   pos (171), -- Packet over SONET/SDH Interface
+                   dvbAsiIn (172), -- DVB-ASI Input
+                   dvbAsiOut (173), -- DVB-ASI Output
+                   plc (174), -- Power Line Communtications
+                   nfas (175), -- Non Facility Associated Signaling
+                   tr008 (176), -- TR008
+                   gr303RDT (177), -- Remote Digital Terminal
+                   gr303IDT (178), -- Integrated Digital Terminal
+                   isup (179), -- ISUP
+                   propDocsWirelessMaclayer (180), -- Cisco proprietary Maclayer
+                   propDocsWirelessDownstream (181), -- Cisco proprietary Downstream
+                   propDocsWirelessUpstream (182), -- Cisco proprietary Upstream
+                   hiperlan2 (183), -- HIPERLAN Type 2 Radio Interface
+                   propBWAp2Mp (184), -- PropBroadbandWirelessAccesspt2multipt
+                             -- use of this iftype for IEEE 802.16 WMAN
+                             -- interfaces as per IEEE Std 802.16f is
+                             -- deprecated and ifType 237 should be used instead.
+                   sonetOverheadChannel (185), -- SONET Overhead Channel
+                   digitalWrapperOverheadChannel (186), -- Digital Wrapper
+                   aal2 (187), -- ATM adaptation layer 2
+                   radioMAC (188), -- MAC layer over radio links
+                   atmRadio (189), -- ATM over radio links
+                   imt (190), -- Inter Machine Trunks
+                   mvl (191), -- Multiple Virtual Lines DSL
+                   reachDSL (192), -- Long Reach DSL
+                   frDlciEndPt (193), -- Frame Relay DLCI End Point
+                   atmVciEndPt (194), -- ATM VCI End Point
+                   opticalChannel (195), -- Optical Channel
+                   opticalTransport (196), -- Optical Transport
+                   propAtm (197), --  Proprietary ATM
+                   voiceOverCable (198), -- Voice Over Cable Interface
+                   infiniband (199), -- Infiniband
+                   teLink (200), -- TE Link
+                   q2931 (201), -- Q.2931
+                   virtualTg (202), -- Virtual Trunk Group
+                   sipTg (203), -- SIP Trunk Group
+                   sipSig (204), -- SIP Signaling
+                   docsCableUpstreamChannel (205), -- CATV Upstream Channel
+                   econet (206), -- Acorn Econet
+                   pon155 (207), -- FSAN 155Mb Symetrical PON interface
+                   pon622 (208), -- FSAN622Mb Symetrical PON interface
+                   bridge (209), -- Transparent bridge interface
+                   linegroup (210), -- Interface common to multiple lines
+                   voiceEMFGD (211), -- voice E&M Feature Group D
+                   voiceFGDEANA (212), -- voice FGD Exchange Access North American
+                   voiceDID (213), -- voice Direct Inward Dialing
+                   mpegTransport (214), -- MPEG transport interface
+                   sixToFour (215), -- 6to4 interface (DEPRECATED)
+                   gtp (216), -- GTP (GPRS Tunneling Protocol)
+                   pdnEtherLoop1 (217), -- Paradyne EtherLoop 1
+                   pdnEtherLoop2 (218), -- Paradyne EtherLoop 2
+                   opticalChannelGroup (219), -- Optical Channel Group
+                   homepna (220), -- HomePNA ITU-T G.989
+                   gfp (221), -- Generic Framing Procedure (GFP)
+                   ciscoISLvlan (222), -- Layer 2 Virtual LAN using Cisco ISL
+                   actelisMetaLOOP (223), -- Acteleis proprietary MetaLOOP High Speed Link
+                   fcipLink (224), -- FCIP Link
+                   rpr (225), -- Resilient Packet Ring Interface Type
+                   qam (226), -- RF Qam Interface
+                   lmp (227), -- Link Management Protocol
+                   cblVectaStar (228), -- Cambridge Broadband Networks Limited VectaStar
+                   docsCableMCmtsDownstream (229), -- CATV Modular CMTS Downstream Interface
+                   adsl2 (230), -- Asymmetric Digital Subscriber Loop Version 2
+                                -- (DEPRECATED/OBSOLETED - please use adsl2plus 238 instead)
+                   macSecControlledIF (231), -- MACSecControlled
+                   macSecUncontrolledIF (232), -- MACSecUncontrolled
+                   aviciOpticalEther (233), -- Avici Optical Ethernet Aggregate
+                   atmbond (234), -- atmbond
+                   voiceFGDOS (235), -- voice FGD Operator Services
+                   mocaVersion1 (236), -- MultiMedia over Coax Alliance (MoCA) Interface
+                             -- as documented in information provided privately to IANA
+                   ieee80216WMAN (237), -- IEEE 802.16 WMAN interface
+                   adsl2plus (238), -- Asymmetric Digital Subscriber Loop Version 2,
+                                   -- Version 2 Plus and all variants
+                   dvbRcsMacLayer (239), -- DVB-RCS MAC Layer
+                   dvbTdm (240), -- DVB Satellite TDM
+                   dvbRcsTdma (241), -- DVB-RCS TDMA
+                   x86Laps (242), -- LAPS based on ITU-T X.86/Y.1323
+                   wwanPP (243), -- 3GPP WWAN
+                   wwanPP2 (244), -- 3GPP2 WWAN
+                   voiceEBS (245), -- voice P-phone EBS physical interface
+                   ifPwType (246), -- Pseudowire interface type
+                   ilan (247), -- Internal LAN on a bridge per IEEE 802.1ap
+                   pip (248), -- Provider Instance Port on a bridge per IEEE 802.1ah PBB
+                   aluELP (249), -- Alcatel-Lucent Ethernet Link Protection
+                   gpon (250), -- Gigabit-capable passive optical networks (G-PON) as per ITU-T G.948
+                   vdsl2 (251), -- Very high speed digital subscriber line Version 2 (as per ITU-T Recommendation G.993.2)
+                   capwapDot11Profile (252), -- WLAN Profile Interface
+                   capwapDot11Bss (253), -- WLAN BSS Interface
+                   capwapWtpVirtualRadio (254), -- WTP Virtual Radio Interface
+                   bits (255), -- bitsport
+                   docsCableUpstreamRfPort (256), -- DOCSIS CATV Upstream RF Port
+                   cableDownstreamRfPort (257), -- CATV downstream RF port
+                   vmwareVirtualNic (258), -- VMware Virtual Network Interface
+                   ieee802154 (259), -- IEEE 802.15.4 WPAN interface
+                   otnOdu (260), -- OTN Optical Data Unit
+                   otnOtu (261), -- OTN Optical channel Transport Unit
+                   ifVfiType (262), -- VPLS Forwarding Instance Interface Type
+                   g9981 (263), -- G.998.1 bonded interface
+                   g9982 (264), -- G.998.2 bonded interface
+                   g9983 (265), -- G.998.3 bonded interface
+                   aluEpon (266), -- Ethernet Passive Optical Networks (E-PON)
+                   aluEponOnu (267), -- EPON Optical Network Unit
+                   aluEponPhysicalUni (268), -- EPON physical User to Network interface
+                   aluEponLogicalLink (269), -- The emulation of a point-to-point link over the EPON layer
+                   aluGponOnu (270), -- GPON Optical Network Unit
+                   aluGponPhysicalUni (271), -- GPON physical User to Network interface
+                   vmwareNicTeam (272), -- VMware NIC Team
+                   docsOfdmDownstream (277), -- CATV Downstream OFDM interface
+                   docsOfdmaUpstream (278), -- CATV Upstream OFDMA interface
+                   gfast (279), -- G.fast port
+                   sdci (280), -- SDCI (IO-Link)
+                   xboxWireless (281), -- Xbox wireless
+                   fastdsl (282), -- FastDSL
+                   docsCableScte55d1FwdOob (283), -- Cable SCTE 55-1 OOB Forward Channel
+                   docsCableScte55d1RetOob (284), -- Cable SCTE 55-1 OOB Return Channel
+                   docsCableScte55d2DsOob (285), -- Cable SCTE 55-2 OOB Downstream Channel
+                   docsCableScte55d2UsOob (286), -- Cable SCTE 55-2 OOB Upstream Channel
+                   docsCableNdf (287), -- Cable Narrowband Digital Forward
+                   docsCableNdr (288), -- Cable Narrowband Digital Return
+                   ptm (289), -- Packet Transfer Mode
+                   ghn (290) -- G.hn port
+                   }
+
+IANAtunnelType ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+            "The encapsulation method used by a tunnel. The value
+            direct indicates that a packet is encapsulated
+            directly within a normal IP header, with no
+            intermediate header, and unicast to the remote tunnel
+            endpoint (e.g., an RFC 2003 IP-in-IP tunnel, or an RFC
+            1933 IPv6-in-IPv4 tunnel). The value minimal indicates
+            that a Minimal Forwarding Header (RFC 2004) is
+            inserted between the outer header and the payload
+            packet. The value UDP indicates that the payload
+            packet is encapsulated within a normal UDP packet
+            (e.g., RFC 1234).
+
+            The values sixToFour, sixOverFour, and isatap
+            indicates that an IPv6 packet is encapsulated directly
+            within an IPv4 header, with no intermediate header,
+            and unicast to the destination determined by the 6to4,
+            6over4, or ISATAP protocol.
+
+            The remaining protocol-specific values indicate that a
+            header of the protocol of that name is inserted
+            between the outer header and the payload header.
+
+            The IP Tunnel MIB [RFC4087] is designed to manage
+            tunnels of any type over IPv4 and IPv6 networks;
+            therefore, it already supports IP-in-IP tunnels.
+            But in a DS-Lite scenario, the tunnel type is
+            point-to-multipoint IP-in-IP tunnels.  The direct(2)
+            defined in the IP Tunnel MIB only supports point-to-point
+            tunnels.  So, it needs to define a new tunnel type for
+            DS-Lite.
+
+            The assignment policy for IANAtunnelType values is
+            identical to the policy for assigning IANAifType
+            values."
+    SYNTAX     INTEGER {
+                   other(1),         -- none of the following
+                   direct(2),        -- no intermediate header
+                   gre(3),           -- GRE encapsulation
+                   minimal(4),       -- Minimal encapsulation
+                   l2tp(5),          -- L2TP encapsulation
+                   pptp(6),          -- PPTP encapsulation
+                   l2f(7),           -- L2F encapsulation
+                   udp(8),           -- UDP encapsulation
+                   atmp(9),          -- ATMP encapsulation
+                   msdp(10),         -- MSDP encapsulation
+                   sixToFour(11),    -- 6to4 encapsulation
+                   sixOverFour(12),  -- 6over4 encapsulation
+                   isatap(13),       -- ISATAP encapsulation
+                   teredo(14),       -- Teredo encapsulation
+                   ipHttps(15),      -- IPHTTPS
+                   softwireMesh(16), -- softwire mesh tunnel
+                   dsLite(17)        -- DS-Lite tunnel
+               }
+
+   END

--- a/rasn-compiler-tests/tests/snmp-mibs/IF-MIB
+++ b/rasn-compiler-tests/tests/snmp-mibs/IF-MIB
@@ -1,0 +1,1874 @@
+IF-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter32, Gauge32, Counter64,
+    Integer32, TimeTicks, mib-2,
+    NOTIFICATION-TYPE                        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString,
+    PhysAddress, TruthValue, RowStatus,
+    TimeStamp, AutonomousType, TestAndIncr   FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP                       FROM SNMPv2-CONF
+    snmpTraps                                FROM SNMPv2-MIB
+    IANAifType                               FROM IANAifType-MIB;
+
+ifMIB MODULE-IDENTITY
+    LAST-UPDATED "200006140000Z"
+    ORGANIZATION "IETF Interfaces MIB Working Group"
+    CONTACT-INFO
+            "   Keith McCloghrie
+                Cisco Systems, Inc.
+                170 West Tasman Drive
+                San Jose, CA  95134-1706
+                US
+
+                408-526-5260
+                kzm@cisco.com"
+    DESCRIPTION
+            "The MIB module to describe generic objects for network
+            interface sub-layers.  This MIB is an updated version of
+            MIB-II's ifTable, and incorporates the extensions defined in
+            RFC 1229."
+
+
+    REVISION      "200006140000Z"
+    DESCRIPTION
+            "Clarifications agreed upon by the Interfaces MIB WG, and
+            published as RFC 2863."
+    REVISION      "199602282155Z"
+    DESCRIPTION
+            "Revisions made by the Interfaces MIB WG, and published in
+            RFC 2233."
+    REVISION      "199311082155Z"
+    DESCRIPTION
+            "Initial revision, published as part of RFC 1573."
+    ::= { mib-2 31 }
+
+ifMIBObjects OBJECT IDENTIFIER ::= { ifMIB 1 }
+
+interfaces   OBJECT IDENTIFIER ::= { mib-2 2 }
+
+--
+-- Textual Conventions
+--
+
+-- OwnerString has the same semantics as used in RFC 1271
+
+OwnerString ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "255a"
+    STATUS       deprecated
+    DESCRIPTION
+            "This data type is used to model an administratively
+            assigned name of the owner of a resource.  This information
+            is taken from the NVT ASCII character set.  It is suggested
+            that this name contain one or more of the following: ASCII
+            form of the manager station's transport address, management
+            station name (e.g., domain name), network management
+            personnel's name, location, or phone number.  In some cases
+            the agent itself will be the owner of an entry.  In these
+            cases, this string shall be set to a string starting with
+            'agent'."
+    SYNTAX       OCTET STRING (SIZE(0..255))
+
+-- InterfaceIndex contains the semantics of ifIndex and should be used
+-- for any objects defined in other MIB modules that need these semantics.
+
+InterfaceIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+
+
+            "A unique value, greater than zero, for each interface or
+            interface sub-layer in the managed system.  It is
+            recommended that values are assigned contiguously starting
+            from 1.  The value for each interface sub-layer must remain
+            constant at least from one re-initialization of the entity's
+            network management system to the next re-initialization."
+    SYNTAX       Integer32 (1..2147483647)
+
+InterfaceIndexOrZero ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+            "This textual convention is an extension of the
+            InterfaceIndex convention.  The latter defines a greater
+            than zero value used to identify an interface or interface
+            sub-layer in the managed system.  This extension permits the
+            additional value of zero.  the value zero is object-specific
+            and must therefore be defined as part of the description of
+            any object which uses this syntax.  Examples of the usage of
+            zero might include situations where interface was unknown,
+            or when none or all interfaces need to be referenced."
+    SYNTAX       Integer32 (0..2147483647)
+
+ifNumber  OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of network interfaces (regardless of their
+            current state) present on this system."
+    ::= { interfaces 1 }
+
+ifTableLastChange  OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime at the time of the last creation or
+            deletion of an entry in the ifTable.  If the number of
+            entries has been unchanged since the last re-initialization
+            of the local network management subsystem, then this object
+            contains a zero value."
+    ::= { ifMIBObjects 5 }
+
+-- the Interfaces table
+
+-- The Interfaces table contains information on the entity's
+
+
+-- interfaces.  Each sub-layer below the internetwork-layer
+-- of a network interface is considered to be an interface.
+
+ifTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A list of interface entries.  The number of entries is
+            given by the value of ifNumber."
+    ::= { interfaces 2 }
+
+ifEntry OBJECT-TYPE
+    SYNTAX      IfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An entry containing management information applicable to a
+            particular interface."
+    INDEX   { ifIndex }
+    ::= { ifTable 1 }
+
+IfEntry ::=
+    SEQUENCE {
+        ifIndex                 InterfaceIndex,
+        ifDescr                 DisplayString,
+        ifType                  IANAifType,
+        ifMtu                   Integer32,
+        ifSpeed                 Gauge32,
+        ifPhysAddress           PhysAddress,
+        ifAdminStatus           INTEGER,
+        ifOperStatus            INTEGER,
+        ifLastChange            TimeTicks,
+        ifInOctets              Counter32,
+        ifInUcastPkts           Counter32,
+        ifInNUcastPkts          Counter32,  -- deprecated
+        ifInDiscards            Counter32,
+        ifInErrors              Counter32,
+        ifInUnknownProtos       Counter32,
+        ifOutOctets             Counter32,
+        ifOutUcastPkts          Counter32,
+        ifOutNUcastPkts         Counter32,  -- deprecated
+        ifOutDiscards           Counter32,
+        ifOutErrors             Counter32,
+        ifOutQLen               Gauge32,    -- deprecated
+        ifSpecific              OBJECT IDENTIFIER -- deprecated
+    }
+
+
+ifIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A unique value, greater than zero, for each interface.  It
+            is recommended that values are assigned contiguously
+            starting from 1.  The value for each interface sub-layer
+            must remain constant at least from one re-initialization of
+            the entity's network management system to the next re-
+            initialization."
+    ::= { ifEntry 1 }
+
+ifDescr OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A textual string containing information about the
+            interface.  This string should include the name of the
+            manufacturer, the product name and the version of the
+            interface hardware/software."
+    ::= { ifEntry 2 }
+
+ifType OBJECT-TYPE
+    SYNTAX      IANAifType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The type of interface.  Additional values for ifType are
+            assigned by the Internet Assigned Numbers Authority (IANA),
+            through updating the syntax of the IANAifType textual
+            convention."
+    ::= { ifEntry 3 }
+
+ifMtu OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The size of the largest packet which can be sent/received
+            on the interface, specified in octets.  For interfaces that
+            are used for transmitting network datagrams, this is the
+            size of the largest network datagram that can be sent on the
+            interface."
+    ::= { ifEntry 4 }
+
+ifSpeed OBJECT-TYPE
+
+
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An estimate of the interface's current bandwidth in bits
+            per second.  For interfaces which do not vary in bandwidth
+            or for those where no accurate estimation can be made, this
+            object should contain the nominal bandwidth.  If the
+            bandwidth of the interface is greater than the maximum value
+            reportable by this object then this object should report its
+            maximum value (4,294,967,295) and ifHighSpeed must be used
+            to report the interace's speed.  For a sub-layer which has
+            no concept of bandwidth, this object should be zero."
+    ::= { ifEntry 5 }
+
+ifPhysAddress OBJECT-TYPE
+    SYNTAX      PhysAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The interface's address at its protocol sub-layer.  For
+            example, for an 802.x interface, this object normally
+            contains a MAC address.  The interface's media-specific MIB
+            must define the bit and byte ordering and the format of the
+            value of this object.  For interfaces which do not have such
+            an address (e.g., a serial line), this object should contain
+            an octet string of zero length."
+    ::= { ifEntry 6 }
+
+ifAdminStatus OBJECT-TYPE
+    SYNTAX  INTEGER {
+                up(1),       -- ready to pass packets
+                down(2),
+                testing(3)   -- in some test mode
+            }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "The desired state of the interface.  The testing(3) state
+            indicates that no operational packets can be passed.  When a
+            managed system initializes, all interfaces start with
+            ifAdminStatus in the down(2) state.  As a result of either
+            explicit management action or per configuration information
+            retained by the managed system, ifAdminStatus is then
+            changed to either the up(1) or testing(3) states (or remains
+            in the down(2) state)."
+    ::= { ifEntry 7 }
+
+
+ifOperStatus OBJECT-TYPE
+    SYNTAX  INTEGER {
+                up(1),        -- ready to pass packets
+                down(2),
+                testing(3),   -- in some test mode
+                unknown(4),   -- status can not be determined
+                              -- for some reason.
+                dormant(5),
+                notPresent(6),    -- some component is missing
+                lowerLayerDown(7) -- down due to state of
+                                  -- lower-layer interface(s)
+            }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The current operational state of the interface.  The
+            testing(3) state indicates that no operational packets can
+            be passed.  If ifAdminStatus is down(2) then ifOperStatus
+            should be down(2).  If ifAdminStatus is changed to up(1)
+            then ifOperStatus should change to up(1) if the interface is
+            ready to transmit and receive network traffic; it should
+            change to dormant(5) if the interface is waiting for
+            external actions (such as a serial line waiting for an
+            incoming connection); it should remain in the down(2) state
+            if and only if there is a fault that prevents it from going
+            to the up(1) state; it should remain in the notPresent(6)
+            state if the interface has missing (typically, hardware)
+            components."
+    ::= { ifEntry 8 }
+
+ifLastChange OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime at the time the interface entered
+            its current operational state.  If the current state was
+            entered prior to the last re-initialization of the local
+            network management subsystem, then this object contains a
+            zero value."
+    ::= { ifEntry 9 }
+
+ifInOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets received on the interface,
+
+
+            including framing characters.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 10 }
+
+ifInUcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were not addressed to a multicast
+            or broadcast address at this sub-layer.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 11 }
+
+ifInNUcastPkts OBJECT-TYPE
+    SYNTAX  Counter32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a multicast or
+            broadcast address at this sub-layer.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime.
+
+            This object is deprecated in favour of ifInMulticastPkts and
+            ifInBroadcastPkts."
+    ::= { ifEntry 12 }
+
+ifInDiscards OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of inbound packets which were chosen to be
+            discarded even though no errors had been detected to prevent
+
+
+            their being deliverable to a higher-layer protocol.  One
+            possible reason for discarding such a packet could be to
+            free up buffer space.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 13 }
+
+ifInErrors OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "For packet-oriented interfaces, the number of inbound
+            packets that contained errors preventing them from being
+            deliverable to a higher-layer protocol.  For character-
+            oriented or fixed-length interfaces, the number of inbound
+            transmission units that contained errors preventing them
+            from being deliverable to a higher-layer protocol.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 14 }
+
+ifInUnknownProtos OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "For packet-oriented interfaces, the number of packets
+            received via the interface which were discarded because of
+            an unknown or unsupported protocol.  For character-oriented
+            or fixed-length interfaces that support protocol
+            multiplexing the number of transmission units received via
+            the interface which were discarded because of an unknown or
+            unsupported protocol.  For any interface that does not
+            support protocol multiplexing, this counter will always be
+            0.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 15 }
+
+
+ifOutOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets transmitted out of the
+            interface, including framing characters.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 16 }
+
+ifOutUcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were not addressed to a
+            multicast or broadcast address at this sub-layer, including
+            those that were discarded or not sent.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 17 }
+
+ifOutNUcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            multicast or broadcast address at this sub-layer, including
+            those that were discarded or not sent.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime.
+
+            This object is deprecated in favour of ifOutMulticastPkts
+            and ifOutBroadcastPkts."
+    ::= { ifEntry 18 }
+
+
+ifOutDiscards OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of outbound packets which were chosen to be
+            discarded even though no errors had been detected to prevent
+            their being transmitted.  One possible reason for discarding
+            such a packet could be to free up buffer space.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 19 }
+
+ifOutErrors OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "For packet-oriented interfaces, the number of outbound
+            packets that could not be transmitted because of errors.
+            For character-oriented or fixed-length interfaces, the
+            number of outbound transmission units that could not be
+            transmitted because of errors.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 20 }
+
+ifOutQLen OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "The length of the output packet queue (in packets)."
+    ::= { ifEntry 21 }
+
+ifSpecific OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "A reference to MIB definitions specific to the particular
+            media being used to realize the interface.  It is
+
+
+            recommended that this value point to an instance of a MIB
+            object in the media-specific MIB, i.e., that this object
+            have the semantics associated with the InstancePointer
+            textual convention defined in RFC 2579.  In fact, it is
+            recommended that the media-specific MIB specify what value
+            ifSpecific should/can take for values of ifType.  If no MIB
+            definitions specific to the particular media are available,
+            the value should be set to the OBJECT IDENTIFIER { 0 0 }."
+    ::= { ifEntry 22 }
+
+--
+--   Extension to the interface table
+--
+-- This table replaces the ifExtnsTable table.
+--
+
+ifXTable        OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfXEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A list of interface entries.  The number of entries is
+            given by the value of ifNumber.  This table contains
+            additional objects for the interface table."
+    ::= { ifMIBObjects 1 }
+
+ifXEntry        OBJECT-TYPE
+    SYNTAX      IfXEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An entry containing additional management information
+            applicable to a particular interface."
+    AUGMENTS    { ifEntry }
+    ::= { ifXTable 1 }
+
+IfXEntry ::=
+    SEQUENCE {
+        ifName                  DisplayString,
+        ifInMulticastPkts       Counter32,
+        ifInBroadcastPkts       Counter32,
+        ifOutMulticastPkts      Counter32,
+        ifOutBroadcastPkts      Counter32,
+        ifHCInOctets            Counter64,
+        ifHCInUcastPkts         Counter64,
+        ifHCInMulticastPkts     Counter64,
+
+
+        ifHCInBroadcastPkts     Counter64,
+        ifHCOutOctets           Counter64,
+        ifHCOutUcastPkts        Counter64,
+        ifHCOutMulticastPkts    Counter64,
+        ifHCOutBroadcastPkts    Counter64,
+        ifLinkUpDownTrapEnable  INTEGER,
+        ifHighSpeed             Gauge32,
+        ifPromiscuousMode       TruthValue,
+        ifConnectorPresent      TruthValue,
+        ifAlias                 DisplayString,
+        ifCounterDiscontinuityTime TimeStamp
+    }
+
+ifName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The textual name of the interface.  The value of this
+            object should be the name of the interface as assigned by
+            the local device and should be suitable for use in commands
+            entered at the device's `console'.  This might be a text
+            name, such as `le0' or a simple port number, such as `1',
+            depending on the interface naming syntax of the device.  If
+            several entries in the ifTable together represent a single
+            interface as named by the device, then each will have the
+            same value of ifName.  Note that for an agent which responds
+            to SNMP queries concerning an interface on some other
+            (proxied) device, then the value of ifName for such an
+            interface is the proxied device's local name for it.
+
+            If there is no local name, or this object is otherwise not
+            applicable, then this object contains a zero-length string."
+    ::= { ifXEntry 1 }
+
+ifInMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a multicast
+            address at this sub-layer.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+
+
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 2 }
+
+ifInBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a broadcast
+            address at this sub-layer.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 3 }
+
+ifOutMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            multicast address at this sub-layer, including those that
+            were discarded or not sent.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 4 }
+
+ifOutBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            broadcast address at this sub-layer, including those that
+            were discarded or not sent.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+
+
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 5 }
+
+--
+-- High Capacity Counter objects.  These objects are all
+-- 64 bit versions of the "basic" ifTable counters.  These
+-- objects all have the same basic semantics as their 32-bit
+-- counterparts, however, their syntax has been extended
+-- to 64 bits.
+--
+
+ifHCInOctets OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets received on the interface,
+            including framing characters.  This object is a 64-bit
+            version of ifInOctets.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 6 }
+
+ifHCInUcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were not addressed to a multicast
+            or broadcast address at this sub-layer.  This object is a
+            64-bit version of ifInUcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 7 }
+
+ifHCInMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+
+
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a multicast
+            address at this sub-layer.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.  This object
+            is a 64-bit version of ifInMulticastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 8 }
+
+ifHCInBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a broadcast
+            address at this sub-layer.  This object is a 64-bit version
+            of ifInBroadcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 9 }
+
+ifHCOutOctets OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets transmitted out of the
+            interface, including framing characters.  This object is a
+            64-bit version of ifOutOctets.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 10 }
+
+ifHCOutUcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+
+
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were not addressed to a
+            multicast or broadcast address at this sub-layer, including
+            those that were discarded or not sent.  This object is a
+            64-bit version of ifOutUcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 11 }
+
+ifHCOutMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            multicast address at this sub-layer, including those that
+            were discarded or not sent.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.  This object
+            is a 64-bit version of ifOutMulticastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 12 }
+
+ifHCOutBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            broadcast address at this sub-layer, including those that
+            were discarded or not sent.  This object is a 64-bit version
+            of ifOutBroadcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 13 }
+
+ifLinkUpDownTrapEnable  OBJECT-TYPE
+
+
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "Indicates whether linkUp/linkDown traps should be generated
+            for this interface.
+
+            By default, this object should have the value enabled(1) for
+            interfaces which do not operate on 'top' of any other
+            interface (as defined in the ifStackTable), and disabled(2)
+            otherwise."
+    ::= { ifXEntry 14 }
+
+ifHighSpeed OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An estimate of the interface's current bandwidth in units
+            of 1,000,000 bits per second.  If this object reports a
+            value of `n' then the speed of the interface is somewhere in
+            the range of `n-500,000' to `n+499,999'.  For interfaces
+            which do not vary in bandwidth or for those where no
+            accurate estimation can be made, this object should contain
+            the nominal bandwidth.  For a sub-layer which has no concept
+            of bandwidth, this object should be zero."
+    ::= { ifXEntry 15 }
+
+ifPromiscuousMode  OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object has a value of false(2) if this interface only
+            accepts packets/frames that are addressed to this station.
+            This object has a value of true(1) when the station accepts
+            all packets/frames transmitted on the media.  The value
+            true(1) is only legal on certain types of media.  If legal,
+            setting this object to a value of true(1) may require the
+            interface to be reset before becoming effective.
+
+            The value of ifPromiscuousMode does not affect the reception
+            of broadcast and multicast packets/frames by the interface."
+    ::= { ifXEntry 16 }
+
+ifConnectorPresent   OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+
+
+    STATUS      current
+    DESCRIPTION
+            "This object has the value 'true(1)' if the interface
+            sublayer has a physical connector and the value 'false(2)'
+            otherwise."
+    ::= { ifXEntry 17 }
+
+ifAlias   OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object is an 'alias' name for the interface as
+            specified by a network manager, and provides a non-volatile
+            'handle' for the interface.
+
+            On the first instantiation of an interface, the value of
+            ifAlias associated with that interface is the zero-length
+            string.  As and when a value is written into an instance of
+            ifAlias through a network management set operation, then the
+            agent must retain the supplied value in the ifAlias instance
+            associated with the same interface for as long as that
+            interface remains instantiated, including across all re-
+            initializations/reboots of the network management system,
+            including those which result in a change of the interface's
+            ifIndex value.
+
+            An example of the value which a network manager might store
+            in this object for a WAN interface is the (Telco's) circuit
+            number/identifier of the interface.
+
+            Some agents may support write-access only for interfaces
+            having particular values of ifType.  An agent which supports
+            write access to this object is required to keep the value in
+            non-volatile storage, but it may limit the length of new
+            values depending on how much storage is already occupied by
+            the current values for other interfaces."
+    ::= { ifXEntry 18 }
+
+ifCounterDiscontinuityTime OBJECT-TYPE
+    SYNTAX      TimeStamp
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime on the most recent occasion at which
+            any one or more of this interface's counters suffered a
+            discontinuity.  The relevant counters are the specific
+            instances associated with this interface of any Counter32 or
+
+
+            Counter64 object contained in the ifTable or ifXTable.  If
+            no such discontinuities have occurred since the last re-
+            initialization of the local management subsystem, then this
+            object contains a zero value."
+    ::= { ifXEntry 19 }
+
+--           The Interface Stack Group
+--
+-- Implementation of this group is optional, but strongly recommended
+-- for all systems
+--
+
+ifStackTable  OBJECT-TYPE
+     SYNTAX        SEQUENCE OF IfStackEntry
+     MAX-ACCESS    not-accessible
+     STATUS        current
+     DESCRIPTION
+            "The table containing information on the relationships
+            between the multiple sub-layers of network interfaces.  In
+            particular, it contains information on which sub-layers run
+            'on top of' which other sub-layers, where each sub-layer
+            corresponds to a conceptual row in the ifTable.  For
+            example, when the sub-layer with ifIndex value x runs over
+            the sub-layer with ifIndex value y, then this table
+            contains:
+
+              ifStackStatus.x.y=active
+
+            For each ifIndex value, I, which identifies an active
+            interface, there are always at least two instantiated rows
+            in this table associated with I.  For one of these rows, I
+            is the value of ifStackHigherLayer; for the other, I is the
+            value of ifStackLowerLayer.  (If I is not involved in
+            multiplexing, then these are the only two rows associated
+            with I.)
+
+            For example, two rows exist even for an interface which has
+            no others stacked on top or below it:
+
+              ifStackStatus.0.x=active
+              ifStackStatus.x.0=active "
+     ::= { ifMIBObjects 2 }
+
+ifStackEntry  OBJECT-TYPE
+     SYNTAX        IfStackEntry
+     MAX-ACCESS    not-accessible
+     STATUS        current
+
+
+     DESCRIPTION
+            "Information on a particular relationship between two sub-
+            layers, specifying that one sub-layer runs on 'top' of the
+            other sub-layer.  Each sub-layer corresponds to a conceptual
+            row in the ifTable."
+     INDEX { ifStackHigherLayer, ifStackLowerLayer }
+     ::= { ifStackTable 1 }
+
+IfStackEntry ::=
+    SEQUENCE {
+        ifStackHigherLayer  InterfaceIndexOrZero,
+        ifStackLowerLayer   InterfaceIndexOrZero,
+        ifStackStatus       RowStatus
+     }
+
+ifStackHigherLayer  OBJECT-TYPE
+     SYNTAX        InterfaceIndexOrZero
+     MAX-ACCESS    not-accessible
+     STATUS        current
+     DESCRIPTION
+            "The value of ifIndex corresponding to the higher sub-layer
+            of the relationship, i.e., the sub-layer which runs on 'top'
+            of the sub-layer identified by the corresponding instance of
+            ifStackLowerLayer.  If there is no higher sub-layer (below
+            the internetwork layer), then this object has the value 0."
+     ::= { ifStackEntry 1 }
+
+ifStackLowerLayer  OBJECT-TYPE
+     SYNTAX        InterfaceIndexOrZero
+     MAX-ACCESS    not-accessible
+     STATUS        current
+     DESCRIPTION
+            "The value of ifIndex corresponding to the lower sub-layer
+            of the relationship, i.e., the sub-layer which runs 'below'
+            the sub-layer identified by the corresponding instance of
+            ifStackHigherLayer.  If there is no lower sub-layer, then
+            this object has the value 0."
+     ::= { ifStackEntry 2 }
+
+ifStackStatus  OBJECT-TYPE
+    SYNTAX         RowStatus
+    MAX-ACCESS     read-create
+    STATUS         current
+    DESCRIPTION
+
+
+            "The status of the relationship between two sub-layers.
+
+            Changing the value of this object from 'active' to
+            'notInService' or 'destroy' will likely have consequences up
+            and down the interface stack.  Thus, write access to this
+            object is likely to be inappropriate for some types of
+            interfaces, and many implementations will choose not to
+            support write-access for any type of interface."
+    ::= { ifStackEntry 3 }
+
+ifStackLastChange OBJECT-TYPE
+    SYNTAX         TimeTicks
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+            "The value of sysUpTime at the time of the last change of
+            the (whole) interface stack.  A change of the interface
+            stack is defined to be any creation, deletion, or change in
+            value of any instance of ifStackStatus.  If the interface
+            stack has been unchanged since the last re-initialization of
+            the local network management subsystem, then this object
+            contains a zero value."
+    ::= { ifMIBObjects 6 }
+
+--   Generic Receive Address Table
+--
+-- This group of objects is mandatory for all types of
+-- interfaces which can receive packets/frames addressed to
+-- more than one address.
+--
+-- This table replaces the ifExtnsRcvAddr table.  The main
+-- difference is that this table makes use of the RowStatus
+-- textual convention, while ifExtnsRcvAddr did not.
+
+ifRcvAddressTable  OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfRcvAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains an entry for each address (broadcast,
+            multicast, or uni-cast) for which the system will receive
+            packets/frames on a particular interface, except as follows:
+
+            - for an interface operating in promiscuous mode, entries
+            are only required for those addresses for which the system
+            would receive frames were it not operating in promiscuous
+            mode.
+
+
+            - for 802.5 functional addresses, only one entry is
+            required, for the address which has the functional address
+            bit ANDed with the bit mask of all functional addresses for
+            which the interface will accept frames.
+
+            A system is normally able to use any unicast address which
+            corresponds to an entry in this table as a source address."
+    ::= { ifMIBObjects 4 }
+
+ifRcvAddressEntry  OBJECT-TYPE
+    SYNTAX      IfRcvAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A list of objects identifying an address for which the
+            system will accept packets/frames on the particular
+            interface identified by the index value ifIndex."
+    INDEX  { ifIndex, ifRcvAddressAddress }
+    ::= { ifRcvAddressTable 1 }
+
+IfRcvAddressEntry ::=
+    SEQUENCE {
+        ifRcvAddressAddress   PhysAddress,
+        ifRcvAddressStatus    RowStatus,
+        ifRcvAddressType      INTEGER
+    }
+
+ifRcvAddressAddress OBJECT-TYPE
+    SYNTAX      PhysAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An address for which the system will accept packets/frames
+            on this entry's interface."
+    ::= { ifRcvAddressEntry 1 }
+
+ifRcvAddressStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+            "This object is used to create and delete rows in the
+            ifRcvAddressTable."
+
+    ::= { ifRcvAddressEntry 2 }
+
+ifRcvAddressType OBJECT-TYPE
+    SYNTAX      INTEGER {
+
+
+                    other(1),
+                    volatile(2),
+                    nonVolatile(3)
+                }
+
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+            "This object has the value nonVolatile(3) for those entries
+            in the table which are valid and will not be deleted by the
+            next restart of the managed system.  Entries having the
+            value volatile(2) are valid and exist, but have not been
+            saved, so that will not exist after the next restart of the
+            managed system.  Entries having the value other(1) are valid
+            and exist but are not classified as to whether they will
+            continue to exist after the next restart."
+
+    DEFVAL  { volatile }
+    ::= { ifRcvAddressEntry 3 }
+
+-- definition of interface-related traps.
+
+linkDown NOTIFICATION-TYPE
+    OBJECTS { ifIndex, ifAdminStatus, ifOperStatus }
+    STATUS  current
+    DESCRIPTION
+            "A linkDown trap signifies that the SNMP entity, acting in
+            an agent role, has detected that the ifOperStatus object for
+            one of its communication links is about to enter the down
+            state from some other state (but not from the notPresent
+            state).  This other state is indicated by the included value
+            of ifOperStatus."
+    ::= { snmpTraps 3 }
+
+linkUp NOTIFICATION-TYPE
+    OBJECTS { ifIndex, ifAdminStatus, ifOperStatus }
+    STATUS  current
+    DESCRIPTION
+            "A linkUp trap signifies that the SNMP entity, acting in an
+            agent role, has detected that the ifOperStatus object for
+            one of its communication links left the down state and
+            transitioned into some other state (but not into the
+            notPresent state).  This other state is indicated by the
+            included value of ifOperStatus."
+    ::= { snmpTraps 4 }
+
+-- conformance information
+
+
+ifConformance OBJECT IDENTIFIER ::= { ifMIB 2 }
+
+ifGroups      OBJECT IDENTIFIER ::= { ifConformance 1 }
+ifCompliances OBJECT IDENTIFIER ::= { ifConformance 2 }
+
+-- compliance statements
+
+ifCompliance3 MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for SNMP entities which have
+            network interfaces."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { ifGeneralInformationGroup,
+                           linkUpDownNotificationsGroup }
+
+-- The groups:
+--        ifFixedLengthGroup
+--        ifHCFixedLengthGroup
+--        ifPacketGroup
+--        ifHCPacketGroup
+--        ifVHCPacketGroup
+-- are mutually exclusive; at most one of these groups is implemented
+-- for a particular interface.  When any of these groups is implemented
+-- for a particular interface, then ifCounterDiscontinuityGroup must
+-- also be implemented for that interface.
+
+        GROUP       ifFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory for those network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units, and for which the value of the
+            corresponding instance of ifSpeed is less than or equal to
+            20,000,000 bits/second."
+
+        GROUP       ifHCFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory for those network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units, and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second."
+
+        GROUP       ifPacketGroup
+        DESCRIPTION
+
+
+            "This group is mandatory for those network interfaces which
+            are packet-oriented, and for which the value of the
+            corresponding instance of ifSpeed is less than or equal to
+            20,000,000 bits/second."
+
+        GROUP       ifHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second but less than or equal to 650,000,000
+            bits/second."
+
+        GROUP       ifVHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than
+            650,000,000 bits/second."
+
+        GROUP       ifCounterDiscontinuityGroup
+        DESCRIPTION
+            "This group is mandatory for those network interfaces that
+            are required to maintain counters (i.e., those for which one
+            of the ifFixedLengthGroup, ifHCFixedLengthGroup,
+            ifPacketGroup, ifHCPacketGroup, or ifVHCPacketGroup is
+            mandatory)."
+
+        GROUP       ifRcvAddressGroup
+        DESCRIPTION
+            "The applicability of this group MUST be defined by the
+            media-specific MIBs.  Media-specific MIBs must define the
+            exact meaning, use, and semantics of the addresses in this
+            group."
+
+        OBJECT      ifLinkUpDownTrapEnable
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifPromiscuousMode
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT       ifAdminStatus
+
+
+        SYNTAX       INTEGER { up(1), down(2) }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support for the value
+            testing(3)."
+
+        OBJECT       ifAlias
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required."
+
+    ::= { ifCompliances 3 }
+
+-- units of conformance
+
+ifGeneralInformationGroup    OBJECT-GROUP
+    OBJECTS { ifIndex, ifDescr, ifType, ifSpeed, ifPhysAddress,
+              ifAdminStatus, ifOperStatus, ifLastChange,
+              ifLinkUpDownTrapEnable, ifConnectorPresent,
+              ifHighSpeed, ifName, ifNumber, ifAlias,
+              ifTableLastChange }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information applicable to
+            all network interfaces."
+    ::= { ifGroups 10 }
+
+-- the following five groups are mutually exclusive; at most
+-- one of these groups is implemented for any interface
+
+ifFixedLengthGroup    OBJECT-GROUP
+    OBJECTS { ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            non-high speed (non-high speed interfaces transmit and
+            receive at speeds less than or equal to 20,000,000
+            bits/second) character-oriented or fixed-length-transmission
+            network interfaces."
+    ::= { ifGroups 2 }
+
+ifHCFixedLengthGroup    OBJECT-GROUP
+    OBJECTS { ifHCInOctets, ifHCOutOctets,
+              ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors }
+    STATUS  current
+    DESCRIPTION
+
+
+            "A collection of objects providing information specific to
+            high speed (greater than 20,000,000 bits/second) character-
+            oriented or fixed-length-transmission network interfaces."
+    ::= { ifGroups 3 }
+
+ifPacketGroup    OBJECT-GROUP
+    OBJECTS { ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors,
+              ifMtu, ifInUcastPkts, ifInMulticastPkts,
+              ifInBroadcastPkts, ifInDiscards,
+              ifOutUcastPkts, ifOutMulticastPkts,
+              ifOutBroadcastPkts, ifOutDiscards,
+              ifPromiscuousMode }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            non-high speed (non-high speed interfaces transmit and
+            receive at speeds less than or equal to 20,000,000
+            bits/second) packet-oriented network interfaces."
+    ::= { ifGroups 4 }
+
+ifHCPacketGroup    OBJECT-GROUP
+    OBJECTS { ifHCInOctets, ifHCOutOctets,
+              ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors,
+              ifMtu, ifInUcastPkts, ifInMulticastPkts,
+              ifInBroadcastPkts, ifInDiscards,
+              ifOutUcastPkts, ifOutMulticastPkts,
+              ifOutBroadcastPkts, ifOutDiscards,
+              ifPromiscuousMode }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            high speed (greater than 20,000,000 bits/second but less
+            than or equal to 650,000,000 bits/second) packet-oriented
+            network interfaces."
+    ::= { ifGroups 5 }
+
+ifVHCPacketGroup    OBJECT-GROUP
+    OBJECTS { ifHCInUcastPkts, ifHCInMulticastPkts,
+              ifHCInBroadcastPkts, ifHCOutUcastPkts,
+              ifHCOutMulticastPkts, ifHCOutBroadcastPkts,
+              ifHCInOctets, ifHCOutOctets,
+              ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors,
+              ifMtu, ifInUcastPkts, ifInMulticastPkts,
+              ifInBroadcastPkts, ifInDiscards,
+              ifOutUcastPkts, ifOutMulticastPkts,
+
+
+              ifOutBroadcastPkts, ifOutDiscards,
+              ifPromiscuousMode }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            higher speed (greater than 650,000,000 bits/second) packet-
+            oriented network interfaces."
+    ::= { ifGroups 6 }
+
+ifRcvAddressGroup    OBJECT-GROUP
+    OBJECTS { ifRcvAddressStatus, ifRcvAddressType }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information on the
+            multiple addresses which an interface receives."
+    ::= { ifGroups 7 }
+
+ifStackGroup2    OBJECT-GROUP
+    OBJECTS { ifStackStatus, ifStackLastChange }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information on the
+            layering of MIB-II interfaces."
+    ::= { ifGroups 11 }
+
+ifCounterDiscontinuityGroup  OBJECT-GROUP
+    OBJECTS { ifCounterDiscontinuityTime }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            interface counter discontinuities."
+    ::= { ifGroups 13 }
+
+linkUpDownNotificationsGroup  NOTIFICATION-GROUP
+    NOTIFICATIONS { linkUp, linkDown }
+    STATUS  current
+    DESCRIPTION
+            "The notifications which indicate specific changes in the
+            value of ifOperStatus."
+    ::= { ifGroups 14 }
+
+-- Deprecated Definitions - Objects
+
+--
+--    The Interface Test Table
+--
+-- This group of objects is optional.  However, a media-specific
+
+
+-- MIB may make implementation of this group mandatory.
+--
+-- This table replaces the ifExtnsTestTable
+--
+
+ifTestTable   OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfTestEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+            "This table contains one entry per interface.  It defines
+            objects which allow a network manager to instruct an agent
+            to test an interface for various faults.  Tests for an
+            interface are defined in the media-specific MIB for that
+            interface.  After invoking a test, the object ifTestResult
+            can be read to determine the outcome.  If an agent can not
+            perform the test, ifTestResult is set to so indicate.  The
+            object ifTestCode can be used to provide further test-
+            specific or interface-specific (or even enterprise-specific)
+            information concerning the outcome of the test.  Only one
+            test can be in progress on each interface at any one time.
+            If one test is in progress when another test is invoked, the
+            second test is rejected.  Some agents may reject a test when
+            a prior test is active on another interface.
+
+            Before starting a test, a manager-station must first obtain
+            'ownership' of the entry in the ifTestTable for the
+            interface to be tested.  This is accomplished with the
+            ifTestId and ifTestStatus objects as follows:
+
+          try_again:
+              get (ifTestId, ifTestStatus)
+              while (ifTestStatus != notInUse)
+                  /*
+                   * Loop while a test is running or some other
+                   * manager is configuring a test.
+                   */
+                  short delay
+                  get (ifTestId, ifTestStatus)
+              }
+
+              /*
+               * Is not being used right now -- let's compete
+               * to see who gets it.
+               */
+              lock_value = ifTestId
+
+              if ( set(ifTestId = lock_value, ifTestStatus = inUse,
+
+
+                       ifTestOwner = 'my-IP-address') == FAILURE)
+                  /*
+                   * Another manager got the ifTestEntry -- go
+                   * try again
+                   */
+                  goto try_again;
+
+              /*
+               * I have the lock
+               */
+              set up any test parameters.
+
+              /*
+               * This starts the test
+               */
+              set(ifTestType = test_to_run);
+
+              wait for test completion by polling ifTestResult
+
+              when test completes, agent sets ifTestResult
+                   agent also sets ifTestStatus = 'notInUse'
+
+              retrieve any additional test results, and ifTestId
+
+              if (ifTestId == lock_value+1) results are valid
+
+            A manager station first retrieves the value of the
+            appropriate ifTestId and ifTestStatus objects, periodically
+            repeating the retrieval if necessary, until the value of
+            ifTestStatus is 'notInUse'.  The manager station then tries
+            to set the same ifTestId object to the value it just
+            retrieved, the same ifTestStatus object to 'inUse', and the
+            corresponding ifTestOwner object to a value indicating
+            itself.  If the set operation succeeds then the manager has
+            obtained ownership of the ifTestEntry, and the value of the
+            ifTestId object is incremented by the agent (per the
+            semantics of TestAndIncr).  Failure of the set operation
+            indicates that some other manager has obtained ownership of
+            the ifTestEntry.
+
+            Once ownership is obtained, any test parameters can be
+            setup, and then the test is initiated by setting ifTestType.
+            On completion of the test, the agent sets ifTestStatus to
+            'notInUse'.  Once this occurs, the manager can retrieve the
+            results.  In the (rare) event that the invocation of tests
+            by two network managers were to overlap, then there would be
+            a possibility that the first test's results might be
+            overwritten by the second test's results prior to the first
+
+
+            results being read.  This unlikely circumstance can be
+            detected by a network manager retrieving ifTestId at the
+            same time as retrieving the test results, and ensuring that
+            the results are for the desired request.
+
+            If ifTestType is not set within an abnormally long period of
+            time after ownership is obtained, the agent should time-out
+            the manager, and reset the value of the ifTestStatus object
+            back to 'notInUse'.  It is suggested that this time-out
+            period be 5 minutes.
+
+            In general, a management station must not retransmit a
+            request to invoke a test for which it does not receive a
+            response; instead, it properly inspects an agent's MIB to
+            determine if the invocation was successful.  Only if the
+            invocation was unsuccessful, is the invocation request
+            retransmitted.
+
+            Some tests may require the interface to be taken off-line in
+            order to execute them, or may even require the agent to
+            reboot after completion of the test.  In these
+            circumstances, communication with the management station
+            invoking the test may be lost until after completion of the
+            test.  An agent is not required to support such tests.
+            However, if such tests are supported, then the agent should
+            make every effort to transmit a response to the request
+            which invoked the test prior to losing communication.  When
+            the agent is restored to normal service, the results of the
+            test are properly made available in the appropriate objects.
+            Note that this requires that the ifIndex value assigned to
+            an interface must be unchanged even if the test causes a
+            reboot.  An agent must reject any test for which it cannot,
+            perhaps due to resource constraints, make available at least
+            the minimum amount of information after that test
+            completes."
+    ::= { ifMIBObjects 3 }
+
+ifTestEntry OBJECT-TYPE
+    SYNTAX       IfTestEntry
+    MAX-ACCESS   not-accessible
+    STATUS       deprecated
+    DESCRIPTION
+            "An entry containing objects for invoking tests on an
+            interface."
+    AUGMENTS  { ifEntry }
+    ::= { ifTestTable 1 }
+
+IfTestEntry ::=
+
+
+    SEQUENCE {
+        ifTestId           TestAndIncr,
+        ifTestStatus       INTEGER,
+        ifTestType         AutonomousType,
+        ifTestResult       INTEGER,
+        ifTestCode         OBJECT IDENTIFIER,
+        ifTestOwner        OwnerString
+    }
+
+ifTestId         OBJECT-TYPE
+    SYNTAX       TestAndIncr
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "This object identifies the current invocation of the
+            interface's test."
+    ::= { ifTestEntry 1 }
+
+ifTestStatus     OBJECT-TYPE
+    SYNTAX       INTEGER { notInUse(1), inUse(2) }
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "This object indicates whether or not some manager currently
+            has the necessary 'ownership' required to invoke a test on
+            this interface.  A write to this object is only successful
+            when it changes its value from 'notInUse(1)' to 'inUse(2)'.
+            After completion of a test, the agent resets the value back
+            to 'notInUse(1)'."
+    ::= { ifTestEntry 2 }
+
+ifTestType       OBJECT-TYPE
+    SYNTAX       AutonomousType
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "A control variable used to start and stop operator-
+            initiated interface tests.  Most OBJECT IDENTIFIER values
+            assigned to tests are defined elsewhere, in association with
+            specific types of interface.  However, this document assigns
+            a value for a full-duplex loopback test, and defines the
+            special meanings of the subject identifier:
+
+                noTest  OBJECT IDENTIFIER ::= { 0 0 }
+
+            When the value noTest is written to this object, no action
+            is taken unless a test is in progress, in which case the
+            test is aborted.  Writing any other value to this object is
+
+
+            only valid when no test is currently in progress, in which
+            case the indicated test is initiated.
+
+            When read, this object always returns the most recent value
+            that ifTestType was set to.  If it has not been set since
+            the last initialization of the network management subsystem
+            on the agent, a value of noTest is returned."
+    ::= { ifTestEntry 3 }
+
+ifTestResult  OBJECT-TYPE
+    SYNTAX       INTEGER {
+                     none(1),          -- no test yet requested
+                     success(2),
+                     inProgress(3),
+                     notSupported(4),
+                     unAbleToRun(5),   -- due to state of system
+                     aborted(6),
+                     failed(7)
+                 }
+    MAX-ACCESS   read-only
+    STATUS       deprecated
+    DESCRIPTION
+            "This object contains the result of the most recently
+            requested test, or the value none(1) if no tests have been
+            requested since the last reset.  Note that this facility
+            provides no provision for saving the results of one test
+            when starting another, as could be required if used by
+            multiple managers concurrently."
+    ::= { ifTestEntry 4 }
+
+ifTestCode  OBJECT-TYPE
+    SYNTAX       OBJECT IDENTIFIER
+    MAX-ACCESS   read-only
+    STATUS       deprecated
+    DESCRIPTION
+            "This object contains a code which contains more specific
+            information on the test result, for example an error-code
+            after a failed test.  Error codes and other values this
+            object may take are specific to the type of interface and/or
+            test.  The value may have the semantics of either the
+            AutonomousType or InstancePointer textual conventions as
+            defined in RFC 2579.  The identifier:
+
+                testCodeUnknown  OBJECT IDENTIFIER ::= { 0 0 }
+
+            is defined for use if no additional result code is
+            available."
+    ::= { ifTestEntry 5 }
+
+
+ifTestOwner      OBJECT-TYPE
+    SYNTAX       OwnerString
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "The entity which currently has the 'ownership' required to
+            invoke a test on this interface."
+    ::= { ifTestEntry 6 }
+
+-- Deprecated Definitions - Groups
+
+ifGeneralGroup    OBJECT-GROUP
+    OBJECTS { ifDescr, ifType, ifSpeed, ifPhysAddress,
+              ifAdminStatus, ifOperStatus, ifLastChange,
+              ifLinkUpDownTrapEnable, ifConnectorPresent,
+              ifHighSpeed, ifName }
+    STATUS  deprecated
+    DESCRIPTION
+            "A collection of objects deprecated in favour of
+            ifGeneralInformationGroup."
+    ::= { ifGroups 1 }
+
+ifTestGroup    OBJECT-GROUP
+    OBJECTS { ifTestId, ifTestStatus, ifTestType,
+              ifTestResult, ifTestCode, ifTestOwner }
+    STATUS  deprecated
+    DESCRIPTION
+            "A collection of objects providing the ability to invoke
+            tests on an interface."
+    ::= { ifGroups 8 }
+
+ifStackGroup    OBJECT-GROUP
+    OBJECTS { ifStackStatus }
+    STATUS  deprecated
+    DESCRIPTION
+            "The previous collection of objects providing information on
+            the layering of MIB-II interfaces."
+    ::= { ifGroups 9 }
+
+ifOldObjectsGroup    OBJECT-GROUP
+    OBJECTS { ifInNUcastPkts, ifOutNUcastPkts,
+              ifOutQLen, ifSpecific }
+    STATUS  deprecated
+    DESCRIPTION
+
+
+            "The collection of objects deprecated from the original MIB-
+            II interfaces group."
+    ::= { ifGroups 12 }
+
+-- Deprecated Definitions - Compliance
+
+ifCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+            "A compliance statement defined in a previous version of
+            this MIB module, for SNMP entities which have network
+            interfaces."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { ifGeneralGroup, ifStackGroup }
+
+        GROUP       ifFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory for all network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units."
+
+        GROUP       ifHCFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are character-oriented or transmit data in fixed-
+            length transmission units, and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second."
+
+        GROUP       ifPacketGroup
+        DESCRIPTION
+            "This group is mandatory for all network interfaces which
+            are packet-oriented."
+
+        GROUP       ifHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than
+            650,000,000 bits/second."
+
+        GROUP       ifTestGroup
+        DESCRIPTION
+            "This group is optional.  Media-specific MIBs which require
+            interface tests are strongly encouraged to use this group
+            for invoking tests and reporting results.  A medium specific
+            MIB which has mandatory tests may make implementation of
+
+
+            this group mandatory."
+
+        GROUP       ifRcvAddressGroup
+        DESCRIPTION
+            "The applicability of this group MUST be defined by the
+            media-specific MIBs.  Media-specific MIBs must define the
+            exact meaning, use, and semantics of the addresses in this
+            group."
+
+        OBJECT      ifLinkUpDownTrapEnable
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifPromiscuousMode
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifStackStatus
+        SYNTAX      INTEGER { active(1) } -- subset of RowStatus
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required, and only one of the six
+            enumerated values for the RowStatus textual convention need
+            be supported, specifically: active(1)."
+
+        OBJECT       ifAdminStatus
+        SYNTAX       INTEGER { up(1), down(2) }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support for the value
+            testing(3)."
+    ::= { ifCompliances 1 }
+
+ifCompliance2 MODULE-COMPLIANCE
+    STATUS      deprecated
+    DESCRIPTION
+            "A compliance statement defined in a previous version of
+            this MIB module, for SNMP entities which have network
+            interfaces."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { ifGeneralInformationGroup, ifStackGroup2,
+                           ifCounterDiscontinuityGroup }
+
+        GROUP       ifFixedLengthGroup
+        DESCRIPTION
+
+
+            "This group is mandatory for all network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units."
+
+        GROUP       ifHCFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are character-oriented or transmit data in fixed-
+            length transmission units, and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second."
+
+        GROUP       ifPacketGroup
+        DESCRIPTION
+            "This group is mandatory for all network interfaces which
+            are packet-oriented."
+
+        GROUP       ifHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than
+            650,000,000 bits/second."
+
+        GROUP       ifRcvAddressGroup
+        DESCRIPTION
+            "The applicability of this group MUST be defined by the
+            media-specific MIBs.  Media-specific MIBs must define the
+            exact meaning, use, and semantics of the addresses in this
+            group."
+
+        OBJECT      ifLinkUpDownTrapEnable
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifPromiscuousMode
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifStackStatus
+        SYNTAX      INTEGER { active(1) } -- subset of RowStatus
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required, and only one of the six
+            enumerated values for the RowStatus textual convention need
+            be supported, specifically: active(1)."
+
+
+        OBJECT       ifAdminStatus
+        SYNTAX       INTEGER { up(1), down(2) }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support for the value
+            testing(3)."
+
+        OBJECT       ifAlias
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required."
+
+    ::= { ifCompliances 2 }
+
+END

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -162,7 +162,18 @@ pub const TIME_OF_DAY: &str = "TIME-OF-DAY";
 pub const TYPE_IDENTIFIER: &str = "TYPE-IDENTIFIER";
 pub const ENCODING_CONTROL: &str = "ENCODING-CONTROL";
 
-pub const ASN1_KEYWORDS: [&str; 63] = [
+// SNMP MACRO names
+pub const MODULE_COMPLIANCE: &str = "MODULE-COMPLIANCE";
+pub const MODULE_IDENTITY: &str = "MODULE-IDENTITY";
+pub const NOTIFICATION_TYPE: &str = "NOTIFICATION-TYPE";
+pub const OBJECT_TYPE: &str = "OBJECT-TYPE";
+pub const OBJECT_GROUP: &str = "OBJECT-GROUP";
+pub const NOTIFICATION_GROUP: &str = "NOTIFICATION-GROUP";
+pub const TEXTUAL_CONVENTION: &str = "TEXTUAL-CONVENTION";
+// SNMP MACRO keywords that can collide with other types
+pub const MANDATORY_GROUPS: &str = "MANDATORY-GROUPS";
+
+pub const ASN1_KEYWORDS: [&str; 71] = [
     ABSTRACT_SYNTAX,
     BIT,
     CHARACTER,
@@ -226,6 +237,14 @@ pub const ASN1_KEYWORDS: [&str; 63] = [
     FROM,
     INSTRUCTIONS,
     TAGS,
+    MODULE_IDENTITY,
+    MODULE_COMPLIANCE,
+    TEXTUAL_CONVENTION,
+    OBJECT_TYPE,
+    OBJECT_GROUP,
+    NOTIFICATION_TYPE,
+    NOTIFICATION_GROUP,
+    MANDATORY_GROUPS,
 ];
 
 macro_rules! grammar_error {

--- a/rasn-compiler/src/lexer/character_string.rs
+++ b/rasn-compiler/src/lexer/character_string.rs
@@ -14,17 +14,14 @@ use super::{
     error::{MiscError, ParserResult},
 };
 
-pub fn character_string_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
-    map(
-        skip_ws_and_comments(alt((
-            map(
-                into_inner(delimited(tag("\""), take_until("\""), tag("\""))),
-                ToString::to_string,
-            ),
-            map(quadruple, |c| c.to_string()),
-        ))),
-        |m: String| ASN1Value::String(m),
-    )(input)
+pub fn character_string_value(input: Input<'_>) -> ParserResult<'_, String> {
+    skip_ws_and_comments(alt((
+        map(
+            into_inner(delimited(tag("\""), take_until("\""), tag("\""))),
+            ToString::to_string,
+        ),
+        map(quadruple, |c| c.to_string()),
+    )))(input)
 }
 
 /// A ASN1 character value can be specified "by reference to a registration number in the ISO
@@ -205,10 +202,7 @@ mod tests {
 
     #[test]
     fn parses_character_string_value() {
-        assert_eq!(
-            character_string_value("\"a\"".into()).unwrap().1,
-            ASN1Value::String("a".to_owned())
-        )
+        assert_eq!(character_string_value("\"a\"".into()).unwrap().1, "a")
     }
 
     #[test]

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -20,7 +20,7 @@ use nom::{
 
 use crate::{
     input::{context_boundary, Input},
-    intermediate::{information_object::*, *},
+    intermediate::{information_object::*, types::ObjectIdentifier, *},
 };
 
 use self::{
@@ -52,6 +52,7 @@ mod sequence;
 mod sequence_of;
 mod set;
 mod set_of;
+mod snmp;
 mod time;
 mod util;
 
@@ -161,6 +162,46 @@ pub fn asn1_type(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             time,
             octet_string,
             character_string,
+            map(snmp::module_identity, |_| {
+                // Discard all info for now.
+                ASN1Type::ObjectIdentifier(ObjectIdentifier {
+                    constraints: Vec::new(),
+                })
+            }),
+            map(snmp::textual_convention, |t| {
+                // Discard all info for now, except the type.
+                t.syntax
+            }),
+            map(snmp::object_type, |_| {
+                // Discard all info for now.
+                ASN1Type::ObjectIdentifier(ObjectIdentifier {
+                    constraints: Vec::new(),
+                })
+            }),
+            map(snmp::notification_type, |_| {
+                // Discard all info for now.
+                ASN1Type::ObjectIdentifier(ObjectIdentifier {
+                    constraints: Vec::new(),
+                })
+            }),
+            map(snmp::module_compliance, |_| {
+                // Discard all info for now.
+                ASN1Type::ObjectIdentifier(ObjectIdentifier {
+                    constraints: Vec::new(),
+                })
+            }),
+            map(snmp::object_group, |_| {
+                // Discard all info for now.
+                ASN1Type::ObjectIdentifier(ObjectIdentifier {
+                    constraints: Vec::new(),
+                })
+            }),
+            map(snmp::notification_group, |_| {
+                // Discard all info for now.
+                ASN1Type::ObjectIdentifier(ObjectIdentifier {
+                    constraints: Vec::new(),
+                })
+            }),
             map(information_object_field_reference, |i| {
                 ASN1Type::InformationObjectFieldReference(i)
             }),
@@ -181,7 +222,7 @@ pub fn asn1_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
         bit_string_value,
         boolean_value,
         integer_value,
-        character_string_value,
+        map(character_string_value, ASN1Value::String),
         elsewhere_declared_value,
     ))(input)
 }

--- a/rasn-compiler/src/lexer/snmp.rs
+++ b/rasn-compiler/src/lexer/snmp.rs
@@ -1,0 +1,1186 @@
+//! Support for parsing conventions used in SNMP MIBs
+
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::{cut, map, opt};
+use nom::multi::{many0, many1, separated_list1};
+use nom::sequence::{pair, preceded, tuple};
+
+use crate::input::Input;
+use crate::intermediate::{
+    ASN1Type, ASN1Value, MANDATORY_GROUPS, MODULE_COMPLIANCE, NOTIFICATION_GROUP,
+    NOTIFICATION_TYPE, OBJECT_GROUP, OBJECT_TYPE,
+};
+use crate::lexer::character_string::character_string_value;
+use crate::lexer::common::{
+    in_braces, skip_ws_and_comments, title_case_identifier, value_identifier,
+};
+use crate::lexer::error::ParserResult;
+use crate::lexer::{asn1_type, asn1_value};
+
+// MODULE-IDENTITY MACRO ::=
+// BEGIN
+//     TYPE NOTATION ::=
+//                   "LAST-UPDATED" value(Update ExtUTCTime)
+//                   "ORGANIZATION" Text
+//                   "CONTACT-INFO" Text
+//                   "DESCRIPTION" Text
+//                   RevisionPart
+//
+//     VALUE NOTATION ::=
+//                   value(VALUE OBJECT IDENTIFIER)
+//
+//     RevisionPart ::=
+//                   Revisions
+//                 | empty
+//     Revisions ::=
+//                   Revision
+//                 | Revisions Revision
+//     Revision ::=
+//                   "REVISION" value(Update ExtUTCTime)
+//                   "DESCRIPTION" Text
+//
+//     -- a character string as defined in section 3.1.1
+//     Text ::= value(IA5String)
+// END
+
+/// SNMPv2-SMI MODULE-IDENTITY MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModuleIdentity {
+    // "LAST-UPDATED" value(Update ExtUTCTime)
+    pub last_updated: String,
+    // "ORGANIZATION" value(IA5String)
+    pub organization: String,
+    // "CONTACT-INFO" value(IA5String)
+    pub contact_info: String,
+    // "DESCRIPTION" value(IA5String)
+    pub description: String,
+    // revision +
+    pub revisions: Vec<ModuleIdentityRevision>,
+}
+
+/// REVISION in SNMPv2-SMI MODULE-IDENTITY MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModuleIdentityRevision {
+    // "REVISION" value(Update ExtUTCTime)
+    revision: String,
+    // "DESCRIPTION" value(IA5String)
+    description: String,
+}
+
+/// Parse an SNMPv2-SMI MODULE-IDENTITY MACRO
+pub fn module_identity(input: Input<'_>) -> ParserResult<'_, ModuleIdentity> {
+    preceded(
+        skip_ws_and_comments(tag("MODULE-IDENTITY")),
+        map(
+            tuple((
+                skip_ws_and_comments(preceded(tag("LAST-UPDATED"), character_string_value)),
+                skip_ws_and_comments(preceded(tag("ORGANIZATION"), character_string_value)),
+                skip_ws_and_comments(preceded(tag("CONTACT-INFO"), character_string_value)),
+                skip_ws_and_comments(preceded(tag("DESCRIPTION"), character_string_value)),
+                skip_ws_and_comments(many0(module_identity_revision)),
+            )),
+            |v| ModuleIdentity {
+                last_updated: v.0,
+                organization: v.1,
+                contact_info: v.2,
+                description: v.3,
+                revisions: v.4,
+            },
+        ),
+    )(input)
+}
+
+/// Parse a REVISION inside an SNMPv2-SMI MODULE-IDENTITY MACRO
+pub fn module_identity_revision(input: Input<'_>) -> ParserResult<'_, ModuleIdentityRevision> {
+    map(
+        pair(
+            preceded(
+                skip_ws_and_comments(tag("REVISION")),
+                character_string_value,
+            ),
+            preceded(
+                skip_ws_and_comments(tag("DESCRIPTION")),
+                character_string_value,
+            ),
+        ),
+        |v| ModuleIdentityRevision {
+            revision: v.0,
+            description: v.1,
+        },
+    )(input)
+}
+
+// TEXTUAL-CONVENTION MACRO ::=
+// BEGIN
+//     TYPE NOTATION ::=
+//                   DisplayPart
+//                   "STATUS" Status
+//                   "DESCRIPTION" Text
+//                   ReferPart
+//                   "SYNTAX" Syntax
+//
+//     VALUE NOTATION ::=
+//                    value(VALUE Syntax)      -- adapted ASN.1
+//
+//     DisplayPart ::=
+//                   "DISPLAY-HINT" Text
+//                 | empty
+//
+//     Status ::=
+//                   "current"
+//                 | "deprecated"
+//                 | "obsolete"
+//
+//     ReferPart ::=
+//                   "REFERENCE" Text
+//                 | empty
+//
+//     -- a character string as defined in [2]
+//     Text ::= value(IA5String)
+//
+//     Syntax ::=   -- Must be one of the following:
+//                        -- a base type (or its refinement), or
+//                        -- a BITS pseudo-type
+//                   type
+//                 | "BITS" "{" NamedBits "}"
+//
+//     NamedBits ::= NamedBit
+//                 | NamedBits "," NamedBit
+//
+//     NamedBit ::=  identifier "(" number ")" -- number is nonnegative
+//
+// END
+
+/// SNMP TEXTUAL-CONVENTION MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextualConvention {
+    // "DISPLAY-HINT" value(IA5String) | empty
+    pub display_hint: Option<String>,
+    // "STATUS" Status
+    pub status: Status,
+    // "DESCRIPTION" value(IA5String)
+    pub description: String,
+    // "REFERENCE" value(IA5String) | empty
+    pub reference: Option<String>,
+    // "SYNTAX" (
+    //      asn1-type
+    //    | "BITS" "{" identifier "(" number ")" ( "," identifier "(" number ")" ) * "}"
+    // )
+    pub syntax: ASN1Type,
+}
+
+/// Parse a SNMP TEXTUAL-CONVENTION MACRO
+pub fn textual_convention(input: Input<'_>) -> ParserResult<'_, TextualConvention> {
+    preceded(
+        skip_ws_and_comments(tag("TEXTUAL-CONVENTION")),
+        map(
+            cut(tuple((
+                skip_ws_and_comments(opt(preceded(
+                    tag("DISPLAY-HINT"),
+                    cut(character_string_value),
+                ))),
+                skip_ws_and_comments(preceded(tag("STATUS"), cut(status))),
+                skip_ws_and_comments(preceded(tag("DESCRIPTION"), character_string_value)),
+                skip_ws_and_comments(opt(preceded(tag("REFERENCE"), cut(character_string_value)))),
+                skip_ws_and_comments(preceded(tag("SYNTAX"), asn1_type)),
+            ))),
+            |v| TextualConvention {
+                display_hint: v.0,
+                status: v.1,
+                description: v.2,
+                reference: v.3,
+                syntax: v.4,
+            },
+        ),
+    )(input)
+}
+
+// OBJECT-TYPE MACRO ::=
+// BEGIN
+//     TYPE NOTATION ::=
+//                   "SYNTAX" Syntax
+//                   UnitsPart
+//                   "MAX-ACCESS" Access
+//                   "STATUS" Status
+//                   "DESCRIPTION" Text
+//                   ReferPart
+//
+//                   IndexPart
+//                   DefValPart
+//
+//     VALUE NOTATION ::=
+//                   value(VALUE ObjectName)
+//
+//     Syntax ::=   -- Must be one of the following:
+//                        -- a base type (or its refinement),
+//                        -- a textual convention (or its refinement), or
+//                        -- a BITS pseudo-type
+//                    type
+//                 | "BITS" "{" NamedBits "}"
+//
+//     NamedBits ::= NamedBit
+//                 | NamedBits "," NamedBit
+//
+//     NamedBit ::=  identifier "(" number ")" -- number is nonnegative
+//
+//     UnitsPart ::=
+//                   "UNITS" Text
+//                 | empty
+//
+//     Access ::=
+//                   "not-accessible"
+//                 | "accessible-for-notify"
+//                 | "read-only"
+//                 | "read-write"
+//                 | "read-create"
+//
+//     Status ::=
+//                   "current"
+//                 | "deprecated"
+//                 | "obsolete"
+//
+//     ReferPart ::=
+//                   "REFERENCE" Text
+//                 | empty
+//
+//     IndexPart ::=
+//                   "INDEX"    "{" IndexTypes "}"
+//                 | "AUGMENTS" "{" Entry      "}"
+//                 | empty
+//     IndexTypes ::=
+//                   IndexType
+//                 | IndexTypes "," IndexType
+//     IndexType ::=
+//                   "IMPLIED" Index
+//                 | Index
+//
+//     Index ::=
+//                     -- use the SYNTAX value of the
+//                     -- correspondent OBJECT-TYPE invocation
+//                   value(ObjectName)
+//     Entry ::=
+//                     -- use the INDEX value of the
+//                     -- correspondent OBJECT-TYPE invocation
+//                   value(ObjectName)
+//
+//     DefValPart ::= "DEFVAL" "{" Defvalue "}"
+//                 | empty
+//
+//     Defvalue ::=  -- must be valid for the type specified in
+//                   -- SYNTAX clause of same OBJECT-TYPE macro
+//                   value(ObjectSyntax)
+//                 | "{" BitsValue "}"
+//
+//     BitsValue ::= BitNames
+//                 | empty
+//
+//     BitNames ::=  BitName
+//                 | BitNames "," BitName
+//
+//     BitName ::= identifier
+//
+//     -- a character string as defined in section 3.1.1
+//     Text ::= value(IA5String)
+// END
+
+/// SNMP OBJECT-TYPE MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectType<'i> {
+    // "SYNTAX" asn1-type
+    pub syntax: ASN1Type,
+    // "UNITS" value(IA5String) | empty
+    pub units: Option<String>,
+    // "MAX-ACCESS" (
+    //     "not-accessible"
+    //   | "accessible-for-notify"
+    //   | "read-only"
+    //   | "read-write"
+    //   | "read-create"
+    //  )
+    pub max_access: &'i str,
+    // "STATUS" Status
+    pub status: Status,
+    // "DESCRIPTION" value(IA5String)
+    pub description: String,
+    // "REFERENCE" value(IA5String) | empty
+    pub reference: Option<String>,
+    // IndexPart | empty
+    pub index: Option<ObjectTypeIndex<'i>>,
+    // "DEFAL" "{" asn1-value ( "," asn1-value .. ) | empty
+    pub defval: Option<ASN1Value>,
+}
+
+/// Index part inside SNMP OBJECT-TYPE MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub enum ObjectTypeIndex<'i> {
+    // "INDEX" "{" "IMPLIED"? value(ObjectName) ( "," "IMPLIED"? value(ObjectName) )* "}"
+    Index(Vec<(bool, &'i str)>),
+    // "AUGMENTS" value(ObjectName)
+    Augments(&'i str),
+}
+
+/// Parse SNMMP OBJECT-TYPE MACRO
+pub fn object_type(input: Input<'_>) -> ParserResult<'_, ObjectType> {
+    preceded(
+        skip_ws_and_comments(tag(OBJECT_TYPE)),
+        map(
+            tuple((
+                skip_ws_and_comments(preceded(
+                    tag("SYNTAX"),
+                    cut(skip_ws_and_comments(asn1_type)),
+                )),
+                skip_ws_and_comments(opt(preceded(tag("UNITS"), cut(character_string_value)))),
+                skip_ws_and_comments(preceded(
+                    tag("MAX-ACCESS"),
+                    skip_ws_and_comments(value_identifier),
+                )),
+                skip_ws_and_comments(preceded(tag("STATUS"), cut(status))),
+                skip_ws_and_comments(preceded(tag("DESCRIPTION"), character_string_value)),
+                skip_ws_and_comments(opt(preceded(tag("REFERENCE"), cut(character_string_value)))),
+                opt(object_type_index),
+                skip_ws_and_comments(opt(preceded(tag("DEFVAL"), cut(asn1_value)))),
+            )),
+            |v| ObjectType {
+                syntax: v.0,
+                units: v.1,
+                max_access: v.2,
+                status: v.3,
+                description: v.4,
+                reference: v.5,
+                index: v.6,
+                defval: v.7,
+            },
+        ),
+    )(input)
+}
+
+/// Parse index part in SNMMP OBJECT-TYPE MACRO
+pub fn object_type_index(input: Input<'_>) -> ParserResult<'_, ObjectTypeIndex> {
+    alt((
+        preceded(
+            skip_ws_and_comments(tag("INDEX")),
+            map(
+                cut(in_braces(separated_list1(
+                    skip_ws_and_comments(tag(",")),
+                    pair(
+                        skip_ws_and_comments(map(opt(tag("IMPLIED")), |v| v.is_some())),
+                        skip_ws_and_comments(value_identifier),
+                    ),
+                ))),
+                ObjectTypeIndex::Index,
+            ),
+        ),
+        preceded(
+            skip_ws_and_comments(tag("AUGMENTS")),
+            map(
+                cut(in_braces(skip_ws_and_comments(value_identifier))),
+                ObjectTypeIndex::Augments,
+            ),
+        ),
+    ))(input)
+}
+
+// NOTIFICATION-TYPE MACRO ::=
+// BEGIN
+//     TYPE NOTATION ::=
+//                   ObjectsPart
+//                   "STATUS" Status
+//                   "DESCRIPTION" Text
+//                   ReferPart
+//
+//     VALUE NOTATION ::=
+//                   value(VALUE NotificationName)
+//
+//     ObjectsPart ::=
+//                   "OBJECTS" "{" Objects "}"
+//                 | empty
+//     Objects ::=
+//                   Object
+//
+//                 | Objects "," Object
+//     Object ::=
+//                   value(ObjectName)
+//
+//     Status ::=
+//                   "current"
+//                 | "deprecated"
+//                 | "obsolete"
+//
+//     ReferPart ::=
+//                   "REFERENCE" Text
+//                 | empty
+//
+//     -- a character string as defined in section 3.1.1
+//     Text ::= value(IA5String)
+// END
+
+/// SNMP NOTIFICATION-TYPE MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct NotificationType<'i> {
+    // "OBJECTS" "{" value(ObjectName) ( "," value(ObjectName) )* "}" | empty
+    pub objects: Vec<&'i str>,
+    // "STATUS" Status
+    pub status: Status,
+    // "DESCRIPTION" value(IA5String)
+    pub description: String,
+    // "REFERENCE" value(IA5String) | empty
+    pub reference: Option<String>,
+}
+
+/// Parse SNMP NOTIFICATION-TYPE MACRO
+pub fn notification_type(input: Input<'_>) -> ParserResult<'_, NotificationType> {
+    preceded(
+        skip_ws_and_comments(tag(NOTIFICATION_TYPE)),
+        map(
+            tuple((
+                skip_ws_and_comments(opt(preceded(
+                    tag("OBJECTS"),
+                    cut(in_braces(separated_list1(
+                        skip_ws_and_comments(tag(",")),
+                        skip_ws_and_comments(value_identifier),
+                    ))),
+                ))),
+                skip_ws_and_comments(preceded(tag("STATUS"), cut(status))),
+                skip_ws_and_comments(preceded(tag("DESCRIPTION"), character_string_value)),
+                skip_ws_and_comments(opt(preceded(tag("REFERENCE"), cut(character_string_value)))),
+            )),
+            |v| NotificationType {
+                objects: v.0.unwrap_or_default(),
+                status: v.1,
+                description: v.2,
+                reference: v.3,
+            },
+        ),
+    )(input)
+}
+
+// MODULE-COMPLIANCE MACRO ::=
+// BEGIN
+//     TYPE NOTATION ::=
+//                   "STATUS" Status
+//                   "DESCRIPTION" Text
+//                   ReferPart
+//                   ModulePart
+//
+//     VALUE NOTATION ::=
+//                   value(VALUE OBJECT IDENTIFIER)
+//
+//     Status ::=
+//                   "current"
+//                 | "deprecated"
+//                 | "obsolete"
+//
+//     ReferPart ::=
+//                   "REFERENCE" Text
+//                 | empty
+//
+//     ModulePart ::=
+//                   Modules
+//     Modules ::=
+//                   Module
+//                 | Modules Module
+//     Module ::=
+//                   -- name of module --
+//                   "MODULE" ModuleName
+//                   MandatoryPart
+//                   CompliancePart
+//
+//     ModuleName ::=
+//                   -- identifier must start with uppercase letter
+//                   identifier ModuleIdentifier
+//                   -- must not be empty unless contained
+//                   -- in MIB Module
+//                 | empty
+//     ModuleIdentifier ::=
+//                   value(OBJECT IDENTIFIER)
+//                 | empty
+//
+//     MandatoryPart ::=
+//                   "MANDATORY-GROUPS" "{" Groups "}"
+//                 | empty
+//
+//     Groups ::=
+//
+//                   Group
+//                 | Groups "," Group
+//     Group ::=
+//                   value(OBJECT IDENTIFIER)
+//
+//     CompliancePart ::=
+//                   Compliances
+//                 | empty
+//
+//     Compliances ::=
+//                   Compliance
+//                 | Compliances Compliance
+//     Compliance ::=
+//                   ComplianceGroup
+//                 | Object
+//
+//     ComplianceGroup ::=
+//                   "GROUP" value(OBJECT IDENTIFIER)
+//                   "DESCRIPTION" Text
+//
+//     Object ::=
+//                   "OBJECT" value(ObjectName)
+//                   SyntaxPart
+//                   WriteSyntaxPart
+//                   AccessPart
+//                   "DESCRIPTION" Text
+//
+//     -- must be a refinement for object's SYNTAX clause
+//     SyntaxPart ::= "SYNTAX" Syntax
+//                 | empty
+//
+//     -- must be a refinement for object's SYNTAX clause
+//     WriteSyntaxPart ::= "WRITE-SYNTAX" Syntax
+//                 | empty
+//
+//     Syntax ::=    -- Must be one of the following:
+//                        -- a base type (or its refinement),
+//                        -- a textual convention (or its refinement), or
+//                        -- a BITS pseudo-type
+//                   type
+//                 | "BITS" "{" NamedBits "}"
+//
+//     NamedBits ::= NamedBit
+//                 | NamedBits "," NamedBit
+//
+//     NamedBit ::= identifier "(" number ")" -- number is nonnegative
+//
+//     AccessPart ::=
+//                   "MIN-ACCESS" Access
+//                 | empty
+//     Access ::=
+//                   "not-accessible"
+//                 | "accessible-for-notify"
+//                 | "read-only"
+//                 | "read-write"
+//                 | "read-create"
+//
+//     -- a character string as defined in [2]
+//     Text ::= value(IA5String)
+// END
+
+/// SNMP MODULE-COMPLIANCE MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModuleCompliance<'i> {
+    // "STATUS" Status
+    status: Status,
+    // "DESCRIPTION" value(IA5String)
+    description: String,
+    // "REFERENCE" value(IA5String) | empty
+    reference: Option<String>,
+    // "MODULE" ..
+    modules: Vec<ModuleComplianceModule<'i>>,
+}
+
+/// MODULE inside a MODULE-COMPLIANCE MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModuleComplianceModule<'i> {
+    // identifier ( value(OBJECT IDENTIFIER) | empty ) | empty
+    module_name: Option<&'i str>,
+    module_identifier: Option<&'i str>,
+    // "MANDATORY-GROUPS" "{" value(OBJECT IDENTIFIER) "," .. "}" | empty
+    mandatory_groups: Vec<&'i str>,
+    // Compliance .. | empty
+    compliances: Vec<Compliance<'i>>,
+}
+
+/// Compliance part inside SNMP MODULE-COMPLIANCE MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub enum Compliance<'i> {
+    // "GROUP"
+    Group {
+        // value(OBJECT IDENTIFIER)
+        object_identifier: &'i str,
+        // "DESCRIPTION" value(IA5String)
+        description: String,
+    },
+    // "OBJECT"
+    Object {
+        // value(ObjectName)
+        name: &'i str,
+        // "SYNTAX" (
+        //      type
+        //      | "BITS" "{" identifier "(" number ")" ( "," identifier "(" number ")" ) * "}"
+        //   )
+        //   | empty
+        syntax: Option<ASN1Type>,
+        // "WRITE-SYNTAX"
+        //     type
+        //   | "BITS" "{" identifier "(" number ")" ( "," identifier "(" number ")" ) * "}"
+        //   | empty
+        write_syntax: Option<ASN1Type>,
+        // "MIN-ACCESS" identifier | empty
+        min_access: Option<&'i str>,
+        // "DESCRIPTION" value(IA5String)
+        description: String,
+    },
+}
+
+/// Parse SNMP MODULE-COMPLIANCE MACRO
+pub fn module_compliance(input: Input<'_>) -> ParserResult<'_, ModuleCompliance> {
+    preceded(
+        skip_ws_and_comments(tag(MODULE_COMPLIANCE)),
+        map(
+            cut(tuple((
+                preceded(skip_ws_and_comments(tag("STATUS")), cut(status)),
+                preceded(
+                    skip_ws_and_comments(tag("DESCRIPTION")),
+                    character_string_value,
+                ),
+                opt(preceded(
+                    skip_ws_and_comments(tag("REFERENCE")),
+                    cut(character_string_value),
+                )),
+                many1(module_compliance_module),
+            ))),
+            |v| ModuleCompliance {
+                status: v.0,
+                description: v.1,
+                reference: v.2,
+                modules: v.3,
+            },
+        ),
+    )(input)
+}
+
+/// Parse MODULE part in SNMP MODULE-COMPLIANCE MACRO
+pub fn module_compliance_module(input: Input<'_>) -> ParserResult<'_, ModuleComplianceModule> {
+    preceded(
+        skip_ws_and_comments(tag("MODULE")),
+        map(
+            cut(tuple((
+                opt(pair(
+                    skip_ws_and_comments(title_case_identifier),
+                    skip_ws_and_comments(opt(value_identifier)),
+                )),
+                opt(preceded(
+                    skip_ws_and_comments(tag(MANDATORY_GROUPS)),
+                    cut(in_braces(separated_list1(
+                        skip_ws_and_comments(tag(",")),
+                        skip_ws_and_comments(value_identifier),
+                    ))),
+                )),
+                many1(compliance),
+            ))),
+            |v| ModuleComplianceModule {
+                module_name: v.0.as_ref().map(|v0| v0.0),
+                module_identifier: v.0.and_then(|v0| v0.1),
+                mandatory_groups: v.1.unwrap_or_default(),
+                compliances: v.2,
+            },
+        ),
+    )(input)
+}
+
+/// Parse compliance part inside SNMP MODULE-COMPLIANCE MACRO
+pub fn compliance(input: Input<'_>) -> ParserResult<'_, Compliance> {
+    skip_ws_and_comments(alt((
+        preceded(
+            tag("GROUP"),
+            map(
+                cut(pair(
+                    skip_ws_and_comments(value_identifier),
+                    skip_ws_and_comments(preceded(tag("DESCRIPTION"), character_string_value)),
+                )),
+                |v| Compliance::Group {
+                    object_identifier: v.0,
+                    description: v.1,
+                },
+            ),
+        ),
+        preceded(
+            tag("OBJECT"),
+            map(
+                cut(tuple((
+                    skip_ws_and_comments(value_identifier),
+                    opt(preceded(
+                        skip_ws_and_comments(tag("SYNTAX")),
+                        cut(skip_ws_and_comments(asn1_type)),
+                    )),
+                    skip_ws_and_comments(opt(preceded(
+                        tag("WRITE-SYNTAX"),
+                        cut(skip_ws_and_comments(asn1_type)),
+                    ))),
+                    skip_ws_and_comments(opt(preceded(
+                        tag("MIN-ACCESS"),
+                        cut(skip_ws_and_comments(value_identifier)),
+                    ))),
+                    skip_ws_and_comments(preceded(tag("DESCRIPTION"), character_string_value)),
+                ))),
+                |v| Compliance::Object {
+                    name: v.0,
+                    syntax: v.1,
+                    write_syntax: v.2,
+                    min_access: v.3,
+                    description: v.4,
+                },
+            ),
+        ),
+    )))(input)
+}
+
+// OBJECT-GROUP MACRO ::=
+// BEGIN
+//     TYPE NOTATION ::=
+//                   ObjectsPart
+//                   "STATUS" Status
+//                   "DESCRIPTION" Text
+//                   ReferPart
+//
+//     VALUE NOTATION ::=
+//                   value(VALUE OBJECT IDENTIFIER)
+//
+//     ObjectsPart ::=
+//                   "OBJECTS" "{" Objects "}"
+//     Objects ::=
+//                   Object
+//                 | Objects "," Object
+//     Object ::=
+//
+//                   value(ObjectName)
+//
+//     Status ::=
+//                   "current"
+//                 | "deprecated"
+//                 | "obsolete"
+//
+//     ReferPart ::=
+//                   "REFERENCE" Text
+//                 | empty
+//
+//     -- a character string as defined in [2]
+//     Text ::= value(IA5String)
+// END
+
+/// SNMP OBJECT-GROUP MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectGroup<'i> {
+    // "OBJECTS" "{" value(ObjectName) ( "," value(ObjectType) )* "}"
+    objects: Vec<&'i str>,
+    // "STATUS" Status
+    status: Status,
+    // "DESCRIPTION" value(IA5String)
+    description: String,
+    // "REFERENCE" value(IA5String) | empty
+    reference: Option<String>,
+}
+
+/// Parse SNMP OBJECT-GROUP MACRO
+pub fn object_group(input: Input<'_>) -> ParserResult<'_, ObjectGroup> {
+    preceded(
+        skip_ws_and_comments(tag(OBJECT_GROUP)),
+        map(
+            cut(tuple((
+                preceded(
+                    skip_ws_and_comments(tag("OBJECTS")),
+                    in_braces(separated_list1(
+                        skip_ws_and_comments(tag(",")),
+                        skip_ws_and_comments(value_identifier),
+                    )),
+                ),
+                preceded(skip_ws_and_comments(tag("STATUS")), cut(status)),
+                preceded(
+                    skip_ws_and_comments(tag("DESCRIPTION")),
+                    character_string_value,
+                ),
+                opt(preceded(
+                    skip_ws_and_comments(tag("REFERENCE")),
+                    cut(character_string_value),
+                )),
+            ))),
+            |v| ObjectGroup {
+                objects: v.0,
+                status: v.1,
+                description: v.2,
+                reference: v.3,
+            },
+        ),
+    )(input)
+}
+
+// NOTIFICATION-GROUP MACRO ::=
+// BEGIN
+//     TYPE NOTATION ::=
+//                   NotificationsPart
+//                   "STATUS" Status
+//                   "DESCRIPTION" Text
+//                   ReferPart
+//
+//     VALUE NOTATION ::=
+//                   value(VALUE OBJECT IDENTIFIER)
+//
+//     NotificationsPart ::=
+//                   "NOTIFICATIONS" "{" Notifications "}"
+//     Notifications ::=
+//                   Notification
+//                 | Notifications "," Notification
+//     Notification ::=
+//                   value(NotificationName)
+//
+//     Status ::=
+//                   "current"
+//                 | "deprecated"
+//                 | "obsolete"
+//
+//     ReferPart ::=
+//                   "REFERENCE" Text
+//                 | empty
+//
+//     -- a character string as defined in [2]
+//     Text ::= value(IA5String)
+// END
+
+/// SNMP NOTIFICATION_GROUP MACRO
+#[derive(Debug, Clone, PartialEq)]
+pub struct NotificationGroup<'i> {
+    // "NOTIFICATIONS" "{" value(ObjectName) ( "," value(ObjectType) )* "}"
+    notifications: Vec<&'i str>,
+    // "STATUS" Status
+    status: Status,
+    // "DESCRIPTION" value(IA5String)
+    description: String,
+    // "REFERENCE" value(IA5String) | empty
+    reference: Option<String>,
+}
+
+/// Parse SNMP NOTIFICATION_GROUP MACRO
+pub fn notification_group(input: Input<'_>) -> ParserResult<'_, NotificationGroup> {
+    preceded(
+        skip_ws_and_comments(tag(NOTIFICATION_GROUP)),
+        map(
+            cut(tuple((
+                preceded(
+                    skip_ws_and_comments(tag("NOTIFICATIONS")),
+                    in_braces(separated_list1(
+                        skip_ws_and_comments(tag(",")),
+                        skip_ws_and_comments(value_identifier),
+                    )),
+                ),
+                preceded(skip_ws_and_comments(tag("STATUS")), cut(status)),
+                preceded(
+                    skip_ws_and_comments(tag("DESCRIPTION")),
+                    character_string_value,
+                ),
+                opt(preceded(
+                    skip_ws_and_comments(tag("REFERENCE")),
+                    cut(character_string_value),
+                )),
+            ))),
+            |v| NotificationGroup {
+                notifications: v.0,
+                status: v.1,
+                description: v.2,
+                reference: v.3,
+            },
+        ),
+    )(input)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Status {
+    Current,
+    Deprecated,
+    Obsolete,
+}
+
+/// Parse a status: "current" | "deprecated" | "obsolete"
+fn status(input: Input<'_>) -> ParserResult<'_, Status> {
+    skip_ws_and_comments(alt((
+        map(tag("current"), |_| Status::Current),
+        map(tag("deprecated"), |_| Status::Deprecated),
+        map(tag("obsolete"), |_| Status::Obsolete),
+    )))(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intermediate::constraints::{
+        Constraint, ElementOrSetOperation, ElementSet, SetOperation, SetOperator, SubtypeElement,
+    };
+    use crate::intermediate::DeclarationElsewhere;
+
+    #[test]
+    fn parses_module_identity() {
+        let input = Input::from(
+            r#"
+            MODULE-IDENTITY
+                LAST-UPDATED "200006140000Z"
+                ORGANIZATION "IETF Interfaces MIB Working Group"
+                CONTACT-INFO "Keith McCloghrie"
+                DESCRIPTION "The MIB module"
+            "#,
+        );
+
+        let mi = module_identity(input).unwrap().1;
+
+        assert_eq!(
+            mi,
+            ModuleIdentity {
+                last_updated: "200006140000Z".to_string(),
+                organization: "IETF Interfaces MIB Working Group".to_string(),
+                contact_info: "Keith McCloghrie".to_string(),
+                description: "The MIB module".to_string(),
+                revisions: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn parses_textual_convention() {
+        let input = Input::from(
+            r#"
+            TEXTUAL-CONVENTION
+                DISPLAY-HINT "d"
+                STATUS       current
+                DESCRIPTION
+
+                        "A unique value, greater than zero, for each interface or
+                        network management system to the next re-initialization."
+                SYNTAX       Integer32 (1..2147483647)
+            "#,
+        );
+
+        let tc = textual_convention(input).unwrap().1;
+
+        assert_eq!(
+            tc,
+            TextualConvention {
+                display_hint: Some("d".to_string()),
+                status: Status::Current,
+                description: "A unique value, greater than zero, for each interface or
+                        network management system to the next re-initialization."
+                    .to_string(),
+                reference: None,
+                syntax: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                    parent: None,
+                    identifier: "Integer32".to_string(),
+                    constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                        set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                            min: Some(ASN1Value::Integer(1)),
+                            max: Some(ASN1Value::Integer(2147483647)),
+                            extensible: false
+                        }),
+                        extensible: false
+                    })],
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_object_type() {
+        let input = Input::from(
+            r#"
+            OBJECT-TYPE
+                SYNTAX      Integer32
+                MAX-ACCESS  read-only
+                STATUS      current
+                DESCRIPTION
+                        "The number of network interfaces (regardless of their
+                        current state) present on this system."
+            "#,
+        );
+
+        let obj_ty = object_type(input).unwrap().1;
+
+        assert_eq!(
+            obj_ty,
+            ObjectType {
+                syntax: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                    parent: None,
+                    identifier: "Integer32".to_string(),
+                    constraints: vec![],
+                }),
+                units: None,
+                max_access: "read-only",
+                status: Status::Current,
+                description: "The number of network interfaces (regardless of their
+                        current state) present on this system."
+                    .to_string(),
+                reference: None,
+                index: None,
+                defval: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_notification_type() {
+        let input = Input::from(
+            r#"
+            NOTIFICATION-TYPE
+                OBJECTS { ifIndex, ifAdminStatus, ifOperStatus }
+                STATUS  current
+                DESCRIPTION
+                        "A linkDown trap signifies that the SNMP entity, acting in
+                        an agent role, has detected that the ifOperStatus object for
+                        one of its communication links is about to enter the down
+                        state from some other state (but not from the notPresent
+                        state).  This other state is indicated by the included value
+                        of ifOperStatus."
+            "#,
+        );
+
+        let notif_ty = notification_type(input).unwrap().1;
+
+        assert_eq!(
+            notif_ty,
+            NotificationType {
+                objects: vec!["ifIndex", "ifAdminStatus", "ifOperStatus"],
+                status: Status::Current,
+                description: "A linkDown trap signifies that the SNMP entity, acting in
+                        an agent role, has detected that the ifOperStatus object for
+                        one of its communication links is about to enter the down
+                        state from some other state (but not from the notPresent
+                        state).  This other state is indicated by the included value
+                        of ifOperStatus."
+                    .to_string(),
+                reference: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_module_compliance() {
+        let input = Input::from(
+            r#"
+            MODULE-COMPLIANCE
+                STATUS      current
+                DESCRIPTION
+                    "The compliance
+                    ifDescr, ifPhysAddress, implemented."
+
+                MODULE
+                    MANDATORY-GROUPS {
+                        dot1dBaseBridgeGroup,
+                        dot1dBasePortGroup
+                    }
+
+                GROUP   dot1dStpBridgeGroup
+                DESCRIPTION
+                    "Implementation of
+                    Spanning Tree Protocol."
+
+                OBJECT dot1dStpPriority
+                SYNTAX Integer32 (4096
+                            |24576)
+                DESCRIPTION
+                    "values defined IEEE 802.1t."
+            "#,
+        );
+
+        let mc = module_compliance(input).unwrap().1;
+
+        assert_eq!(
+            mc,
+            ModuleCompliance {
+                status: Status::Current,
+                description: "The compliance
+                    ifDescr, ifPhysAddress, implemented."
+                    .to_string(),
+                reference: None,
+                modules: vec![ModuleComplianceModule {
+                    module_name: None,
+                    module_identifier: None,
+                    mandatory_groups: vec!["dot1dBaseBridgeGroup", "dot1dBasePortGroup"],
+                    compliances: vec![
+                        Compliance::Group {
+                            object_identifier: "dot1dStpBridgeGroup",
+                            description:
+                                "Implementation of\n                    Spanning Tree Protocol."
+                                    .to_string(),
+                        },
+                        Compliance::Object {
+                            name: "dot1dStpPriority",
+                            syntax: Some(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                                parent: None,
+                                identifier: "Integer32".to_string(),
+                                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                                    set: ElementOrSetOperation::SetOperation(SetOperation {
+                                        base: SubtypeElement::SingleValue {
+                                            value: ASN1Value::Integer(4096),
+                                            extensible: false,
+                                        },
+                                        operator: SetOperator::Union,
+                                        operant: Box::new(ElementOrSetOperation::Element(
+                                            SubtypeElement::SingleValue {
+                                                value: ASN1Value::Integer(24576),
+                                                extensible: false,
+                                            }
+                                        )),
+                                    }),
+                                    extensible: false,
+                                })],
+                            })),
+                            write_syntax: None,
+                            min_access: None,
+                            description: "values defined IEEE 802.1t.".to_string(),
+                        },
+                    ],
+                }]
+            }
+        );
+    }
+
+    #[test]
+    fn parses_object_group() {
+        let input = Input::from(
+            r#"
+            OBJECT-GROUP
+            OBJECTS { ifIndex, ifPhysAddress,
+                    ifTableLastChange }
+            STATUS  current
+            DESCRIPTION
+                    "A collection of objects providing information applicable to
+                    all network interfaces."
+            "#,
+        );
+
+        let mc = object_group(input).unwrap().1;
+
+        assert_eq!(
+            mc,
+            ObjectGroup {
+                objects: vec!["ifIndex", "ifPhysAddress", "ifTableLastChange"],
+                status: Status::Current,
+                description: "A collection of objects providing information applicable to
+                    all network interfaces."
+                    .to_string(),
+                reference: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_notification_group() {
+        let input = Input::from(
+            r#"
+            NOTIFICATION-GROUP
+                NOTIFICATIONS { linkUp, linkDown }
+                STATUS  current
+                DESCRIPTION
+                        "The notifications which indicate specific changes in the
+                        value of ifOperStatus."
+            "#,
+        );
+
+        let mc = notification_group(input).unwrap().1;
+
+        assert_eq!(
+            mc,
+            NotificationGroup {
+                notifications: vec!["linkUp", "linkDown"],
+                status: Status::Current,
+                description: "The notifications which indicate specific changes in the
+                        value of ifOperStatus."
+                    .to_string(),
+                reference: None,
+            }
+        );
+    }
+}


### PR DESCRIPTION
SNMP MIBs depends on MACROs, but MACROs was deprecated in 1994, replaced by Information Objects, and later removed.

This pull requests adds hard coded support for some of the MACROs used in SNMP MIBs, so that MIBs can be parsed.

The following MACROs are recognized:

- `MODULE-IDENTITY`
- `TEXTUAL-CONVENTION`
- `OBJECT-TYPE`
- `NOTIFICATION-TYPE`
- `MODULE-COMPLIANCE`
- `OBJECT-GROUP`
