### PR TITLE
Renames to better follow the naming in the specification

### DIFF
--- a/rasn-compiler-tests/tests/modules/itu-t_x_x1080.1_2011_E-health-identification.asn1
+++ b/rasn-compiler-tests/tests/modules/itu-t_x_x1080.1_2011_E-health-identification.asn1
@@ -12,7 +12,7 @@ IMPORTS
     FROM Telebiometrics {joint-iso-itu-t(2) telebiometrics(42) tmm(1)
       modules(0)      modules(0) main(0) version(0)};
 
-IDENTIFICATION ::= 0db>CLASS {&category        OID UNIQUE,
+IDENTIFICATION ::= CLASS {&category        OID UNIQUE,
                           &Identification
 }WITH SYNTAX {CATEGORY &category
               IDENTIFIED WITH &Identification

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use crate::intermediate::{
     constraints::Constraint,
     information_object::{
-        ASN1Information, ClassLink, InformationObjectClass, InformationObjectFields,
-        ObjectSetValue, ToplevelInformationDefinition,
+        ASN1Information, ClassLink, InformationObjectFields, ObjectClassDefn, ObjectSetValue,
+        ToplevelInformationDefinition,
     },
     ASN1Type, ASN1Value, CharacterStringType, ToplevelDefinition, ToplevelTypeDefinition,
     ToplevelValueDefinition,
@@ -841,7 +841,7 @@ impl Rasn {
             return Ok(TokenStream::new());
         }
         if let ASN1Information::ObjectSet(o) = &tld.value {
-            let class: &InformationObjectClass = match tld.class {
+            let class: &ObjectClassDefn = match tld.class {
                 Some(ClassLink::ByReference(ref c)) => c,
                 _ => {
                     return Err(GeneratorError::new(

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -69,9 +69,9 @@ impl Rasn {
                         top_level_declaration: None,
                     }),
                     ASN1Type::ObjectIdentifier(_) => self.generate_oid(t),
-                    ASN1Type::InformationObjectFieldReference(_)
-                    | ASN1Type::EmbeddedPdv
-                    | ASN1Type::External => self.generate_any(t),
+                    ASN1Type::ObjectClassField(_) | ASN1Type::EmbeddedPdv | ASN1Type::External => {
+                        self.generate_any(t)
+                    }
                     ASN1Type::GeneralizedTime(_) => self.generate_generalized_time(t),
                     ASN1Type::UTCTime(_) => self.generate_utc_time(t),
                     ASN1Type::ChoiceSelectionType(_) => Err(GeneratorError {
@@ -715,7 +715,7 @@ impl Rasn {
                         .concat()
                         .iter()
                         .for_each(|c| {
-                            if let (Constraint::TableConstraint(t), ASN1Type::InformationObjectFieldReference(iofr)) = (c, &m.ty) {
+                            if let (Constraint::TableConstraint(t), ASN1Type::ObjectClassField(iofr)) = (c, &m.ty) {
                                 let decode_fn = format_ident!("decode_{}", self.to_rust_snake_case(&m.name));
                                 let open_field_name = self.to_rust_snake_case(&m.name);
                                 let identifier = t.linked_fields.iter().map(|l|

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -12,7 +12,7 @@ use crate::{
         encoding_rules::per_visible::{
             per_visible_range_constraints, CharsetSubset, PerVisibleAlphabetConstraints,
         },
-        information_object::{InformationObjectClass, InformationObjectField, Optionality},
+        information_object::{InformationObjectField, ObjectClassDefn, Optionality},
         types::{Choice, ChoiceOption, Enumerated, SequenceOrSet, SequenceOrSetMember},
         ASN1Type, ASN1Value, AsnTag, CharacterStringType, IntegerType, TagClass,
         TaggingEnvironment, ToplevelDefinition, ToplevelTypeDefinition,
@@ -1039,7 +1039,7 @@ impl Rasn {
     /// Resolves the custom syntax declared in an information object class' WITH SYNTAX clause
     pub(crate) fn resolve_standard_syntax(
         &self,
-        class: &InformationObjectClass,
+        class: &ObjectClassDefn,
         application: &[InformationObjectField],
     ) -> Result<(ASN1Value, Vec<(usize, ASN1Type)>), GeneratorError> {
         let mut key = None;

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -617,9 +617,9 @@ impl Rasn {
                 };
                 (e.constraints.clone(), tokenized)
             }
-            ASN1Type::InformationObjectFieldReference(_)
-            | ASN1Type::EmbeddedPdv
-            | ASN1Type::External => (vec![], quote!(Any)),
+            ASN1Type::ObjectClassField(_) | ASN1Type::EmbeddedPdv | ASN1Type::External => {
+                (vec![], quote!(Any))
+            }
             ASN1Type::ChoiceSelectionType(_) => unreachable!(),
         })
     }
@@ -742,9 +742,9 @@ impl Rasn {
                 "Set values are currently unsupported!"
             )),
             ASN1Type::ElsewhereDeclaredType(e) => Ok(self.to_rust_title_case(&e.identifier)),
-            ASN1Type::InformationObjectFieldReference(_) => Err(error!(
+            ASN1Type::ObjectClassField(_) => Err(error!(
                 NotYetInplemented,
-                "Information Object field reference values are currently unsupported!"
+                "Object class field types are currently unsupported!"
             )),
             ASN1Type::Time(_) => Err(error!(
                 NotYetInplemented,

--- a/rasn-compiler/src/generator/typescript/mod.rs
+++ b/rasn-compiler/src/generator/typescript/mod.rs
@@ -123,9 +123,9 @@ impl Backend for Typescript {
                     ASN1Type::Choice(_) => self.generate_choice(t),
                     ASN1Type::Time(_) => unimplemented!("rasn does not support TIME types yet!"),
                     ASN1Type::Real(_) => self.generate_number_like(t),
-                    ASN1Type::InformationObjectFieldReference(_)
-                    | ASN1Type::EmbeddedPdv
-                    | ASN1Type::External => self.generate_any(t),
+                    ASN1Type::ObjectClassField(_) | ASN1Type::EmbeddedPdv | ASN1Type::External => {
+                        self.generate_any(t)
+                    }
                     ASN1Type::OctetString(_) => self.generate_octet_string(t),
                     ASN1Type::ObjectIdentifier(_)
                     | ASN1Type::GeneralizedTime(_)

--- a/rasn-compiler/src/intermediate/information_object.rs
+++ b/rasn-compiler/src/intermediate/information_object.rs
@@ -523,14 +523,17 @@ impl From<(ObjectFieldIdentifier, ObjectSet)> for InformationObjectField {
     }
 }
 
+/// #### X.681 14 Notation for the object class field type
+/// _The type that is referenced by this notation depends on the category of the field name. For
+/// the different categories of field names, 14.2 to 14.5 specify the type that is referenced._
 #[derive(Debug, Clone, PartialEq)]
-pub struct InformationObjectFieldReference {
+pub struct ObjectClassFieldType {
     pub class: String,
     pub field_path: Vec<ObjectFieldIdentifier>,
     pub constraints: Vec<Constraint>,
 }
 
-impl InformationObjectFieldReference {
+impl ObjectClassFieldType {
     /// Returns the field path as string.
     /// The field path is stringified by joining
     /// the stringified `ObjectFieldIdentifier`s with
@@ -544,9 +547,7 @@ impl InformationObjectFieldReference {
     }
 }
 
-impl From<(&str, Vec<ObjectFieldIdentifier>, Option<Vec<Constraint>>)>
-    for InformationObjectFieldReference
-{
+impl From<(&str, Vec<ObjectFieldIdentifier>, Option<Vec<Constraint>>)> for ObjectClassFieldType {
     fn from(value: (&str, Vec<ObjectFieldIdentifier>, Option<Vec<Constraint>>)) -> Self {
         Self {
             class: value.0.into(),

--- a/rasn-compiler/src/intermediate/information_object.rs
+++ b/rasn-compiler/src/intermediate/information_object.rs
@@ -9,7 +9,7 @@ pub struct ToplevelInformationDefinition {
     pub parameterization: Option<Parameterization>,
     pub class: Option<ClassLink>,
     pub value: ASN1Information,
-    pub index: Option<(Rc<RefCell<ModuleReference>>, usize)>,
+    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
 }
 
 impl From<(&str, ASN1Information, &str)> for ToplevelInformationDefinition {

--- a/rasn-compiler/src/intermediate/information_object.rs
+++ b/rasn-compiler/src/intermediate/information_object.rs
@@ -30,7 +30,7 @@ impl From<(&str, ASN1Information, &str)> for ToplevelInformationDefinition {
 #[derive(Clone, PartialEq)]
 pub enum ClassLink {
     ByName(String),
-    ByReference(InformationObjectClass),
+    ByReference(ObjectClassDefn),
 }
 
 impl ToplevelInformationDefinition {
@@ -86,22 +86,10 @@ impl From<(Vec<&str>, &str, Option<Parameterization>, &str, ObjectSet)>
     }
 }
 
-impl
-    From<(
-        Vec<&str>,
-        &str,
-        Option<Parameterization>,
-        InformationObjectClass,
-    )> for ToplevelInformationDefinition
+impl From<(Vec<&str>, &str, Option<Parameterization>, ObjectClassDefn)>
+    for ToplevelInformationDefinition
 {
-    fn from(
-        value: (
-            Vec<&str>,
-            &str,
-            Option<Parameterization>,
-            InformationObjectClass,
-        ),
-    ) -> Self {
+    fn from(value: (Vec<&str>, &str, Option<Parameterization>, ObjectClassDefn)) -> Self {
         Self {
             comments: value.0.join("\n"),
             name: value.1.into(),
@@ -118,7 +106,7 @@ impl
 #[cfg_attr(not(test), derive(Debug))]
 #[derive(Clone, PartialEq)]
 pub enum ASN1Information {
-    ObjectClass(InformationObjectClass),
+    ObjectClass(ObjectClassDefn),
     ObjectSet(ObjectSet),
     Object(InformationObject),
 }
@@ -313,9 +301,15 @@ impl InformationObjectSyntax {
     }
 }
 
+/// X.681 9.3  Every class is ultimately defined by an "ObjectClassDefn".
+///
+/// Allows the definer to provide the field specifications, and optionally a syntax list. The
+/// definer may also specify semantics associated with the definition of the class.
 #[derive(Debug, Clone, PartialEq)]
-pub struct InformationObjectClass {
+pub struct ObjectClassDefn {
+    /// Named field specifications, as defined in 9.4.
     pub fields: Vec<InformationObjectClassField>,
+    /// An information object definition syntax ("SyntaxList"), as defined in 10.5.
     pub syntax: Option<InformationObjectSyntax>,
 }
 
@@ -323,7 +317,7 @@ impl
     From<(
         Vec<InformationObjectClassField>,
         Option<Vec<SyntaxExpression>>,
-    )> for InformationObjectClass
+    )> for ObjectClassDefn
 {
     fn from(
         value: (

--- a/rasn-compiler/src/intermediate/macros.rs
+++ b/rasn-compiler/src/intermediate/macros.rs
@@ -1,13 +1,13 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::intermediate::ModuleReference;
+use crate::intermediate::ModuleHeader;
 use crate::lexer::macros::MacroDefinition;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ToplevelMacroDefinition {
     pub name: String,
-    pub index: Option<(Rc<RefCell<ModuleReference>>, usize)>,
+    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
 }
 
 impl From<MacroDefinition<'_>> for ToplevelMacroDefinition {

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -402,7 +402,7 @@ impl From<(ObjectIdentifierValue, Option<&str>)> for DefinitiveIdentifier {
 /// Represents a module header as specified in
 /// Rec. ITU-T X.680 (02/2021) § 13
 #[derive(Debug, Clone, PartialEq)]
-pub struct ModuleReference {
+pub struct ModuleHeader {
     pub name: String,
     pub module_identifier: Option<DefinitiveIdentifier>,
     pub encoding_reference_default: Option<EncodingReferenceDefault>,
@@ -412,7 +412,7 @@ pub struct ModuleReference {
     pub exports: Option<Exports>,
 }
 
-impl ModuleReference {
+impl ModuleHeader {
     /// Returns an import that matches a given identifier, if present.
     pub fn find_import(&self, identifier: &str) -> Option<&String> {
         self.imports
@@ -432,7 +432,7 @@ impl
         )>,
         Option<Exports>,
         Option<Vec<Import>>,
-    )> for ModuleReference
+    )> for ModuleHeader
 {
     fn from(
         value: (
@@ -547,28 +547,24 @@ impl ToplevelDefinition {
         }
     }
 
-    pub(crate) fn set_index(
-        &mut self,
-        module_reference: Rc<RefCell<ModuleReference>>,
-        item_no: usize,
-    ) {
+    pub(crate) fn set_index(&mut self, module_header: Rc<RefCell<ModuleHeader>>, item_no: usize) {
         match self {
             ToplevelDefinition::Type(ref mut t) => {
-                t.index = Some((module_reference, item_no));
+                t.index = Some((module_header, item_no));
             }
             ToplevelDefinition::Value(ref mut v) => {
-                v.index = Some((module_reference, item_no));
+                v.index = Some((module_header, item_no));
             }
             ToplevelDefinition::Information(ref mut i) => {
-                i.index = Some((module_reference, item_no));
+                i.index = Some((module_header, item_no));
             }
             ToplevelDefinition::Macro(ref mut m) => {
-                m.index = Some((module_reference, item_no));
+                m.index = Some((module_header, item_no));
             }
         }
     }
 
-    pub(crate) fn get_index(&self) -> Option<&(Rc<RefCell<ModuleReference>>, usize)> {
+    pub(crate) fn get_index(&self) -> Option<&(Rc<RefCell<ModuleHeader>>, usize)> {
         match self {
             ToplevelDefinition::Type(ref t) => t.index.as_ref(),
             ToplevelDefinition::Value(ref v) => v.index.as_ref(),
@@ -577,7 +573,7 @@ impl ToplevelDefinition {
         }
     }
 
-    pub(crate) fn get_module_reference(&self) -> Option<Rc<RefCell<ModuleReference>>> {
+    pub(crate) fn get_module_header(&self) -> Option<Rc<RefCell<ModuleHeader>>> {
         match self {
             ToplevelDefinition::Type(ref t) => t.index.as_ref().map(|(m, _)| m.clone()),
             ToplevelDefinition::Value(ref v) => v.index.as_ref().map(|(m, _)| m.clone()),
@@ -653,7 +649,7 @@ pub struct ToplevelValueDefinition {
     pub associated_type: ASN1Type,
     pub parameterization: Option<Parameterization>,
     pub value: ASN1Value,
-    pub index: Option<(Rc<RefCell<ModuleReference>>, usize)>,
+    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
 }
 
 impl From<(&str, ASN1Value, ASN1Type)> for ToplevelValueDefinition {
@@ -705,7 +701,7 @@ pub struct ToplevelTypeDefinition {
     pub name: String,
     pub ty: ASN1Type,
     pub parameterization: Option<Parameterization>,
-    pub index: Option<(Rc<RefCell<ModuleReference>>, usize)>,
+    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
 }
 
 impl ToplevelTypeDefinition {

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -20,7 +20,7 @@ use std::{borrow::Cow, cell::RefCell, collections::BTreeMap, ops::Add, rc::Rc};
 use crate::common::INTERNAL_IO_FIELD_REF_TYPE_NAME_PREFIX;
 use constraints::Constraint;
 use error::{GrammarError, GrammarErrorType};
-use information_object::{InformationObjectFieldReference, ToplevelInformationDefinition};
+use information_object::{ObjectClassFieldType, ToplevelInformationDefinition};
 #[cfg(test)]
 use internal_macros::EnumDebug;
 use macros::ToplevelMacroDefinition;
@@ -776,7 +776,7 @@ pub enum ASN1Type {
     ElsewhereDeclaredType(DeclarationElsewhere),
     ChoiceSelectionType(ChoiceSelectionType),
     ObjectIdentifier(ObjectIdentifier),
-    InformationObjectFieldReference(InformationObjectFieldReference),
+    ObjectClassField(ObjectClassFieldType),
     EmbeddedPdv,
     External,
 }
@@ -848,7 +848,7 @@ impl ASN1Type {
             }
             ASN1Type::ChoiceSelectionType(_) => todo!(),
             ASN1Type::ObjectIdentifier(_) => Cow::Borrowed(OBJECT_IDENTIFIER),
-            ASN1Type::InformationObjectFieldReference(ifr) => Cow::Owned(format!(
+            ASN1Type::ObjectClassField(ifr) => Cow::Owned(format!(
                 "{INTERNAL_IO_FIELD_REF_TYPE_NAME_PREFIX}{}${}",
                 ifr.class,
                 ifr.field_path_as_str()
@@ -944,7 +944,7 @@ impl ASN1Type {
             self,
             ASN1Type::ElsewhereDeclaredType(_)
                 | ASN1Type::ChoiceSelectionType(_)
-                | ASN1Type::InformationObjectFieldReference(_)
+                | ASN1Type::ObjectClassField(_)
         )
     }
 
@@ -962,7 +962,7 @@ impl ASN1Type {
             ASN1Type::Set(s) | ASN1Type::Sequence(s) => Some(s.constraints()),
             ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => Some(s.constraints()),
             ASN1Type::ElsewhereDeclaredType(e) => Some(e.constraints()),
-            ASN1Type::InformationObjectFieldReference(f) => Some(f.constraints()),
+            ASN1Type::ObjectClassField(f) => Some(f.constraints()),
             _ => None,
         }
     }
@@ -981,7 +981,7 @@ impl ASN1Type {
             ASN1Type::Set(s) | ASN1Type::Sequence(s) => Some(s.constraints_mut()),
             ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => Some(s.constraints_mut()),
             ASN1Type::ElsewhereDeclaredType(e) => Some(e.constraints_mut()),
-            ASN1Type::InformationObjectFieldReference(f) => Some(f.constraints_mut()),
+            ASN1Type::ObjectClassField(f) => Some(f.constraints_mut()),
             _ => None,
         }
     }

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -59,7 +59,7 @@ constrainable!(SequenceOrSetOf);
 constrainable!(Choice);
 constrainable!(Enumerated);
 constrainable!(DeclarationElsewhere);
-constrainable!(InformationObjectFieldReference);
+constrainable!(ObjectClassFieldType);
 constrainable!(Time);
 
 /// Representation of an ASN1 BOOLEAN data element

--- a/rasn-compiler/src/lexer/bit_string.rs
+++ b/rasn-compiler/src/lexer/bit_string.rs
@@ -39,7 +39,7 @@ pub fn bit_string_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
         map(
             skip_ws_and_comments(delimited(
                 char(LEFT_BRACE),
-                separated_list0(char(','), skip_ws_and_comments(value_identifier)),
+                separated_list0(char(','), skip_ws_and_comments(value_reference)),
                 char(RIGHT_BRACE),
             )),
             |named_bits| {

--- a/rasn-compiler/src/lexer/choice.rs
+++ b/rasn-compiler/src/lexer/choice.rs
@@ -51,7 +51,7 @@ pub fn selection_type_choice(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
         into(separated_pair(
             skip_ws_and_comments(value_reference),
             skip_ws_and_comments(char(LEFT_CHEVRON)),
-            skip_ws_and_comments(title_case_identifier),
+            skip_ws_and_comments(type_reference),
         )),
         ASN1Type::ChoiceSelectionType,
     )

--- a/rasn-compiler/src/lexer/choice.rs
+++ b/rasn-compiler/src/lexer/choice.rs
@@ -49,7 +49,7 @@ pub fn choice_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
 pub fn selection_type_choice(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         into(separated_pair(
-            skip_ws_and_comments(value_identifier),
+            skip_ws_and_comments(value_reference),
             skip_ws_and_comments(char(LEFT_CHEVRON)),
             skip_ws_and_comments(title_case_identifier),
         )),

--- a/rasn-compiler/src/lexer/common.rs
+++ b/rasn-compiler/src/lexer/common.rs
@@ -80,6 +80,23 @@ pub fn identifier(input: Input<'_>) -> ParserResult<'_, &str> {
     .parse(input)
 }
 
+/// Parses a valuereference lexical item.
+///
+/// #### X.680 12.4  Value references
+/// _A "valuereference" shall consist of the sequence of characters specified for an "identifier" in
+/// 12.3. In analyzing an instance of use of this notation, a "valuereference" is distinguished
+/// from an "identifier" by the context in which it appears._
+pub fn value_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
+    into_inner(recognize(pair(
+        one_of("abcdefghijklmnopqrstuvwxyz"),
+        many0(alt((
+            preceded(char('-'), into_inner(alphanumeric1)),
+            into_inner(alphanumeric1),
+        ))),
+    )))
+    .parse(input)
+}
+
 pub fn into_inner<'a, F>(parser: F) -> impl Parser<Input<'a>, Output = &'a str, Error = F::Error>
 where
     F: Parser<Input<'a>, Output = Input<'a>>,
@@ -105,17 +122,6 @@ pub fn title_case_identifier(input: Input<'_>) -> ParserResult<'_, &str> {
         },
     )
     .parse(input.clone())
-}
-
-pub fn value_identifier(input: Input<'_>) -> ParserResult<'_, &str> {
-    into_inner(recognize(pair(
-        one_of("abcdefghijklmnopqrstuvwxyz"),
-        many0(alt((
-            preceded(char('-'), into_inner(alphanumeric1)),
-            into_inner(alphanumeric1),
-        ))),
-    )))
-    .parse(input)
 }
 
 pub fn skip_ws<'a, F>(inner: F) -> impl Parser<Input<'a>, Output = F::Output, Error = F::Error>

--- a/rasn-compiler/src/lexer/common.rs
+++ b/rasn-compiler/src/lexer/common.rs
@@ -58,6 +58,34 @@ pub fn block_comment(input: Input<'_>) -> ParserResult<'_, &str> {
     .parse(input)
 }
 
+/// Parses a typereference lexical item.
+///
+/// #### X.680 12.2  Type references
+/// _A "typereference" shall consist of an arbitrary number (one or more) of letters, digits, and
+/// hyphens. The initial character shall be an upper-case letter. A hyphen shall not be the last
+/// character. A hyphen shall not be immediately followed by another hyphen. NOTE – The rules
+/// concerning hyphen are designed to avoid ambiguity with (possibly following) comment. 12.2.2A
+/// "typereference" shall not be one of the reserved character sequences listed in 12.38._
+pub fn type_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
+    map_res(
+        recognize(pair(
+            one_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+            many0(alt((
+                preceded(char('-'), into_inner(alphanumeric1)),
+                into_inner(alphanumeric1),
+            ))),
+        )),
+        |identifier| {
+            if ASN1_KEYWORDS.contains(&identifier.inner()) {
+                Err(MiscError("Identifier is ASN.1 keyword."))
+            } else {
+                Ok(identifier.into_inner())
+            }
+        },
+    )
+    .parse(input.clone())
+}
+
 /// Parses an ASN1 identifier.
 ///
 /// * `input` [Input]-wrapped string slice reference used as an input for the lexer
@@ -97,31 +125,21 @@ pub fn value_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
     .parse(input)
 }
 
+/// Parses a modulereference lexical item.
+///
+/// #### X.680 12.5 Module references
+/// _A "modulereference" shall consist of the sequence of characters specified for a
+/// "typereference" in 12.2. In analyzing an instance of use of this notation, a "modulereference"
+/// is distinguished from a "typereference" by the context in which it appears._
+pub fn module_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
+    type_reference(input)
+}
+
 pub fn into_inner<'a, F>(parser: F) -> impl Parser<Input<'a>, Output = &'a str, Error = F::Error>
 where
     F: Parser<Input<'a>, Output = Input<'a>>,
 {
     map(parser, Input::into_inner)
-}
-
-pub fn title_case_identifier(input: Input<'_>) -> ParserResult<'_, &str> {
-    map_res(
-        recognize(pair(
-            one_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-            many0(alt((
-                preceded(char('-'), into_inner(alphanumeric1)),
-                into_inner(alphanumeric1),
-            ))),
-        )),
-        |identifier| {
-            if ASN1_KEYWORDS.contains(&identifier.inner()) {
-                Err(MiscError("Identifier is ASN.1 keyword."))
-            } else {
-                Ok(identifier.into_inner())
-            }
-        },
-    )
-    .parse(input.clone())
 }
 
 pub fn skip_ws<'a, F>(inner: F) -> impl Parser<Input<'a>, Output = F::Output, Error = F::Error>

--- a/rasn-compiler/src/lexer/enumerated.rs
+++ b/rasn-compiler/src/lexer/enumerated.rs
@@ -26,10 +26,10 @@ pub fn enumerated_value(input: Input<'_>) -> ParserResult<'_, ToplevelValueDefin
     map(
         (
             skip_ws(many0(comment)),
-            skip_ws(value_identifier),
+            skip_ws(value_reference),
             skip_ws_and_comments(opt(parameterization)),
             skip_ws_and_comments(asn1_type),
-            preceded(assignment, skip_ws_and_comments(value_identifier)),
+            preceded(assignment, skip_ws_and_comments(value_reference)),
         ),
         |(c, n, params, p, e)| ToplevelValueDefinition {
             comments: c.into_iter().fold(String::new(), |mut acc, s| {

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -39,9 +39,9 @@ use super::{
 /// }
 /// WITH SYNTAX {&Type IDENTIFIED BY &id}
 /// ```
-pub fn type_identifier(input: Input<'_>) -> ParserResult<'_, InformationObjectClass> {
+pub fn type_identifier(input: Input<'_>) -> ParserResult<'_, ObjectClassDefn> {
     skip_ws_and_comments(value(
-        InformationObjectClass {
+        ObjectClassDefn {
             fields: vec![
                 InformationObjectClassField {
                     identifier: ObjectFieldIdentifier::SingleValue("id".into()),
@@ -92,7 +92,19 @@ pub fn instance_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     .parse(input)
 }
 
-pub fn information_object_class(input: Input<'_>) -> ParserResult<'_, InformationObjectClass> {
+/// Parses an ObjectClassDefn.
+///
+/// # Syntax
+///
+/// ```text
+/// ObjectClassDefn ::=
+///     CLASS
+///     "{" FieldSpec "," + "}"
+///     WithSyntaxSpec?
+///
+/// WithSyntaxSpec ::= WITH SYNTAX SyntaxList
+/// ```
+pub fn object_class_defn(input: Input<'_>) -> ParserResult<'_, ObjectClassDefn> {
     into(preceded(
         skip_ws_and_comments(tag(CLASS)),
         pair(
@@ -296,15 +308,15 @@ mod tests {
 
     use crate::intermediate::types::*;
 
-    use crate::lexer::information_object_class::{information_object_class, object_set};
+    use crate::lexer::information_object_class::object_set;
     use crate::lexer::top_level_type_declaration;
 
     use super::*;
 
     #[test]
-    fn parses_information_object_class() {
+    fn parses_object_class_defn() {
         assert_eq!(
-            information_object_class(
+            object_class_defn(
                 r#"CLASS
       {&operationCode CHOICE {local INTEGER,
       global OCTET STRING}
@@ -316,7 +328,7 @@ mod tests {
             )
             .unwrap()
             .1,
-            InformationObjectClass {
+            ObjectClassDefn {
                 syntax: None,
                 fields: vec![
                     InformationObjectClassField {
@@ -447,9 +459,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_information_object_class_with_custom_syntax() {
+    fn parses_object_class_defn_with_custom_syntax() {
         assert_eq!(
-            information_object_class(
+            object_class_defn(
                 r#"CLASS{
             &itsaidCtxRef ItsAidCtxRef UNIQUE,
             &ContextInfo OPTIONAL
@@ -459,7 +471,7 @@ mod tests {
             )
             .unwrap()
             .1,
-            InformationObjectClass {
+            ObjectClassDefn {
                 fields: vec![
                     InformationObjectClassField {
                         identifier: ObjectFieldIdentifier::SingleValue("&itsaidCtxRef".into()),
@@ -495,10 +507,10 @@ mod tests {
     }
 
     #[test]
-    fn parses_information_object_with_custom_syntax() {
+    fn parses_object_class_defn_with_custom_syntax_2() {
         println!(
             "{:?}",
-            information_object_class(
+            object_class_defn(
                 r#"CLASS {&id    BilateralDomain UNIQUE,
             &Type
 }WITH SYNTAX {&Type,
@@ -535,7 +547,7 @@ mod tests {
     fn tld_test() {
         println!(
             "{:?}",
-            super::information_object_class(
+            super::object_class_defn(
                 r#"CLASS {
                     &InitiatingMessage				,
                     &SuccessfulOutcome							OPTIONAL,

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -118,9 +118,17 @@ pub fn object_class_defn(input: Input<'_>) -> ParserResult<'_, ObjectClassDefn> 
     .parse(input)
 }
 
-pub fn information_object_field_reference(
-    input: Input<'_>,
-) -> ParserResult<'_, InformationObjectFieldReference> {
+/// Parses an ObjectClassFieldType.
+///
+/// # Syntax
+///
+/// ```text
+/// ObjectClassFieldType ::=
+///     DefinedObjectClass
+///     "."
+///     FieldName
+/// ```
+pub fn object_class_field_type(input: Input<'_>) -> ParserResult<'_, ObjectClassFieldType> {
     into((
         skip_ws_and_comments(uppercase_identifier),
         many1(skip_ws_and_comments(preceded(
@@ -532,7 +540,7 @@ mod tests {
                 comments: "".into(),
                 tag: None,
                 name: "AttributeValue".into(),
-                ty: ASN1Type::InformationObjectFieldReference(InformationObjectFieldReference {
+                ty: ASN1Type::ObjectClassField(ObjectClassFieldType {
                     class: "OPEN".into(),
                     field_path: vec![ObjectFieldIdentifier::MultipleValue("&Type".into())],
                     constraints: vec![]

--- a/rasn-compiler/src/lexer/macros.rs
+++ b/rasn-compiler/src/lexer/macros.rs
@@ -12,7 +12,7 @@ use crate::intermediate::{
     GREATER_THAN, LESS_THAN, MACRO, PIPE,
 };
 use crate::lexer::common::{
-    in_parentheses, skip_ws_and_comments, title_case_identifier, uppercase_identifier,
+    in_parentheses, module_reference, skip_ws_and_comments, type_reference, uppercase_identifier,
     value_reference,
 };
 use crate::lexer::error::{MiscError, ParserResult};
@@ -188,7 +188,7 @@ fn supporting_productions(input: Input<'_>) -> ParserResult<'_, Vec<Production>>
 /// ```
 fn external_macro_reference(input: Input<'_>) -> ParserResult<'_, (&'_ str, &'_ str)> {
     separated_pair(
-        title_case_identifier,
+        module_reference,
         skip_ws_and_comments(char(DOT)),
         skip_ws_and_comments(macro_reference),
     )
@@ -502,8 +502,12 @@ fn macro_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
 }
 
 /// Parse a production reference.
+///
+/// #### X.680 1994 J.2.2 Productionreference
+/// _A "productionreference" shall consist of the sequence of characters specified for a
+/// "typereference" in 9.2._
 fn production_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
-    map_res(title_case_identifier, |v| {
+    map_res(type_reference, |v| {
         if ADDITIONAL_KEYWORDS.contains(&v) {
             Err(MiscError(
                 "Production reference can not be a keyword when used in ASN.1 MACRO.",
@@ -516,8 +520,13 @@ fn production_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
 }
 
 /// Parse a local type reference.
+///
+/// #### X.680 1994 J.2.3 Localtypereference
+/// _A "localtypereference" shall consist of the sequence of characters specified for a
+/// "typereference" in 9.2. A "localtypereference" is used as an identifier for types which are
+/// recognized during syntax analysis of an instance of the new type or value notation._
 fn local_type_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
-    map_res(title_case_identifier, |v| {
+    map_res(type_reference, |v| {
         if ADDITIONAL_KEYWORDS.contains(&v) {
             Err(MiscError(
                 "Type reference can not be a keyword when used in ASN.1 MACRO.",

--- a/rasn-compiler/src/lexer/macros.rs
+++ b/rasn-compiler/src/lexer/macros.rs
@@ -13,7 +13,7 @@ use crate::intermediate::{
 };
 use crate::lexer::common::{
     in_parentheses, skip_ws_and_comments, title_case_identifier, uppercase_identifier,
-    value_identifier,
+    value_reference,
 };
 use crate::lexer::error::{MiscError, ParserResult};
 use crate::lexer::{asn1_type, asn1_value};
@@ -531,7 +531,7 @@ fn local_type_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
 
 /// Parse a local value reference
 fn local_value_reference(input: Input<'_>) -> ParserResult<'_, &'_ str> {
-    map_res(value_identifier, |v| {
+    map_res(value_reference, |v| {
         if ADDITIONAL_KEYWORDS.contains(&v) {
             Err(MiscError(
                 "Value reference can not be a keyword when used in ASN.1 MACRO.",

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -29,8 +29,8 @@ use crate::{
 use self::{
     bit_string::*, boolean::*, character_string::*, choice::*, common::*, constraint::*,
     embedded_pdv::*, enumerated::*, error::LexerError, external::*, information_object_class::*,
-    integer::*, module_reference::*, null::*, object_identifier::*, octet_string::*,
-    parameterization::*, real::*, sequence::*, sequence_of::*, set::*, set_of::*, time::*,
+    integer::*, null::*, object_identifier::*, octet_string::*, parameterization::*, real::*,
+    sequence::*, sequence_of::*, set::*, set_of::*, time::*,
 };
 
 mod bit_string;
@@ -46,7 +46,7 @@ mod external;
 mod information_object_class;
 mod integer;
 pub(crate) mod macros;
-mod module_reference;
+mod module_header;
 mod null;
 mod object_identifier;
 mod octet_string;
@@ -62,9 +62,7 @@ mod util;
 #[cfg(test)]
 mod tests;
 
-pub fn asn_spec(
-    input: &str,
-) -> Result<Vec<(ModuleReference, Vec<ToplevelDefinition>)>, LexerError> {
+pub fn asn_spec(input: &str) -> Result<Vec<(ModuleHeader, Vec<ToplevelDefinition>)>, LexerError> {
     let mut result = Vec::new();
     let mut remaining_input = Input::from(input);
     loop {
@@ -88,9 +86,9 @@ pub fn asn_spec(
 
 pub(crate) fn asn_module(
     input: Input<'_>,
-) -> ParserResult<'_, (ModuleReference, Vec<ToplevelDefinition>)> {
+) -> ParserResult<'_, (ModuleHeader, Vec<ToplevelDefinition>)> {
     pair(
-        module_reference,
+        module_header::module_header,
         terminated(
             many0(skip_ws(alt((
                 map(
@@ -291,7 +289,7 @@ fn eof_comments() {
     println!(
         "{:#?}",
         pair(
-            module_reference,
+            module_header::module_header,
             terminated(
                 many0(skip_ws(alt((
                     map(

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -203,7 +203,7 @@ pub fn elsewhere_declared_value(input: Input<'_>) -> ParserResult<'_, ASN1Value>
                 identifier,
                 tag(".&"),
             ))))),
-            value_identifier,
+            value_reference,
         ),
         |(p, id)| ASN1Value::ElsewhereDeclaredValue {
             parent: p.map(|par| par.inner().to_string()),
@@ -234,7 +234,7 @@ fn top_level_value_declaration(input: Input<'_>) -> ParserResult<'_, ToplevelVal
     alt((
         into((
             skip_ws(many0(comment)),
-            skip_ws(context_boundary(value_identifier)),
+            skip_ws(context_boundary(value_reference)),
             skip_ws_and_comments(opt(parameterization)),
             skip_ws_and_comments(asn1_type),
             preceded(assignment, skip_ws_and_comments(asn1_value)),

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -171,9 +171,7 @@ pub fn asn1_type(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             time,
             octet_string,
             character_string,
-            map(information_object_field_reference, |i| {
-                ASN1Type::InformationObjectFieldReference(i)
-            }),
+            map(object_class_field_type, |i| ASN1Type::ObjectClassField(i)),
             elsewhere_declared_type,
         )),
     ))

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -127,7 +127,7 @@ fn end(input: Input<'_>) -> ParserResult<'_, &str> {
 pub fn top_level_type_declaration(input: Input<'_>) -> ParserResult<'_, ToplevelTypeDefinition> {
     into((
         skip_ws(many0(comment)),
-        skip_ws(title_case_identifier),
+        skip_ws(type_reference),
         opt(parameterization),
         preceded(assignment, pair(opt(asn_tag), asn1_type)),
     ))
@@ -220,7 +220,7 @@ pub fn elsewhere_declared_type(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 identifier,
                 tag(".&"),
             ))))),
-            skip_ws_and_comments(title_case_identifier),
+            skip_ws_and_comments(type_reference),
             opt(skip_ws_and_comments(constraint)),
         ),
         |(parent, id, constraints)| {

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -281,7 +281,7 @@ fn top_level_object_class_declaration(
         skip_ws(many0(comment)),
         skip_ws(context_boundary(uppercase_identifier)),
         skip_ws(opt(parameterization)),
-        preceded(assignment, alt((type_identifier, information_object_class))),
+        preceded(assignment, alt((type_identifier, object_class_defn))),
     ))
     .parse(input)
 }

--- a/rasn-compiler/src/lexer/module_header.rs
+++ b/rasn-compiler/src/lexer/module_header.rs
@@ -13,7 +13,7 @@ use nom::{
 };
 
 use super::{
-    common::{identifier, skip_ws, skip_ws_and_comments, value_identifier},
+    common::{identifier, skip_ws, skip_ws_and_comments, value_reference},
     error::ParserResult,
     in_braces, into_inner,
     object_identifier::object_identifier_value,
@@ -91,7 +91,7 @@ fn global_module_reference(input: Input<'_>) -> ParserResult<'_, GlobalModuleRef
                 AssignedIdentifier::ObjectIdentifierValue,
             ),
             map(
-                skip_ws_and_comments(separated_pair(identifier, char(DOT), value_identifier)),
+                skip_ws_and_comments(separated_pair(identifier, char(DOT), value_reference)),
                 |(mod_ref, val_ref)| {
                     AssignedIdentifier::ExternalValueReference(ExternalValueReference {
                         module_reference: mod_ref.to_owned(),
@@ -101,7 +101,7 @@ fn global_module_reference(input: Input<'_>) -> ParserResult<'_, GlobalModuleRef
             ),
             map(
                 skip_ws_and_comments(pair(
-                    value_identifier,
+                    value_reference,
                     skip_ws(recognize(in_braces(take_until("}")))),
                 )),
                 |(v, p)| AssignedIdentifier::ParameterizedValue {
@@ -111,7 +111,7 @@ fn global_module_reference(input: Input<'_>) -> ParserResult<'_, GlobalModuleRef
             ),
             map(
                 skip_ws_and_comments(terminated(
-                    value_identifier,
+                    value_reference,
                     not(skip_ws_and_comments(alt((
                         peek(value((), tag(FROM))),
                         peek(value((), char(COMMA))),

--- a/rasn-compiler/src/lexer/module_header.rs
+++ b/rasn-compiler/src/lexer/module_header.rs
@@ -19,7 +19,7 @@ use super::{
     object_identifier::object_identifier_value,
 };
 
-pub fn module_reference(input: Input<'_>) -> ParserResult<'_, ModuleReference> {
+pub fn module_header(input: Input<'_>) -> ParserResult<'_, ModuleHeader> {
     skip_ws_and_comments(into((
         identifier,
         opt(skip_ws(definitive_identification)),
@@ -192,11 +192,11 @@ fn environments(
 mod tests {
     use std::vec;
 
-    use crate::lexer::module_reference::*;
+    use crate::lexer::module_header::*;
 
     #[test]
-    fn parses_a_module_reference() {
-        assert_eq!(module_reference(r#"--! @options: no-fields-header
+    fn parses_a_module_header() {
+        assert_eq!(module_header(r#"--! @options: no-fields-header
 
     ETSI-ITS-CDD {itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) 102894 cdd (2) major-version-3 (3) minor-version-1 (1)}
 
@@ -204,13 +204,13 @@ mod tests {
 
     BEGIN
     "#.into()).unwrap().1,
-    ModuleReference {name:"ETSI-ITS-CDD".into(),module_identifier:Some(DefinitiveIdentifier::DefinitiveOID(ObjectIdentifierValue(vec![ObjectIdentifierArc{name:Some("itu-t".into()),number:Some(0)},ObjectIdentifierArc{name:Some("identified-organization".into()),number:Some(4)},ObjectIdentifierArc{name:Some("etsi".into()),number:Some(0)},ObjectIdentifierArc{name:Some("itsDomain".into()),number:Some(5)},ObjectIdentifierArc{name:Some("wg1".into()),number:Some(1)},ObjectIdentifierArc{name:None,number:Some(102894)},ObjectIdentifierArc{name:Some("cdd".into()),number:Some(2)},ObjectIdentifierArc{name:Some("major-version-3".into()),number:Some(3)},ObjectIdentifierArc{name:Some("minor-version-1".into()),number:Some(1)}]))),encoding_reference_default:None,tagging_environment:crate::intermediate::TaggingEnvironment::Automatic,extensibility_environment:crate::intermediate::ExtensibilityEnvironment::Explicit, imports: vec![], exports: None }
+    ModuleHeader {name:"ETSI-ITS-CDD".into(),module_identifier:Some(DefinitiveIdentifier::DefinitiveOID(ObjectIdentifierValue(vec![ObjectIdentifierArc{name:Some("itu-t".into()),number:Some(0)},ObjectIdentifierArc{name:Some("identified-organization".into()),number:Some(4)},ObjectIdentifierArc{name:Some("etsi".into()),number:Some(0)},ObjectIdentifierArc{name:Some("itsDomain".into()),number:Some(5)},ObjectIdentifierArc{name:Some("wg1".into()),number:Some(1)},ObjectIdentifierArc{name:None,number:Some(102894)},ObjectIdentifierArc{name:Some("cdd".into()),number:Some(2)},ObjectIdentifierArc{name:Some("major-version-3".into()),number:Some(3)},ObjectIdentifierArc{name:Some("minor-version-1".into()),number:Some(1)}]))),encoding_reference_default:None,tagging_environment:crate::intermediate::TaggingEnvironment::Automatic,extensibility_environment:crate::intermediate::ExtensibilityEnvironment::Explicit, imports: vec![], exports: None }
   )
     }
 
     #[test]
-    fn parses_a_module_reference_with_imports() {
-        assert_eq!(module_reference(r#"CPM-PDU-Descriptions { itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts (103324) cpm (1) major-version-1 (1) minor-version-1(1)}
+    fn parses_a_module_header_with_imports() {
+        assert_eq!(module_header(r#"CPM-PDU-Descriptions { itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts (103324) cpm (1) major-version-1 (1) minor-version-1(1)}
 
         DEFINITIONS AUTOMATIC TAGS ::=
 
@@ -226,12 +226,12 @@ mod tests {
         FROM CPM-OriginatingStationContainers {itu-t (0) identified-organization (4) etsi (0) itsDomain (5) wg1 (1) ts (103324) originatingStationContainers (2) major-version-1 (1) minor-version-1(1)}
         WITH SUCCESSORS;
     "#.into()).unwrap().1,
-    ModuleReference { name: "CPM-PDU-Descriptions".into(), module_identifier: Some(DefinitiveIdentifier::DefinitiveOID(ObjectIdentifierValue(vec![ObjectIdentifierArc { name: Some("itu-t".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("identified-organization".into()), number: Some(4) }, ObjectIdentifierArc { name: Some("etsi".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("itsDomain".into()), number: Some(5) }, ObjectIdentifierArc { name: Some("wg1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("ts".into()), number: Some(103324) }, ObjectIdentifierArc { name: Some("cpm".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("major-version-1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("minor-version-1".into()), number: Some(1) }]))), encoding_reference_default: None, tagging_environment: TaggingEnvironment::Automatic, extensibility_environment: ExtensibilityEnvironment::Explicit, imports: vec![Import { types: vec!["ItsPduHeader".into(), "MessageRateHz".into(), "MessageSegmentationInfo".into(), "OrdinalNumber1B".into(), "ReferencePosition".into(), "StationType".into(), "TimestampIts".into()], global_module_reference: GlobalModuleReference { module_reference: "ETSI-ITS-CDD".into(), assigned_identifier: AssignedIdentifier::ObjectIdentifierValue(ObjectIdentifierValue(vec![ObjectIdentifierArc { name: Some("itu-t".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("identified-organization".into()), number: Some(4) }, ObjectIdentifierArc { name: Some("etsi".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("itsDomain".into()), number: Some(5) }, ObjectIdentifierArc { name: Some("wg1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("ts".into()), number: Some(102894) }, ObjectIdentifierArc { name: Some("cdd".into()), number: Some(2) }, ObjectIdentifierArc { name: Some("major-version-3".into()), number: Some(3) }, ObjectIdentifierArc { name: Some("minor-version-1".into()), number: Some(1) }]))}, with: Some(With::Successors) }, Import { types: vec!["OriginatingRsuContainer".into(), "OriginatingVehicleContainer".into()], global_module_reference: GlobalModuleReference { module_reference: "CPM-OriginatingStationContainers".into(), assigned_identifier: AssignedIdentifier::ObjectIdentifierValue(ObjectIdentifierValue(vec![ObjectIdentifierArc { name: Some("itu-t".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("identified-organization".into()), number: Some(4) }, ObjectIdentifierArc { name: Some("etsi".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("itsDomain".into()), number: Some(5) }, ObjectIdentifierArc { name: Some("wg1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("ts".into()), number: Some(103324) }, ObjectIdentifierArc { name: Some("originatingStationContainers".into()), number: Some(2) }, ObjectIdentifierArc { name: Some("major-version-1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("minor-version-1".into()), number: Some(1) }]))}, with: Some(With::Successors) }], exports: None } )
+    ModuleHeader { name: "CPM-PDU-Descriptions".into(), module_identifier: Some(DefinitiveIdentifier::DefinitiveOID(ObjectIdentifierValue(vec![ObjectIdentifierArc { name: Some("itu-t".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("identified-organization".into()), number: Some(4) }, ObjectIdentifierArc { name: Some("etsi".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("itsDomain".into()), number: Some(5) }, ObjectIdentifierArc { name: Some("wg1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("ts".into()), number: Some(103324) }, ObjectIdentifierArc { name: Some("cpm".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("major-version-1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("minor-version-1".into()), number: Some(1) }]))), encoding_reference_default: None, tagging_environment: TaggingEnvironment::Automatic, extensibility_environment: ExtensibilityEnvironment::Explicit, imports: vec![Import { types: vec!["ItsPduHeader".into(), "MessageRateHz".into(), "MessageSegmentationInfo".into(), "OrdinalNumber1B".into(), "ReferencePosition".into(), "StationType".into(), "TimestampIts".into()], global_module_reference: GlobalModuleReference { module_reference: "ETSI-ITS-CDD".into(), assigned_identifier: AssignedIdentifier::ObjectIdentifierValue(ObjectIdentifierValue(vec![ObjectIdentifierArc { name: Some("itu-t".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("identified-organization".into()), number: Some(4) }, ObjectIdentifierArc { name: Some("etsi".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("itsDomain".into()), number: Some(5) }, ObjectIdentifierArc { name: Some("wg1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("ts".into()), number: Some(102894) }, ObjectIdentifierArc { name: Some("cdd".into()), number: Some(2) }, ObjectIdentifierArc { name: Some("major-version-3".into()), number: Some(3) }, ObjectIdentifierArc { name: Some("minor-version-1".into()), number: Some(1) }]))}, with: Some(With::Successors) }, Import { types: vec!["OriginatingRsuContainer".into(), "OriginatingVehicleContainer".into()], global_module_reference: GlobalModuleReference { module_reference: "CPM-OriginatingStationContainers".into(), assigned_identifier: AssignedIdentifier::ObjectIdentifierValue(ObjectIdentifierValue(vec![ObjectIdentifierArc { name: Some("itu-t".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("identified-organization".into()), number: Some(4) }, ObjectIdentifierArc { name: Some("etsi".into()), number: Some(0) }, ObjectIdentifierArc { name: Some("itsDomain".into()), number: Some(5) }, ObjectIdentifierArc { name: Some("wg1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("ts".into()), number: Some(103324) }, ObjectIdentifierArc { name: Some("originatingStationContainers".into()), number: Some(2) }, ObjectIdentifierArc { name: Some("major-version-1".into()), number: Some(1) }, ObjectIdentifierArc { name: Some("minor-version-1".into()), number: Some(1) }]))}, with: Some(With::Successors) }], exports: None } )
     }
 
     #[test]
     fn parses_iri_value() {
-        assert_eq!(module_reference(r#"CMSCKMKeyManagement {itu-t recommendation(0) x(24) cms-profile(894) module(0) cKMKeyManagement(1) version1(1)}
+        assert_eq!(module_header(r#"CMSCKMKeyManagement {itu-t recommendation(0) x(24) cms-profile(894) module(0) cKMKeyManagement(1) version1(1)}
         "/ITU-T/Recommendation/X/CMS-Profile/Module/CKMKeyManagement/Version1"
         DEFINITIONS ::=
         BEGIN
@@ -241,7 +241,7 @@ mod tests {
         FROM AlgorithmInformation-2009
         {iso(1) identified-organization(3) dod(6) internet(1) security(5)
         mechanisms(5) pkix(7) id-mod(0) id-mod-algorithmInformation-02(58)} WITH DESCENDANTS;"#.into()).unwrap().1,
-        ModuleReference {
+        ModuleHeader {
             name: "CMSCKMKeyManagement".into(),
             module_identifier: Some(DefinitiveIdentifier::DefinitiveOIDandIRI {
                 oid: ObjectIdentifierValue(vec![

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -18,7 +18,7 @@ use nom::{
 };
 
 use super::{
-    common::{in_braces, in_parentheses, skip_ws, skip_ws_and_comments, value_identifier},
+    common::{in_braces, in_parentheses, skip_ws, skip_ws_and_comments, value_reference},
     constraint::constraint,
     error::ParserResult,
     RELATIVE_OID,
@@ -56,8 +56,8 @@ pub fn object_identifier(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
 fn object_identifier_arc(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierArc> {
     skip_ws(alt((
         numeric_id,
-        into(pair(value_identifier, skip_ws(in_parentheses(u128)))),
-        into(value_identifier),
+        into(pair(value_reference, skip_ws(in_parentheses(u128)))),
+        into(value_reference),
     ))).parse(input)
 }
 

--- a/rasn-compiler/src/lexer/parameterization.rs
+++ b/rasn-compiler/src/lexer/parameterization.rs
@@ -17,7 +17,7 @@ use super::{
     common::{identifier, in_braces, skip_ws_and_comments},
     error::ParserResult,
     information_object_class::{information_object, object_set},
-    value_identifier,
+    value_reference,
 };
 
 pub fn parameterization(input: Input<'_>) -> ParserResult<'_, Parameterization> {
@@ -27,9 +27,9 @@ pub fn parameterization(input: Input<'_>) -> ParserResult<'_, Parameterization> 
             into(separated_pair(
                 asn1_type,
                 skip_ws_and_comments(char(COLON)),
-                skip_ws_and_comments(value_identifier),
+                skip_ws_and_comments(value_reference),
             )),
-            into(skip_ws_and_comments(value_identifier)),
+            into(skip_ws_and_comments(value_reference)),
             into(skip_ws_and_comments(separated_pair(
                 identifier,
                 skip_ws_and_comments(char(COLON)),

--- a/rasn-compiler/src/lexer/sequence.rs
+++ b/rasn-compiler/src/lexer/sequence.rs
@@ -18,7 +18,7 @@ pub fn sequence_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
         in_braces(separated_list0(
             skip_ws_and_comments(char(',')),
             skip_ws_and_comments(alt((
-                pair(opt(value_identifier), skip_ws_and_comments(asn1_value)),
+                pair(opt(value_reference), skip_ws_and_comments(asn1_value)),
                 map(skip_ws_and_comments(asn1_value), |v| (None, v)),
             ))),
         )),

--- a/rasn-compiler/src/lexer/sequence.rs
+++ b/rasn-compiler/src/lexer/sequence.rs
@@ -116,7 +116,7 @@ pub fn sequence_component(input: Input<'_>) -> ParserResult<'_, SequenceComponen
                 tag(COMPONENTS_OF),
                 skip_ws_and_comments(alt((
                     into_inner(recognize(separated_list1(tag(".&"), identifier))),
-                    title_case_identifier,
+                    type_reference,
                 ))),
             ),
             |id| SequenceComponent::ComponentsOf(id.into()),

--- a/rasn-compiler/src/lexer/sequence_of.rs
+++ b/rasn-compiler/src/lexer/sequence_of.rs
@@ -8,7 +8,7 @@ use nom::{
 
 use super::{
     asn1_type,
-    common::{asn_tag, opt_parentheses, skip_ws_and_comments, value_identifier},
+    common::{asn_tag, opt_parentheses, skip_ws_and_comments, value_reference},
     constraint::constraint,
     error::ParserResult,
 };
@@ -29,7 +29,7 @@ pub fn sequence_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 opt(opt_parentheses(constraint)),
             ),
             preceded(
-                skip_ws_and_comments(pair(tag(OF), opt(skip_ws_and_comments(value_identifier)))),
+                skip_ws_and_comments(pair(tag(OF), opt(skip_ws_and_comments(value_reference)))),
                 skip_ws_and_comments(pair(opt(asn_tag), skip_ws_and_comments(asn1_type))),
             ),
         ),

--- a/rasn-compiler/src/lexer/set_of.rs
+++ b/rasn-compiler/src/lexer/set_of.rs
@@ -8,7 +8,7 @@ use nom::{
 
 use super::{
     asn1_type,
-    common::{asn_tag, opt_parentheses, skip_ws_and_comments, value_identifier},
+    common::{asn_tag, opt_parentheses, skip_ws_and_comments, value_reference},
     constraint::constraint,
     error::ParserResult,
 };
@@ -29,7 +29,7 @@ pub fn set_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 opt(opt_parentheses(constraint)),
             ),
             preceded(
-                skip_ws_and_comments(pair(tag(OF), opt(skip_ws_and_comments(value_identifier)))),
+                skip_ws_and_comments(pair(tag(OF), opt(skip_ws_and_comments(value_reference)))),
                 skip_ws_and_comments(pair(opt(asn_tag), skip_ws_and_comments(asn1_type))),
             ),
         ),

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -432,19 +432,17 @@ fn parses_parameterized_declaration() {
                         is_recursive: false,
                         name: "regionId".into(),
                         tag: None,
-                        ty: ASN1Type::InformationObjectFieldReference(
-                            InformationObjectFieldReference {
-                                class: "REG-EXT-ID-AND-TYPE".into(),
-                                field_path: vec![ObjectFieldIdentifier::SingleValue("&id".into())],
-                                constraints: vec![Constraint::TableConstraint(TableConstraint {
-                                    object_set: ObjectSet {
-                                        values: vec![ObjectSetValue::Reference("Set".into())],
-                                        extensible: None
-                                    },
-                                    linked_fields: vec![]
-                                })]
-                            }
-                        ),
+                        ty: ASN1Type::ObjectClassField(ObjectClassFieldType {
+                            class: "REG-EXT-ID-AND-TYPE".into(),
+                            field_path: vec![ObjectFieldIdentifier::SingleValue("&id".into())],
+                            constraints: vec![Constraint::TableConstraint(TableConstraint {
+                                object_set: ObjectSet {
+                                    values: vec![ObjectSetValue::Reference("Set".into())],
+                                    extensible: None
+                                },
+                                linked_fields: vec![]
+                            })]
+                        }),
                         default_value: None,
                         is_optional: false,
                         constraints: vec![]
@@ -453,24 +451,20 @@ fn parses_parameterized_declaration() {
                         is_recursive: false,
                         name: "regExtValue".into(),
                         tag: None,
-                        ty: ASN1Type::InformationObjectFieldReference(
-                            InformationObjectFieldReference {
-                                class: "REG-EXT-ID-AND-TYPE".into(),
-                                field_path: vec![ObjectFieldIdentifier::MultipleValue(
-                                    "&Type".into()
-                                )],
-                                constraints: vec![Constraint::TableConstraint(TableConstraint {
-                                    object_set: ObjectSet {
-                                        values: vec![ObjectSetValue::Reference("Set".into())],
-                                        extensible: None
-                                    },
-                                    linked_fields: vec![RelationalConstraint {
-                                        field_name: "regionId".into(),
-                                        level: 0
-                                    }]
-                                })]
-                            }
-                        ),
+                        ty: ASN1Type::ObjectClassField(ObjectClassFieldType {
+                            class: "REG-EXT-ID-AND-TYPE".into(),
+                            field_path: vec![ObjectFieldIdentifier::MultipleValue("&Type".into())],
+                            constraints: vec![Constraint::TableConstraint(TableConstraint {
+                                object_set: ObjectSet {
+                                    values: vec![ObjectSetValue::Reference("Set".into())],
+                                    extensible: None
+                                },
+                                linked_fields: vec![RelationalConstraint {
+                                    field_name: "regionId".into(),
+                                    level: 0
+                                }]
+                            })]
+                        }),
                         default_value: None,
                         is_optional: false,
                         constraints: vec![]

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -371,7 +371,7 @@ fn parses_class_declaration() {
             class: None,
             index: None,
             parameterization: None,
-            value: ASN1Information::ObjectClass(InformationObjectClass {
+            value: ASN1Information::ObjectClass(ObjectClassDefn {
                 fields: vec![
                     InformationObjectClassField {
                         identifier: ObjectFieldIdentifier::SingleValue("&id".into()),

--- a/rasn-compiler/src/validator/linking/information_object.rs
+++ b/rasn-compiler/src/validator/linking/information_object.rs
@@ -66,7 +66,7 @@ impl ToplevelInformationDefinition {
 
 fn resolve_and_link(
     fields: &mut InformationObjectFields,
-    class: &InformationObjectClass,
+    class: &ObjectClassDefn,
     tlds: &BTreeMap<String, ToplevelDefinition>,
 ) -> Result<Option<ToplevelInformationDefinition>, GrammarError> {
     match resolve_custom_syntax(fields, class) {
@@ -94,7 +94,7 @@ fn resolve_and_link(
 
 fn link_object_fields(
     fields: &mut InformationObjectFields,
-    class: &InformationObjectClass,
+    class: &ObjectClassDefn,
     tlds: &BTreeMap<String, ToplevelDefinition>,
 ) -> Result<(), GrammarError> {
     match fields {
@@ -177,7 +177,7 @@ impl SyntaxApplication {
     }
 }
 
-impl InformationObjectClass {
+impl ObjectClassDefn {
     pub fn get_field<'a>(
         &'a self,
         path: &'a Vec<ObjectFieldIdentifier>,

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -104,7 +104,7 @@ impl ToplevelDefinition {
         None
     }
 
-    pub fn is_class_with_name(&self, name: &String) -> Option<&InformationObjectClass> {
+    pub fn is_class_with_name(&self, name: &String) -> Option<&ObjectClassDefn> {
         match self {
             ToplevelDefinition::Information(info) => match &info.value {
                 ASN1Information::ObjectClass(class) => (&info.name == name).then_some(class),

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -447,14 +447,14 @@ impl ASN1Type {
                     }
                 }
             }
-            ASN1Type::InformationObjectFieldReference(iofr) => {
+            ASN1Type::ObjectClassField(ocf) => {
                 if let Some(ToplevelDefinition::Information(ToplevelInformationDefinition {
                     value: ASN1Information::ObjectClass(clazz),
                     ..
-                })) = tlds.get(&iofr.class)
+                })) = tlds.get(&ocf.class)
                 {
                     if let Some(InformationObjectClassField { ty: Some(ty), .. }) =
-                        clazz.get_field(&iofr.field_path)
+                        clazz.get_field(&ocf.field_path)
                     {
                         self_replacement = Some(ty.clone());
                     }
@@ -640,9 +640,7 @@ impl ASN1Type {
                 LinkerError,
                 "Choice selection types should be resolved by now"
             )),
-            ASN1Type::InformationObjectFieldReference(_information_object_field_reference) => {
-                Ok(Vec::new())
-            } // TODO
+            ASN1Type::ObjectClassField(_object_class_field_type) => Ok(Vec::new()), // TODO
             n => Ok(vec![n.as_str()]),
         }
     }
@@ -732,13 +730,13 @@ impl ASN1Type {
                     ))
                 }
             }
-            ASN1Type::InformationObjectFieldReference(iofr) => {
+            ASN1Type::ObjectClassField(ocf) => {
                 if let Some(ToplevelDefinition::Information(ToplevelInformationDefinition {
                     value: ASN1Information::ObjectClass(c),
                     ..
-                })) = tlds.get(&iofr.class)
+                })) = tlds.get(&ocf.class)
                 {
-                    if let Some(field) = c.get_field(&iofr.field_path) {
+                    if let Some(field) = c.get_field(&ocf.field_path) {
                         if let Some(ref ty) = field.ty {
                             *self = ty.clone();
                         }
@@ -748,8 +746,8 @@ impl ASN1Type {
                 Err(grammar_error!(
                     LinkerError,
                     "Failed to resolve argument {}.{} of parameterized implementation.",
-                    iofr.class,
-                    iofr.field_path
+                    ocf.class,
+                    ocf.field_path
                         .iter()
                         .map(|f| f.identifier().clone())
                         .collect::<Vec<_>>()
@@ -807,9 +805,9 @@ impl ASN1Type {
             ASN1Type::Choice(c) => c.options.iter().any(|o| o.ty.references_class_by_name()),
             ASN1Type::Sequence(s) => s.members.iter().any(|m| m.ty.references_class_by_name()),
             ASN1Type::SequenceOf(so) => so.element_type.references_class_by_name(),
-            ASN1Type::InformationObjectFieldReference(io_ref) => {
+            ASN1Type::ObjectClassField(ocf) => {
                 matches!(
-                    io_ref.field_path.last(),
+                    ocf.field_path.last(),
                     Some(ObjectFieldIdentifier::SingleValue(_))
                 )
             }
@@ -848,18 +846,18 @@ impl ASN1Type {
                     })
                     .collect(),
             }),
-            ASN1Type::InformationObjectFieldReference(_) => self.reassign_type_for_ref(tlds),
+            ASN1Type::ObjectClassField(_) => self.reassign_type_for_ref(tlds),
             _ => self,
         }
     }
 
     fn reassign_type_for_ref(mut self, tlds: &BTreeMap<String, ToplevelDefinition>) -> Self {
-        if let Self::InformationObjectFieldReference(ref ior) = self {
+        if let Self::ObjectClassField(ref ocf) = self {
             if let Some(t) = tlds
                 .iter()
                 .find_map(|(_, c)| {
-                    c.is_class_with_name(&ior.class)
-                        .map(|clazz| clazz.get_field(&ior.field_path))
+                    c.is_class_with_name(&ocf.class)
+                        .map(|clazz| clazz.get_field(&ocf.field_path))
                 })
                 .flatten()
                 .and_then(|class_field| class_field.ty.clone())

--- a/rasn-compiler/src/validator/linking/utils.rs
+++ b/rasn-compiler/src/validator/linking/utils.rs
@@ -89,7 +89,7 @@ pub(crate) fn walk_object_field_ref_path<'a>(
 /// Resolves the custom syntax declared in an information object class' WITH SYNTAX clause
 pub fn resolve_custom_syntax(
     fields: &mut InformationObjectFields,
-    class: &InformationObjectClass,
+    class: &ObjectClassDefn,
 ) -> Result<(), GrammarError> {
     if let InformationObjectFields::CustomSyntax(application) = fields {
         let tokens = match &class.syntax {

--- a/rasn-compiler/src/validator/mod.rs
+++ b/rasn-compiler/src/validator/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 use self::{
     error::{LinkerError, LinkerErrorType},
     information_object::{
-        ASN1Information, InformationObjectClass, InformationObjectClassField, ObjectSet,
+        ASN1Information, InformationObjectClassField, ObjectClassDefn, ObjectSet,
     },
 };
 
@@ -297,7 +297,7 @@ impl Validator {
         })) = &field.ty
         {
             if let Some(ToplevelDefinition::Information(ToplevelInformationDefinition {
-                value: ASN1Information::ObjectClass(InformationObjectClass { fields, .. }),
+                value: ASN1Information::ObjectClass(ObjectClassDefn { fields, .. }),
                 ..
             })) = self.tlds.get(class_id)
             {

--- a/rasn-compiler/src/validator/mod.rs
+++ b/rasn-compiler/src/validator/mod.rs
@@ -162,7 +162,7 @@ impl Validator {
             if self
                 .tlds
                 .get(&key)
-                .and_then(ToplevelDefinition::get_module_reference)
+                .and_then(ToplevelDefinition::get_module_header)
                 .is_some_and(|m| visited_headers.contains(&m.borrow().name).not())
             {
                 self.fill_in_associated_type_imports(key, &mut visited_headers);
@@ -179,7 +179,7 @@ impl Validator {
     ) {
         let tld = self.tlds.remove(&key).unwrap();
         {
-            let mod_ref = tld.get_module_reference().unwrap();
+            let module_header = tld.get_module_header().unwrap();
 
             let mut associated_type_imports = Vec::new();
             if let ToplevelDefinition::Information(ToplevelInformationDefinition {
@@ -190,12 +190,12 @@ impl Validator {
                 for field in &class_ref.fields {
                     self.associated_import_type_class_field(
                         field,
-                        mod_ref.clone(),
+                        module_header.clone(),
                         &mut associated_type_imports,
                     );
                 }
             }
-            for import_modules in &mod_ref.borrow().imports {
+            for import_modules in &module_header.borrow().imports {
                 for import in &import_modules.types {
                     if import.starts_with(|c: char| c.is_lowercase()) {
                         match self.tlds.get(import) {
@@ -208,7 +208,7 @@ impl Validator {
                                 for field in &class_ref.fields {
                                     self.associated_import_type_class_field(
                                         field,
-                                        mod_ref.clone(),
+                                        module_header.clone(),
                                         &mut associated_type_imports,
                                     );
                                 }
@@ -219,7 +219,7 @@ impl Validator {
                             })) => {
                                 self.associated_import_type(
                                     associated_type.as_str().as_ref(),
-                                    mod_ref.clone(),
+                                    module_header.clone(),
                                     &mut associated_type_imports,
                                 );
                             }
@@ -229,8 +229,8 @@ impl Validator {
                 }
             }
             for mut import in associated_type_imports {
-                let mut mut_mod_ref = mod_ref.borrow_mut();
-                if let Some(mod_imports) = mut_mod_ref
+                let mut mut_module_header = module_header.borrow_mut();
+                if let Some(mod_imports) = mut_module_header
                     .imports
                     .iter_mut()
                     .find(|i| i.global_module_reference == import.global_module_reference)
@@ -239,11 +239,11 @@ impl Validator {
                         mod_imports.types.push(std::mem::take(&mut import.types[0]));
                     }
                 } else {
-                    mut_mod_ref.imports.push(import);
+                    mut_module_header.imports.push(import);
                 }
             }
 
-            visited_headers.insert(mod_ref.borrow().name.clone());
+            visited_headers.insert(module_header.borrow().name.clone());
         }
         self.tlds.insert(key, tld);
     }
@@ -251,26 +251,26 @@ impl Validator {
     fn associated_import_type(
         &self,
         associated_type: &str,
-        mod_ref: Rc<RefCell<ModuleReference>>,
+        module_header: Rc<RefCell<ModuleHeader>>,
         associated_type_imports: &mut Vec<Import>,
     ) {
         if let Some(ToplevelDefinition::Type(ToplevelTypeDefinition {
             name,
             parameterization,
-            index: Some((m_ref, _)),
+            index: Some((m_hdr, _)),
             ..
         })) = self.tlds.get(associated_type)
         {
             let v_type_name = format!("{}{}", name, parameterization.as_ref().map_or("", |_| "{}"));
-            let v_type_mod_name = &m_ref.borrow().name;
-            if v_type_mod_name != &mod_ref.borrow().name
-                && mod_ref.borrow().find_import(&v_type_name).is_none()
+            let v_type_mod_name = &m_hdr.borrow().name;
+            if v_type_mod_name != &module_header.borrow().name
+                && module_header.borrow().find_import(&v_type_name).is_none()
             {
                 associated_type_imports.push(Import {
                     types: vec![v_type_name],
                     global_module_reference: GlobalModuleReference {
-                        module_reference: m_ref.borrow().name.clone(),
-                        assigned_identifier: match &m_ref.borrow().module_identifier {
+                        module_reference: m_hdr.borrow().name.clone(),
+                        assigned_identifier: match &m_hdr.borrow().module_identifier {
                             Some(DefinitiveIdentifier::DefinitiveOID(oid))
                             | Some(DefinitiveIdentifier::DefinitiveOIDandIRI { oid, .. }) => {
                                 AssignedIdentifier::ObjectIdentifierValue(oid.clone())
@@ -287,7 +287,7 @@ impl Validator {
     fn associated_import_type_class_field(
         &self,
         field: &InformationObjectClassField,
-        mod_ref: Rc<RefCell<ModuleReference>>,
+        module_header: Rc<RefCell<ModuleHeader>>,
         associated_type_imports: &mut Vec<Import>,
     ) {
         if let Some(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
@@ -307,7 +307,7 @@ impl Validator {
                 {
                     self.associated_import_type_class_field(
                         field,
-                        mod_ref,
+                        module_header,
                         associated_type_imports,
                     );
                 }
@@ -317,7 +317,7 @@ impl Validator {
             ..
         })) = &field.ty
         {
-            self.associated_import_type(identifier, mod_ref, associated_type_imports)
+            self.associated_import_type(identifier, module_header, associated_type_imports)
         }
     }
 


### PR DESCRIPTION
Renames to better follow the naming in the specification.

- Rename `InformationObjectClass` to `ObjectClassDefn`.
- Rename `ModuleReference` to `ModuleHeader`. To not collide with actual module references.
- Rename `InformationObjectFieldReference` to `ObjectClassFieldType`.
- Rename `value_identifier` parser to `value_reference`.
- Rename `title_case_identifier` parser to `type_reference`.
- Add `module_reference` parser.

And also fixes an error in `itu-t_x_x1080.1_2011_E-health-identification.asn1`.