### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,6 @@ dependencies = [
  "bitvec",
  "bitvec-nom",
  "bytes",
- "lazy_static",
  "num-bigint",
  "rasn",
  "rasn-compiler",

--- a/rasn-compiler-tests/Cargo.toml
+++ b/rasn-compiler-tests/Cargo.toml
@@ -23,4 +23,3 @@ bitvec-nom = { version = "0.2" }
 rasn-kerberos = "0.26"
 bytes = "1.10.0"
 num-bigint = "0.4.6"
-lazy_static = "1.5.0"

--- a/rasn-compiler-tests/src/helpers/mod.rs
+++ b/rasn-compiler-tests/src/helpers/mod.rs
@@ -19,7 +19,7 @@ macro_rules! e2e_pdu {
                     .unwrap()
                     .generated
                     .replace(|c: char| c.is_whitespace(), "")
-                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused,clippy::too_many_arguments)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;uselazy_static::lazy_static;userasn::prelude::*;", ""),
+                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused,clippy::too_many_arguments)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;userasn::prelude::*;usestd::sync::LazyLock;", ""),
                 format!("{}}}", $expected)
                     .to_string()
                     .replace(|c: char| c.is_whitespace(), ""),
@@ -37,7 +37,7 @@ macro_rules! e2e_pdu {
                     .unwrap()
                     .generated
                     .replace(|c: char| c.is_whitespace(), "")
-                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused,clippy::too_many_arguments)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;uselazy_static::lazy_static;userasn::prelude::*;", ""),
+                    .replace("#[allow(non_camel_case_types,non_snake_case,non_upper_case_globals,unused,clippy::too_many_arguments)]pubmodtest_module{externcratealloc;usecore::borrow::Borrow;userasn::prelude::*;usestd::sync::LazyLock;", ""),
                 format!("{}}}", $expected)
                     .to_string()
                     .replace(|c: char| c.is_whitespace(), ""),

--- a/rasn-compiler-tests/tests/information_objects.rs
+++ b/rasn-compiler-tests/tests/information_objects.rs
@@ -173,14 +173,14 @@ e2e_pdu!(
             }
         }
     }
-    lazy_static! {
-        pub static ref ASN_VAL_SECURITY_FAILURE: ErrorCode = ErrorCode::local(Integer::from(1));
-    }
-    lazy_static! {
-        pub static ref ASN_VAL_UNKNOWN_BRANCH: ErrorCode = ErrorCode::local(Integer::from(2));
-    }
-    lazy_static! {
-        pub static ref ASN_VAL_UNKNOWN_ORDER: ErrorCode = ErrorCode::local(Integer::from(3));
-    }
+    pub static ASN_VAL_SECURITY_FAILURE: LazyLock<ErrorCode> = LazyLock::new(||
+        ErrorCode::local(Integer::from(1))
+    );
+    pub static ASN_VAL_UNKNOWN_BRANCH: LazyLock<ErrorCode> = LazyLock::new(||
+        ErrorCode::local(Integer::from(2))
+    );
+    pub static ASN_VAL_UNKNOWN_ORDER: LazyLock<ErrorCode> = LazyLock::new(||
+        ErrorCode::local(Integer::from(3))
+    );
           "#
 );

--- a/rasn-compiler-tests/tests/nested_types.rs
+++ b/rasn-compiler-tests/tests/nested_types.rs
@@ -76,12 +76,12 @@ e2e_pdu!(
         #[rasn(delegate, identifier = "Wrapping-Int", value("0..=123"))]
         pub struct WrappingInt(pub TestInt);
 
-        lazy_static! {
-            pub static ref VALUE: TestSequence = TestSequence::new(
+        pub static VALUE: LazyLock<TestSequence> = LazyLock::new(|| {
+            TestSequence::new(
                 WrappingInt(TestInt(5)),
                 WrappingBoolean(TestBoolean(true))
-            );
-        }                                                                        "#
+            )
+        });                                                                        "#
 );
 
 e2e_pdu!(

--- a/rasn-compiler-tests/tests/simple_types.rs
+++ b/rasn-compiler-tests/tests/simple_types.rs
@@ -26,7 +26,7 @@ e2e_pdu!(
 e2e_pdu!(
     integer_value,
     "test-int INTEGER ::= 4",
-    r#" lazy_static! { pub static ref TEST_INT: Integer = Integer::from(4); }                           "#
+    r#" pub static TEST_INT: LazyLock<Integer> = LazyLock::new(|| Integer::from(4));                           "#
 );
 
 e2e_pdu!(
@@ -38,7 +38,7 @@ e2e_pdu!(
 e2e_pdu!(
     integer_value_large_constrained,
     "test-int INTEGER(0..MAX) ::= 4",
-    r#"lazy_static! { pub static ref TEST_INT: Integer = Integer::from(4); }"#
+    r#"pub static TEST_INT: LazyLock<Integer> = LazyLock::new(|| Integer::from(4));"#
 );
 
 e2e_pdu!(
@@ -60,9 +60,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Int")]
         pub struct TestInt(pub Integer);
-        lazy_static!{
-            pub static ref TEST_INT_VAL: TestInt = TestInt(Integer::from(4));
-        }                                                                            "#
+        pub static TEST_INT_VAL: LazyLock<TestInt> = LazyLock::new(||
+            TestInt(Integer::from(4))
+        );                                                                            "#
 );
 
 e2e_pdu!(
@@ -88,9 +88,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Int", value("4", extensible))]
         pub struct TestInt(pub Integer);
-        lazy_static!{
-            pub static ref TEST_INT_VAL: TestInt = TestInt(Integer::from(4));
-        }                                                                            "#
+        pub static TEST_INT_VAL: LazyLock<TestInt> = LazyLock::new(||
+            TestInt(Integer::from(4))
+        );                                                                            "#
 );
 
 e2e_pdu!(
@@ -110,9 +110,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Int", value("4..=6", extensible))]
         pub struct TestInt(pub Integer);
-        lazy_static!{
-            pub static ref TEST_INT_VAL: TestInt = TestInt(Integer::from(5));
-        }                                                                            "#
+        pub static TEST_INT_VAL: LazyLock<TestInt> = LazyLock::new(||
+            TestInt(Integer::from(5))
+        );                                                                            "#
 );
 
 e2e_pdu!(
@@ -136,23 +136,23 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Bits")]
         pub struct TestBits(pub BitString);
-        lazy_static!{
-            pub static ref TEST_BITS_VAL: TestBits = TestBits(
-                [true,false,true,false,true,false,true,false].into_iter().collect()
-            );
-        }                                                       "#
+        pub static TEST_BITS_VAL: LazyLock<TestBits> = LazyLock::new(|| {
+            TestBits(
+                [true,false,true,false,true,false,true,false].into_iter().collect(),
+            )
+        });                                                       "#
 );
 
 e2e_pdu!(
     bit_string_value,
     "test-bits BIT STRING ::= '1010'B",
-    r#" lazy_static! { pub static ref TEST_BITS: BitString = [true,false,true,false].into_iter().collect(); }                           "#
+    r#" pub static TEST_BITS: LazyLock<BitString> = LazyLock::new(|| [true,false,true,false].into_iter().collect());                           "#
 );
 
 e2e_pdu!(
     bit_string_value_hex,
     "test-bits BIT STRING ::= 'FF'H",
-    r#" lazy_static! { pub static ref TEST_BITS: BitString = [true,true,true,true,true,true,true,true].into_iter().collect(); }                           "#
+    r#" pub static TEST_BITS: LazyLock<BitString> = LazyLock::new(|| { [true,true,true,true,true,true,true,true].into_iter().collect() });                           "#
 );
 
 e2e_pdu!(
@@ -189,11 +189,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Bits", size("4..=6"))]
         pub struct TestBits(pub BitString);
-        lazy_static!{
-            pub static ref TEST_BITS_VAL: TestBits = TestBits(
+        pub static TEST_BITS_VAL: LazyLock<TestBits> = LazyLock::new(||
+            TestBits(
                 [true,false,true,false,true].into_iter().collect()
-            );
-        }                                                                   "#
+            )
+        );                                                                   "#
 );
 
 e2e_pdu!(
@@ -203,11 +203,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Bits", size("4..=6", extensible))]
         pub struct TestBits(pub BitString);
-        lazy_static!{
-            pub static ref TEST_BITS_VAL: TestBits = TestBits(
-                [true,true,false,true,false,true,false,true].into_iter().collect()
-            );
-        }                                                                          "#
+        pub static TEST_BITS_VAL: LazyLock<TestBits> = LazyLock::new(|| {
+            TestBits(
+                [true,true,false,true,false,true,false,true].into_iter().collect(),
+            )
+        });                                                                          "#
 );
 
 e2e_pdu!(
@@ -217,23 +217,23 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Octets")]
         pub struct TestOctets(pub OctetString);
-        lazy_static!{
-            pub static ref TEST_OCTETS_VAL: TestOctets = TestOctets(
+        pub static TEST_OCTETS_VAL: LazyLock<TestOctets> = LazyLock::new(||
+            TestOctets(
                 <OctetStringasFrom<&'static[u8]>>::from(&[170])
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
     octet_string_value,
     "test-bytes OCTET STRING ::= 'FF'H",
-    r#" lazy_static! { pub static ref TEST_BYTES: OctetString = <OctetString as From<&'static[u8]>>::from(&[255]); }                           "#
+    r#" pub static TEST_BYTES: LazyLock<OctetString> = LazyLock::new(|| <OctetString as From<&'static[u8]>>::from(&[255]));                           "#
 );
 
 e2e_pdu!(
     octet_string_value_binary,
     "test-bytes OCTET STRING ::= '11111111'B",
-    r#" lazy_static! { pub static ref TEST_BYTES: OctetString = <OctetString as From<&'static[u8]>>::from(&[255]); }                           "#
+    r#"pub static TEST_BYTES: LazyLock<OctetString> = LazyLock::new(|| <OctetString as From<&'static[u8]>>::from(&[255]));                           "#
 );
 
 e2e_pdu!(
@@ -259,11 +259,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Octets", size("4..=6"))]
         pub struct TestOctets(pub OctetString);
-        lazy_static!{
-            pub static ref TEST_OCTETS_VAL: TestOctets = TestOctets(
-                <OctetString as From<&'static[u8]>>::from(&[255, 1, 2, 1, 255])
-            );
-        }                                                                       "#
+        pub static TEST_OCTETS_VAL: LazyLock<TestOctets> = LazyLock::new(|| {
+            TestOctets(
+                <OctetString as From<&'static[u8]>>::from(&[255, 1, 2, 1, 255,])
+            )
+        });                                                                       "#
 );
 
 e2e_pdu!(
@@ -273,11 +273,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-Octets", size("4..=6", extensible))]
         pub struct TestOctets(pub OctetString);
-        lazy_static!{
-            pub static ref TEST_OCTETS_VAL: TestOctets = TestOctets(
-                <OctetString as From<&'static[u8]>>::from(&[255, 1, 2, 1, 255, 46, 221, 96])
-            );
-        }                                                                       "#
+        pub static TEST_OCTETS_VAL: LazyLock<TestOctets> = LazyLock::new(|| {
+            TestOctets(
+                <OctetString as From<&'static[u8]>>::from(&[255, 1, 2, 1, 255, 46, 221, 96,])
+            )
+        });                                                                       "#
 );
 
 e2e_pdu!(
@@ -355,11 +355,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub BmpString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                BmpString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(BmpString::try_from("012345").unwrap())
+        );"#
 );
 e2e_pdu!(
     bmp_strict,
@@ -368,11 +366,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub BmpString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 BmpString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -382,11 +380,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub BmpString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 BmpString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -396,11 +394,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub BmpString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 BmpString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -410,11 +408,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub BmpString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 BmpString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -424,11 +422,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub NumericString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 NumericString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 e2e_pdu!(
     numeric_strict,
@@ -437,11 +435,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub NumericString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 NumericString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -451,11 +449,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub NumericString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 NumericString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -465,11 +463,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub NumericString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 NumericString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -479,11 +477,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub NumericString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 NumericString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -493,11 +491,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub Ia5String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 Ia5String::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 e2e_pdu!(
     ia5_strict,
@@ -506,11 +504,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub Ia5String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 Ia5String::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -520,11 +518,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub Ia5String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 Ia5String::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -534,11 +532,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub Ia5String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 Ia5String::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -548,11 +546,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub Ia5String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 Ia5String::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -562,11 +560,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub PrintableString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 PrintableString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 e2e_pdu!(
     printable_strict,
@@ -575,11 +573,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub PrintableString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 PrintableString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -589,11 +587,11 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub PrintableString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(
                 PrintableString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+            )
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -603,11 +601,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub PrintableString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                PrintableString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(PrintableString::try_from("012345").unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -617,11 +613,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub PrintableString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                PrintableString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(PrintableString::try_from("012345").unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -631,11 +625,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub GeneralString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GeneralString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GeneralString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 e2e_pdu!(
     general_strict,
@@ -644,11 +636,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub GeneralString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GeneralString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static  TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GeneralString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -658,11 +648,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub GeneralString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GeneralString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static  TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GeneralString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -672,11 +660,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub GeneralString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GeneralString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GeneralString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -686,11 +672,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub GeneralString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GeneralString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GeneralString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -700,11 +684,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub GraphicString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GraphicString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GraphicString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -714,11 +696,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub GraphicString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GraphicString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GraphicString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -728,11 +708,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub GraphicString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GraphicString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GraphicString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -742,11 +720,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub GraphicString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GraphicString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GraphicString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -756,11 +732,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub GraphicString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                GraphicString::try_from(String::from("012345")).unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(GraphicString::try_from(String::from("012345")).unwrap())
+        );                                                           "#
 );
 
 e2e_pdu!(
@@ -770,11 +744,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub Utf8String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                String::from("012345")
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(String::from("012345"))
+        );                                                          "#
 );
 e2e_pdu!(
     utf8_strict,
@@ -783,11 +755,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub Utf8String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                String::from("012345")
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(String::from("012345"))
+        );                                                          "#
 );
 
 e2e_pdu!(
@@ -797,11 +767,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub Utf8String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                String::from("012345")
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(String::from("012345"))
+        );                                                          "#
 );
 
 e2e_pdu!(
@@ -811,11 +779,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub Utf8String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                String::from("012345")
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(String::from("012345"))
+        );                                                          "#
 );
 
 e2e_pdu!(
@@ -825,11 +791,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub Utf8String);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                String::from("012345")
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(String::from("012345"))
+        );                                                          "#
 );
 
 e2e_pdu!(
@@ -839,11 +803,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String")]
         pub struct TestString(pub VisibleString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                VisibleString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(VisibleString::try_from("012345").unwrap())
+        );                                                          "#
 );
 e2e_pdu!(
     visible_strict,
@@ -852,11 +814,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4"))]
         pub struct TestString(pub VisibleString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                VisibleString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(VisibleString::try_from("012345").unwrap())
+        );                                                          "#
 );
 
 e2e_pdu!(
@@ -866,11 +826,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4", extensible))]
         pub struct TestString(pub VisibleString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                VisibleString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(VisibleString::try_from("012345").unwrap())
+        );                                                          "#
 );
 
 e2e_pdu!(
@@ -880,11 +838,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6"))]
         pub struct TestString(pub VisibleString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                VisibleString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(VisibleString::try_from("012345").unwrap())
+        );                                                          "#
 );
 
 e2e_pdu!(
@@ -894,11 +850,9 @@ e2e_pdu!(
     r#" #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
         #[rasn(delegate, identifier = "Test-String", size("4..=6", extensible))]
         pub struct TestString(pub VisibleString);
-        lazy_static!{
-            pub static ref TEST_STRING_VAL: TestString = TestString(
-                VisibleString::try_from("012345").unwrap()
-            );
-        }                                                           "#
+        pub static TEST_STRING_VAL: LazyLock<TestString> = LazyLock::new(||
+            TestString(VisibleString::try_from("012345").unwrap())
+        );                                                          "#
 );
 
 e2e_pdu!(

--- a/rasn-compiler-tests/tests/structured_types.rs
+++ b/rasn-compiler-tests/tests/structured_types.rs
@@ -3,9 +3,9 @@ use rasn_compiler_tests::e2e_pdu;
 e2e_pdu!(
     sequence_of_primitive_value,
     r#" value SEQUENCE OF INTEGER ::= { 1, 2, 3 }"#,
-    r#" lazy_static! {
-            pub static ref VALUE: Vec<Integer> = alloc::vec![Integer::from(1), Integer::from(2), Integer::from(3)];
-        }                                                       "#
+    r#" pub static VALUE: LazyLock<Vec<Integer>> = LazyLock::new(||
+        alloc::vec![Integer::from(1), Integer::from(2), Integer::from(3)]
+    );                                                       "#
 );
 
 e2e_pdu!(
@@ -93,9 +93,9 @@ e2e_pdu!(
             }
         }         
         
-        lazy_static! {
-            pub static ref NESTED_TYPE_VAL: NestedType = NestedType::new(NestedTypeChoiceField::one(Integer::from(4)));
-        }          "#
+        pub static NESTED_TYPE_VAL: LazyLock<NestedType> = LazyLock::new(||
+            NestedType::new(NestedTypeChoiceField::one(Integer::from(4)))
+        );          "#
 );
 
 e2e_pdu!(
@@ -145,9 +145,9 @@ e2e_pdu!(
             }
         }
 
-        lazy_static! {
-            pub static ref NESTED_TYPE_VAL: NestedType = NestedType::new(NestedTypeChoiceField::one(Integer::from(4)));
-        }          "#
+        pub static NESTED_TYPE_VAL: LazyLock<NestedType> = LazyLock::new(||
+            NestedType::new(NestedTypeChoiceField::one(Integer::from(4)))
+        );          "#
 );
 
 e2e_pdu!(
@@ -221,9 +221,9 @@ e2e_pdu!(
                 Self { ctfc_size }
             }
         }
-        lazy_static! {
-            pub static ref MAX_TFC: Integer = Integer::from(1024);
-        }
+        pub static MAX_TFC: LazyLock<Integer> = LazyLock::new(||
+            Integer::from(1024)
+        );
     "#
 );
 

--- a/rasn-compiler/src/generator/rasn/mod.rs
+++ b/rasn-compiler/src/generator/rasn/mod.rs
@@ -198,8 +198,8 @@ impl Backend for Rasn {
                     extern crate alloc;
 
                     use core::borrow::Borrow;
+                    use std::sync::LazyLock;
                     use rasn::prelude::*;
-                    use lazy_static::lazy_static;
                     #(#custom_imports)*
                     #(#imports)*
 

--- a/rasn-compiler/src/generator/rasn/template.rs
+++ b/rasn-compiler/src/generator/rasn/template.rs
@@ -33,10 +33,10 @@ pub fn lazy_static_value_template(
     value: TokenStream,
 ) -> TokenStream {
     quote! {
-        lazy_static! {
-            #comments
-            pub static ref #name: #vtype = #value;
-        }
+        #comments
+        pub static #name: LazyLock< #vtype > = LazyLock::new(||
+            #value
+        );
     }
 }
 
@@ -237,12 +237,12 @@ pub fn sequence_or_set_value_template(
     members: TokenStream,
 ) -> TokenStream {
     quote! {
-        lazy_static! {
-            #comments
-            pub static ref #name: #vtype = #vtype ::new(
+        #comments
+        pub static #name: LazyLock< #vtype > = LazyLock::new(||
+            #vtype ::new(
                 #members
-            );
-        }
+            )
+        );
     }
 }
 
@@ -302,10 +302,10 @@ pub fn choice_value_template(
     inner_decl: TokenStream,
 ) -> TokenStream {
     quote! {
-        lazy_static! {
-            #comments
-            pub static ref #name: #type_id = #type_id :: #choice_name (#inner_decl);
-        }
+        #comments
+        pub static #name: LazyLock< #type_id > = LazyLock::new(||
+            #type_id :: #choice_name (#inner_decl)
+        );
     }
 }
 


### PR DESCRIPTION
Use `std::sync::LazyLock` instead. Available since Rust 1.80.