### PR TITLE
build: Upgrade nom to version 8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5bcd41dad4e05fbacd367e8965f94606e4be4efd2be0a7d0dc0e368e123722d"
 dependencies = [
  "bitvec",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -100,7 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d988fcc40055ceaa85edc55875a08f8abd29018582647fd82ad6128dba14a5f0"
 dependencies = [
  "bitvec",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -329,6 +329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,7 +450,7 @@ dependencies = [
  "bytes",
  "chrono",
  "either",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -460,7 +469,7 @@ dependencies = [
  "clap",
  "colored",
  "internal_macros",
- "nom",
+ "nom 8.0.0",
  "num",
  "proc-macro2",
  "quote",

--- a/rasn-compiler/Cargo.toml
+++ b/rasn-compiler/Cargo.toml
@@ -33,7 +33,7 @@ cli = ["clap", "colored", "walkdir"]
 chrono = "0.4.41"
 clap = { version = "4.5.38", optional = true, features = ["derive"] }
 colored = { version = "2", optional = true }
-nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
+nom = { version = "8.0", default-features = false, features = ["alloc"] }
 num = { version = "0.4", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/rasn-compiler/src/lexer/bit_string.rs
+++ b/rasn-compiler/src/lexer/bit_string.rs
@@ -5,6 +5,7 @@ use nom::{
     combinator::{map, opt},
     multi::{fold_many0, separated_list0},
     sequence::{delimited, pair, preceded},
+    Parser,
 };
 
 use crate::{input::Input, intermediate::*};
@@ -45,7 +46,8 @@ pub fn bit_string_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
                 ASN1Value::BitStringNamedBits(named_bits.into_iter().map(String::from).collect())
             },
         ),
-    ))(input)
+    ))
+    .parse(input)
 }
 
 /// Tries to parse an ASN1 BIT STRING
@@ -63,7 +65,8 @@ pub fn bit_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             pair(opt(distinguished_values), opt(constraint)),
         ),
         |m| ASN1Type::BitString(m.into()),
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/boolean.rs
+++ b/rasn-compiler/src/lexer/boolean.rs
@@ -3,6 +3,7 @@ use nom::{
     bytes::complete::tag,
     combinator::{into, map, opt, value},
     sequence::preceded,
+    Parser,
 };
 
 use crate::{
@@ -16,7 +17,8 @@ pub fn boolean_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
     alt((
         value(ASN1Value::Boolean(true), skip_ws_and_comments(tag(TRUE))),
         value(ASN1Value::Boolean(false), skip_ws_and_comments(tag(FALSE))),
-    ))(input)
+    ))
+    .parse(input)
 }
 
 /// Tries to parse an ASN1 BOOLEAN
@@ -34,7 +36,8 @@ pub fn boolean(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             skip_ws_and_comments(opt(constraint)),
         ))),
         ASN1Type::Boolean,
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/embedded_pdv.rs
+++ b/rasn-compiler/src/lexer/embedded_pdv.rs
@@ -1,4 +1,4 @@
-use nom::{bytes::complete::tag, combinator::value};
+use nom::{bytes::complete::tag, combinator::value, Parser};
 
 use crate::{input::Input, intermediate::*};
 
@@ -24,5 +24,6 @@ pub fn embedded_pdv(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     value(
         ASN1Type::EmbeddedPdv,
         skip_ws_and_comments(tag(EMBEDDED_PDV)),
-    )(input)
+    )
+    .parse(input)
 }

--- a/rasn-compiler/src/lexer/external.rs
+++ b/rasn-compiler/src/lexer/external.rs
@@ -1,4 +1,4 @@
-use nom::{bytes::complete::tag, combinator::value};
+use nom::{bytes::complete::tag, combinator::value, Parser};
 
 use crate::{input::Input, intermediate::*};
 
@@ -13,5 +13,5 @@ use super::{common::skip_ws_and_comments, error::ParserResult};
 /// and an `ASN1Type::External` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
 pub fn external(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
-    value(ASN1Type::External, skip_ws_and_comments(tag(EXTERNAL)))(input)
+    value(ASN1Type::External, skip_ws_and_comments(tag(EXTERNAL))).parse(input)
 }

--- a/rasn-compiler/src/lexer/integer.rs
+++ b/rasn-compiler/src/lexer/integer.rs
@@ -3,7 +3,7 @@ use nom::{
     bytes::complete::tag,
     character::complete::i128,
     combinator::{map, opt},
-    sequence::tuple,
+    Parser,
 };
 
 use crate::intermediate::{ASN1Type, ASN1Value, INTEGER};
@@ -11,7 +11,7 @@ use crate::intermediate::{ASN1Type, ASN1Value, INTEGER};
 use super::{constraint::*, *};
 
 pub fn integer_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
-    map(skip_ws_and_comments(i128), ASN1Value::Integer)(input)
+    map(skip_ws_and_comments(i128), ASN1Value::Integer).parse(input)
 }
 
 /// Tries to parse an ASN1 INTEGER
@@ -24,13 +24,14 @@ pub fn integer_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
 /// If the match fails, the lexer will not consume the input and will return an error.
 pub fn integer(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
-        tuple((
+        (
             into_inner(skip_ws_and_comments(tag(INTEGER))),
             opt(skip_ws_and_comments(distinguished_values)),
             opt(skip_ws_and_comments(constraint)),
-        )),
+        ),
         |m| ASN1Type::Integer(m.into()),
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/null.rs
+++ b/rasn-compiler/src/lexer/null.rs
@@ -1,4 +1,4 @@
-use nom::{bytes::complete::tag, combinator::value};
+use nom::{bytes::complete::tag, combinator::value, Parser};
 
 use crate::{
     input::Input,
@@ -8,7 +8,7 @@ use crate::{
 use super::{common::skip_ws_and_comments, error::ParserResult};
 
 pub fn null_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
-    value(ASN1Value::Null, skip_ws_and_comments(tag(NULL)))(input)
+    value(ASN1Value::Null, skip_ws_and_comments(tag(NULL))).parse(input)
 }
 
 /// Tries to parse an ASN1 NULL
@@ -20,7 +20,7 @@ pub fn null_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
 /// and an `ASN1Type::Null` value representing the ASN1 declaration.
 /// If the match fails, the lexer will not consume the input and will return an error.
 pub fn null(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
-    value(ASN1Type::Null, skip_ws_and_comments(tag(NULL)))(input)
+    value(ASN1Type::Null, skip_ws_and_comments(tag(NULL))).parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 use nom::{
+    Parser,
     branch::alt,
     bytes::complete::tag,
     character::complete::u128,
@@ -39,7 +40,7 @@ pub fn object_identifier_value(input: Input<'_>) -> ParserResult<'_, ObjectIdent
         // TODO: store info whether the object id is relative
         opt(alt((tag(OBJECT_IDENTIFIER), tag(RELATIVE_OID)))),
         in_braces(many1(skip_ws(object_identifier_arc))),
-    )))(input)
+    ))).parse(input)
 }
 
 pub fn object_identifier(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
@@ -49,7 +50,7 @@ pub fn object_identifier(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             opt(skip_ws_and_comments(constraint)),
         )),
         ASN1Type::ObjectIdentifier,
-    )(input)
+    ).parse(input)
 }
 
 fn object_identifier_arc(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierArc> {
@@ -57,11 +58,11 @@ fn object_identifier_arc(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierA
         numeric_id,
         into(pair(value_identifier, skip_ws(in_parentheses(u128)))),
         into(value_identifier),
-    )))(input)
+    ))).parse(input)
 }
 
 fn numeric_id(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierArc> {
-    map(u128, |i| i.into())(input)
+    map(u128, |i| i.into()).parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/octet_string.rs
+++ b/rasn-compiler/src/lexer/octet_string.rs
@@ -2,6 +2,7 @@ use nom::{
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::preceded,
+    Parser,
 };
 
 use crate::{input::Input, intermediate::*};
@@ -20,7 +21,8 @@ pub fn octet_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         preceded(skip_ws_and_comments(tag(OCTET_STRING)), opt(constraint)),
         |m| ASN1Type::OctetString(m.into()),
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/parameterization.rs
+++ b/rasn-compiler/src/lexer/parameterization.rs
@@ -4,6 +4,7 @@ use nom::{
     combinator::{into, map},
     multi::separated_list1,
     sequence::separated_pair,
+    Parser,
 };
 
 use crate::{
@@ -36,7 +37,8 @@ pub fn parameterization(input: Input<'_>) -> ParserResult<'_, Parameterization> 
             ))),
             into(skip_ws_and_comments(identifier)),
         ))),
-    )))(input)
+    )))
+    .parse(input)
 }
 
 pub fn parameters(input: Input<'_>) -> ParserResult<'_, Vec<Parameter>> {
@@ -50,7 +52,8 @@ pub fn parameters(input: Input<'_>) -> ParserResult<'_, Vec<Parameter>> {
                 Parameter::InformationObjectParameter(o)
             }),
         ))),
-    )))(input)
+    )))
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/sequence_of.rs
+++ b/rasn-compiler/src/lexer/sequence_of.rs
@@ -3,6 +3,7 @@ use nom::{
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::{pair, preceded},
+    Parser,
 };
 
 use super::{
@@ -33,7 +34,8 @@ pub fn sequence_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             ),
         ),
         |m| ASN1Type::SequenceOf(m.into()),
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/set.rs
+++ b/rasn-compiler/src/lexer/set.rs
@@ -3,7 +3,7 @@ use nom::{
     character::complete::char,
     combinator::opt,
     multi::many0,
-    sequence::{terminated, tuple},
+    sequence::{terminated},
 };
 
 use crate::intermediate::*;
@@ -25,7 +25,7 @@ pub fn set(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
         preceded(
             skip_ws_and_comments(tag(SET)),
             pair(
-                in_braces(tuple((
+                in_braces((
                     many0(terminated(
                         skip_ws_and_comments(sequence_component),
                         optional_comma,
@@ -35,12 +35,12 @@ pub fn set(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                         skip_ws_and_comments(sequence_component),
                         optional_comma,
                     ))),
-                ))),
+                )),
                 opt(constraint),
             ),
         ),
         |m| ASN1Type::Set(m.into()),
-    )(input)
+    ).parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/set_of.rs
+++ b/rasn-compiler/src/lexer/set_of.rs
@@ -3,6 +3,7 @@ use nom::{
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::{pair, preceded},
+    Parser,
 };
 
 use super::{
@@ -33,7 +34,8 @@ pub fn set_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             ),
         ),
         |m| ASN1Type::SetOf(m.into()),
-    )(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lexer/time.rs
+++ b/rasn-compiler/src/lexer/time.rs
@@ -4,6 +4,7 @@ use nom::{
     combinator::{map, map_res, opt, recognize},
     multi::many1,
     sequence::{delimited, preceded},
+    Parser,
 };
 
 use crate::{
@@ -24,14 +25,16 @@ use super::{
 pub fn time_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
     map(skip_ws_and_comments(t_string), |t_string| {
         ASN1Value::Time(t_string.to_owned())
-    })(input)
+    })
+    .parse(input)
 }
 
 pub fn time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         skip_ws_and_comments(preceded(tag(TIME), opt(constraint))),
         |t| ASN1Type::Time(t.into()),
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn generalized_time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
@@ -42,7 +45,8 @@ pub fn generalized_time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 constraints: cnst.unwrap_or_default(),
             })
         },
-    )(input)
+    )
+    .parse(input)
 }
 
 pub fn utc_time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
@@ -53,7 +57,8 @@ pub fn utc_time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 constraints: cnst.unwrap_or_default(),
             })
         },
-    )(input)
+    )
+    .parse(input)
 }
 
 const NON_NUMERIC_TIME_CHARS: [char; 17] = [
@@ -81,5 +86,6 @@ fn t_string(input: Input<'_>) -> ParserResult<'_, &str> {
             },
         ),
         char('"'),
-    )(input.clone())
+    )
+    .parse(input)
 }


### PR DESCRIPTION
Most changes are due to these two:

- Instead of writing `combinator(arg)(input)`, we now write `combinator(arg).parse(input)`.
- InputIter, InputTakeAtPosition, InputLength, InputTake and Slice are now merged in the Input trait.

See [nom changelog](https://github.com/rust-bakery/nom/blob/main/CHANGELOG.md#800-2025-01-25) for details.