### PR TITLE
Do not specify crate-type for rasn-compiler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
             toolchain: stable
 
-      - name: Build
+      - name: Build lib
         uses: actions-rs/cargo@v1
         with:
           command: build
@@ -39,11 +39,12 @@ jobs:
             toolchain: stable
             target: wasm32-unknown-unknown
 
-      - name: Build
+      - name: Build WASM
         uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --target wasm32-unknown-unknown
+          command: rustc
+          target: wasm32-unknown-unknown
+          args: --manifest-path=rasn-compiler/Cargo.toml --crate-type=cdylib
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/rasn-compiler/Cargo.toml
+++ b/rasn-compiler/Cargo.toml
@@ -19,7 +19,6 @@ maintenance = { status = "actively-developed" }
 [lib]
 name = "rasn_compiler"
 path = "src/lib.rs"
-crate-type = ["cdylib", "lib"]
 
 [[bin]]
 required-features = ["cli"]


### PR DESCRIPTION
Try to fix issue #131. The problem with file name collisions:

```text
warning: output filename collision.
The lib target `rasn_compiler` in package `rasn-compiler v0.11.0 (/home/matte/projects/rasn-compiler/rasn-compiler)` has
 the same output filename as the lib target `rasn_compiler` in package `rasn-compiler v0.11.0 (/home/matte/projects/rasn
-compiler/rasn-compiler)`.
Colliding filename is: /home/matte/projects/rasn-compiler/target/debug/deps/librasn_compiler.so
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```

WASM can still be built with:

```sh
cargo rustc --manifest-path=rasn-compiler/Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown
```

A possible alternative is to move wasm to a new workspace crate, with crate-type = cdylib.