### PR TITLE
Split `ToplevelDefinition::Information` into `Object` and `Class`

### DIFF
--- a/rasn-compiler/src/generator/error.rs
+++ b/rasn-compiler/src/generator/error.rs
@@ -74,7 +74,8 @@ impl Display for GeneratorError {
         let name = match &self.top_level_declaration {
             Some(ToplevelDefinition::Type(t)) => &t.name,
             Some(ToplevelDefinition::Value(v)) => &v.name,
-            Some(ToplevelDefinition::Information(i)) => &i.name,
+            Some(ToplevelDefinition::Class(c)) => &c.name,
+            Some(ToplevelDefinition::Object(o)) => &o.name,
             Some(ToplevelDefinition::Macro(m)) => &m.name,
             None => "",
         };

--- a/rasn-compiler/src/intermediate/parameterization.rs
+++ b/rasn-compiler/src/intermediate/parameterization.rs
@@ -1,6 +1,6 @@
 use super::ASN1Type;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Parameterization {
     pub parameters: Vec<ParameterizationArgument>,
 }

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -91,9 +91,10 @@ pub(crate) fn asn_module(
         module_header::module_header,
         terminated(
             many0(skip_ws(alt((
+                map(object_class_assignement, ToplevelDefinition::Class),
                 map(
                     top_level_information_declaration,
-                    ToplevelDefinition::Information,
+                    ToplevelDefinition::Object,
                 ),
                 map(top_level_type_declaration, ToplevelDefinition::Type),
                 map(top_level_value_declaration, ToplevelDefinition::Value),
@@ -140,7 +141,6 @@ pub fn top_level_information_declaration(
     skip_ws(alt((
         top_level_information_object_declaration,
         top_level_object_set_declaration,
-        top_level_object_class_declaration,
     )))
     .parse(input)
 }
@@ -270,18 +270,6 @@ fn top_level_object_set_declaration(
     .parse(input)
 }
 
-fn top_level_object_class_declaration(
-    input: Input<'_>,
-) -> ParserResult<'_, ToplevelInformationDefinition> {
-    into((
-        skip_ws(many0(comment)),
-        skip_ws(context_boundary(uppercase_identifier)),
-        skip_ws(opt(parameterization)),
-        preceded(assignment, alt((type_identifier, object_class_defn))),
-    ))
-    .parse(input)
-}
-
 #[test]
 fn eof_comments() {
     println!(
@@ -292,7 +280,7 @@ fn eof_comments() {
                 many0(skip_ws(alt((
                     map(
                         top_level_information_declaration,
-                        ToplevelDefinition::Information,
+                        ToplevelDefinition::Object,
                     ),
                     map(top_level_type_declaration, ToplevelDefinition::Type),
                     map(top_level_value_declaration, ToplevelDefinition::Value),

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -279,7 +279,7 @@ fn parses_object_set_value() {
             name: "CpmContainers".into(),
             index: None,
             parameterization: None,
-            class: Some(ClassLink::ByName("CPM-CONTAINER-ID-AND-TYPE".into())),
+            class: ClassLink::ByName("CPM-CONTAINER-ID-AND-TYPE".into()),
             value: ASN1Information::ObjectSet(ObjectSet {
                 values: vec![
                     ObjectSetValue::Inline(InformationObjectFields::CustomSyntax(vec![
@@ -344,7 +344,7 @@ fn parses_empty_extensible_object_set() {
             index: None,
             parameterization: None,
             name: "Reg-AdvisorySpeed".into(),
-            class: Some(ClassLink::ByName("REG-EXT-ID-AND-TYPE".into())),
+            class: ClassLink::ByName("REG-EXT-ID-AND-TYPE".into()),
             value: ASN1Information::ObjectSet(ObjectSet {
                 values: vec![],
                 extensible: Some(0)
@@ -356,7 +356,7 @@ fn parses_empty_extensible_object_set() {
 #[test]
 fn parses_class_declaration() {
     assert_eq!(
-        top_level_information_declaration(
+        object_class_assignement(
             r#"REG-EXT-ID-AND-TYPE ::= CLASS {
                   &id     RegionId UNIQUE,
                   &Type
@@ -365,13 +365,12 @@ fn parses_class_declaration() {
         )
         .unwrap()
         .1,
-        ToplevelInformationDefinition {
+        ObjectClassAssignment {
             comments: "".into(),
             name: "REG-EXT-ID-AND-TYPE".into(),
-            class: None,
             index: None,
-            parameterization: None,
-            value: ASN1Information::ObjectClass(ObjectClassDefn {
+            parameterization: Parameterization::default(),
+            definition: ObjectClassDefn {
                 fields: vec![
                     InformationObjectClassField {
                         identifier: ObjectFieldIdentifier::SingleValue("&id".into()),
@@ -402,7 +401,7 @@ fn parses_class_declaration() {
                         ))
                     ]
                 })
-            })
+            }
         }
     )
 }

--- a/rasn-compiler/src/validator/linking/types.rs
+++ b/rasn-compiler/src/validator/linking/types.rs
@@ -15,7 +15,8 @@ impl DeclarationElsewhere {
         ))? {
             ToplevelDefinition::Type(ToplevelTypeDefinition { ty: ASN1Type::ElsewhereDeclaredType(e), .. }) => e.root(tlds),
             ToplevelDefinition::Type(ToplevelTypeDefinition { ty, .. }) => Ok(ty),
-            ToplevelDefinition::Information(_) => Err(GrammarError::todo()),
+            ToplevelDefinition::Class(_) => Err(GrammarError::todo()),
+            ToplevelDefinition::Object(_) => Err(GrammarError::todo()),
             _ => Err(GrammarError::new(
                 &format!(
                     "Unexpectedly found a value definition resolving reference of ElsewhereDefined: {}",


### PR DESCRIPTION
Information object class have quite different usage/semantics from information object and information object set, so split them into two.