### PR TITLE
Fix Clippy lints

### DIFF
--- a/rasn-compiler-tests/tests/rasn_kerberos_tests.rs
+++ b/rasn-compiler-tests/tests/rasn_kerberos_tests.rs
@@ -694,7 +694,6 @@ pub struct UInt32(pub u32);
 /// This OID also designates the OID arc for KerberosV5-related OIDs.
 ///
 /// NOTE: RFC 1510 had an incorrect value (5) for "dod" in its OID.
-
 pub const ID_KRB5: &Oid = Oid::const_new(&[1, 3, 6, 1, 5, 2]);
 
 #[test]

--- a/rasn-compiler/src/generator/error.rs
+++ b/rasn-compiler/src/generator/error.rs
@@ -7,7 +7,7 @@ use crate::intermediate::{error::GrammarError, ToplevelDefinition};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GeneratorError {
-    pub top_level_declaration: Option<ToplevelDefinition>,
+    pub top_level_declaration: Option<Box<ToplevelDefinition>>,
     pub details: String,
     pub kind: GeneratorErrorType,
 }
@@ -15,7 +15,7 @@ pub struct GeneratorError {
 impl GeneratorError {
     pub fn new(tld: Option<ToplevelDefinition>, details: &str, kind: GeneratorErrorType) -> Self {
         GeneratorError {
-            top_level_declaration: tld,
+            top_level_declaration: tld.map(Box::new),
             details: details.into(),
             kind,
         }
@@ -71,7 +71,7 @@ impl From<LexError> for GeneratorError {
 
 impl Display for GeneratorError {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let name = match &self.top_level_declaration {
+        let name = match self.top_level_declaration.as_deref() {
             Some(ToplevelDefinition::Type(t)) => &t.name,
             Some(ToplevelDefinition::Value(v)) => &v.name,
             Some(ToplevelDefinition::Class(c)) => &c.name,

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -91,7 +91,7 @@ impl Rasn {
             ToplevelDefinition::Macro(_) => Err(GeneratorError {
                 kind: GeneratorErrorType::NotYetInplemented,
                 details: "MACROs are currently unsupported!".to_string(),
-                top_level_declaration: Some(tld),
+                top_level_declaration: Some(Box::new(tld)),
             }),
         }
     }
@@ -430,7 +430,7 @@ impl Rasn {
                     | CharacterStringType::UniversalString => {
                         return Err(GeneratorError::new(
                             None,
-                            &format!("{:?} values are currently unsupported", cs_ty),
+                            &format!("{cs_ty:?} values are currently unsupported"),
                             GeneratorErrorType::NotYetInplemented,
                         ))
                     }
@@ -881,7 +881,9 @@ impl Rasn {
                         .get(index)
                         .map(|f| f.identifier.identifier())
                         .ok_or_else(|| GeneratorError {
-                            top_level_declaration: Some(ToplevelDefinition::Object(tld.clone())),
+                            top_level_declaration: Some(Box::new(ToplevelDefinition::Object(
+                                tld.clone(),
+                            ))),
                             details: "Could not find class field for index.".into(),
                             kind: GeneratorErrorType::SyntaxMismatch,
                         })?;
@@ -960,7 +962,7 @@ impl Rasn {
                         } => self.to_rust_title_case(ref_id),
                         _ => format_ident!("{field_enum_name}_{index}").to_token_stream(),
                     };
-                    if ty.constraints().map_or(true, |c| c.is_empty()) {
+                    if ty.constraints().is_none_or(|c| c.is_empty()) {
                         ids.push((variant_name, type_id, identifier_value));
                         inner_types.push(TokenStream::new());
                     } else {

--- a/rasn-compiler/src/generator/rasn/mod.rs
+++ b/rasn-compiler/src/generator/rasn/mod.rs
@@ -283,15 +283,9 @@ impl Rasn {
         match String::from_utf8(output) {
             Ok(bindings) => match status.code() {
                 Some(0) => Ok(bindings),
-                Some(2) => Err(Box::new(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Rustfmt parsing errors.".to_string(),
-                ))),
+                Some(2) => Err(Box::new(io::Error::other("Rustfmt parsing errors."))),
                 Some(3) => Ok(bindings),
-                _ => Err(Box::new(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Internal rustfmt error".to_string(),
-                ))),
+                _ => Err(Box::new(io::Error::other("Internal rustfmt error"))),
             },
             _ => Ok(bindings),
         }

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -329,7 +329,7 @@ impl Rasn {
     pub(crate) fn format_sequence_or_set_members(
         &self,
         sequence_or_set: &SequenceOrSet,
-        parent_name: &String,
+        parent_name: &str,
     ) -> Result<FormattedMembers, GeneratorError> {
         let first_extension_index = sequence_or_set.extensible;
 
@@ -379,7 +379,7 @@ impl Rasn {
     pub(crate) fn format_sequence_member(
         &self,
         member: &SequenceOrSetMember,
-        parent_name: &String,
+        parent_name: &str,
         extension_annotation: TokenStream,
     ) -> Result<(TokenStream, NameType), GeneratorError> {
         let name = self.to_rust_snake_case(&member.name);
@@ -423,7 +423,7 @@ impl Rasn {
     pub(crate) fn format_choice_options(
         &self,
         choice: &Choice,
-        parent_name: &String,
+        parent_name: &str,
     ) -> Result<FormattedOptions, GeneratorError> {
         let first_extension_index = choice.extensible;
         choice.options.iter().enumerate().try_fold(
@@ -471,7 +471,7 @@ impl Rasn {
         &self,
         name: Ident,
         member: &ChoiceOption,
-        parent_name: &String,
+        parent_name: &str,
         extension_annotation: TokenStream,
     ) -> Result<TokenStream, GeneratorError> {
         let FormattedMemberOrOption {
@@ -936,7 +936,7 @@ impl Rasn {
                     | CharacterStringType::UniversalString
                     | CharacterStringType::TeletexString => Err(GeneratorError::new(
                         None,
-                        &format!("{:?} values are currently unsupported!", string_type),
+                        &format!("{string_type:?} values are currently unsupported!"),
                         GeneratorErrorType::NotYetInplemented,
                     )),
                 }
@@ -1282,7 +1282,7 @@ impl Rasn {
     ) -> Result<T, GeneratorError> {
         Err(GeneratorError::new(
             Some(ToplevelDefinition::Type(tld)),
-            &format!("Expected {} top-level declaration", expected_type),
+            &format!("Expected {expected_type} top-level declaration"),
             GeneratorErrorType::Asn1TypeMismatch,
         ))
     }
@@ -1467,7 +1467,7 @@ mod tests {
                             }
                         ]
                     },
-                    &"Parent".into(),
+                    "Parent",
                 )
                 .unwrap()
                 .struct_body
@@ -1560,7 +1560,7 @@ is_recursive: false,
                         }
                     ]
                 },
-                &"Parent".into(),
+                "Parent",
             )
             .unwrap()
             .enum_body

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -256,7 +256,7 @@ impl Rasn {
             TokenStream::new()
         } else {
             let alphabet_ts: TokenStream = alphabet_unicode
-                .parse()                           // turn the text into *tokens*
+                .parse() // turn the text into *tokens*
                 .expect("internal error: cannot parse generated unicode list");
             quote!(from(#alphabet_ts))
         })
@@ -1278,7 +1278,7 @@ impl Rasn {
     pub(super) fn type_mismatch_error<T>(
         &self,
         tld: ToplevelTypeDefinition,
-        expected_type: &str
+        expected_type: &str,
     ) -> Result<T, GeneratorError> {
         Err(GeneratorError::new(
             Some(ToplevelDefinition::Type(tld)),

--- a/rasn-compiler/src/generator/typescript/builder.rs
+++ b/rasn-compiler/src/generator/typescript/builder.rs
@@ -171,7 +171,7 @@ impl Typescript {
                             to_jer_identifier(&en.name),
                             en.name,
                             en.description
-                                .map_or(String::default(), |d| format!("//{}", d)),
+                                .map_or(String::default(), |d| format!("//{d}")),
                         ));
                         acc
                     }),

--- a/rasn-compiler/src/generator/typescript/mod.rs
+++ b/rasn-compiler/src/generator/typescript/mod.rs
@@ -143,7 +143,7 @@ impl Backend for Typescript {
             ToplevelDefinition::Macro(_) => Err(GeneratorError {
                 kind: GeneratorErrorType::NotYetInplemented,
                 details: "MACROs are currently unsupported!".to_string(),
-                top_level_declaration: Some(tld),
+                top_level_declaration: Some(Box::new(tld)),
             }),
             _ => Ok(String::new()),
         }

--- a/rasn-compiler/src/input.rs
+++ b/rasn-compiler/src/input.rs
@@ -200,7 +200,7 @@ impl<'a> Input<'a> {
         } else {
             let consumed = &self.inner[..consumed_len];
             let line_breaks = consumed.match_indices('\n');
-            let last_line_break = line_breaks.clone().last();
+            let last_line_break = line_breaks.clone().next_back();
             let column = if let Some(last) = last_line_break {
                 consumed_len - last.0 + 1 // because we're 1-indexing
             } else {

--- a/rasn-compiler/src/intermediate/constraints.rs
+++ b/rasn-compiler/src/intermediate/constraints.rs
@@ -88,10 +88,7 @@ impl Constraint {
             }
         }
         Err(GrammarError::new(
-            &format!(
-                "Failed to unpack constraint as value range. Constraint: {:?}",
-                self
-            ),
+            &format!("Failed to unpack constraint as value range. Constraint: {self:?}"),
             GrammarErrorType::UnpackingError,
         ))
     }
@@ -107,10 +104,7 @@ impl Constraint {
             }
         }
         Err(GrammarError::new(
-            &format!(
-                "Failed to unpack constraint as strict value. Constraint: {:?}",
-                self
-            ),
+            &format!("Failed to unpack constraint as strict value. Constraint: {self:?}"),
             GrammarErrorType::UnpackingError,
         ))
     }

--- a/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
+++ b/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
@@ -99,13 +99,16 @@ impl PerVisibleAlphabetConstraints {
                             elems.push(set.base.clone());
                             match &*set.operant {
                                 ElementOrSetOperation::Element(e2) => elems.push(e2.clone()),
-                                ElementOrSetOperation::SetOperation(inner) => flatten_set(elems, inner),
+                                ElementOrSetOperation::SetOperation(inner) => {
+                                    flatten_set(elems, inner)
+                                }
                             }
                         }
                         let mut elems = Vec::new();
                         flatten_set(&mut elems, s);
                         for elem in elems {
-                            if let Some(mut p) = Self::from_subtype_elem(Some(&elem), string_type)? {
+                            if let Some(mut p) = Self::from_subtype_elem(Some(&elem), string_type)?
+                            {
                                 result += &mut p;
                             }
                         }

--- a/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
+++ b/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
@@ -158,7 +158,7 @@ impl PerVisibleAlphabetConstraints {
                     _ => (0, char_set.len() - 1),
                 };
                 if lower > upper {
-                    return Err(GrammarError::new(&format!("Invalid range for permitted alphabet: Charset {:?}; Range: {lower}..={upper}", char_set), GrammarErrorType::UnpackingError
+                    return Err(GrammarError::new(&format!("Invalid range for permitted alphabet: Charset {char_set:?}; Range: {lower}..={upper}"), GrammarErrorType::UnpackingError
                     ));
                 }
                 Ok(Some(PerVisibleAlphabetConstraints {
@@ -235,7 +235,7 @@ fn find_char_index(char_set: &BTreeMap<usize, char>, as_char: char) -> Result<us
         .iter()
         .find_map(|(i, c)| (as_char == *c).then_some(*i))
         .ok_or(GrammarError::new(
-            &format!("Character {as_char} is not in char set: {:?}", char_set),
+            &format!("Character {as_char} is not in char set: {char_set:?}"),
             GrammarErrorType::UnpackingError,
         ))
 }
@@ -590,7 +590,7 @@ fn fold_constraint_set(
                     }
                 }
                 (v1, v2, _) => Err(GrammarError::new(
-                    &format!("Unsupported operation for ASN1Values {:?} and {:?}", v1, v2),
+                    &format!("Unsupported operation for ASN1Values {v1:?} and {v2:?}"),
                     GrammarErrorType::UnpackingError,
                 )),
             },
@@ -711,7 +711,7 @@ fn fold_constraint_set(
                     }))
                 }
                 _ => Err(GrammarError::new(
-                    &format!("Unsupported operation for ASN1Values {:?} and {:?}", v1, v2),
+                    &format!("Unsupported operation for ASN1Values {v1:?} and {v2:?}"),
                     GrammarErrorType::UnpackingError,
                 )),
             },
@@ -858,10 +858,7 @@ fn intersect_single_and_range(
             }))
         }
         _ => Err(GrammarError::new(
-            &format!(
-                "Unsupported operation for ASN1Values {:?} and {:?}..{:?}",
-                value, min, max
-            ),
+            &format!("Unsupported operation for ASN1Values {value:?} and {min:?}..{max:?}"),
             GrammarErrorType::UnpackingError,
         )),
     }
@@ -906,10 +903,7 @@ fn union_single_and_range(
             }))
         }
         _ => Err(GrammarError::new(
-            &format!(
-                "Unsupported operation for values {:?} and {:?}..{:?}",
-                v, min, max
-            ),
+            &format!("Unsupported operation for values {v:?} and {min:?}..{max:?}"),
             GrammarErrorType::UnpackingError,
         )),
     }

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -415,6 +415,7 @@ impl
 /// will subsequently try to resolve the `components_of` identifiers.
 #[cfg_attr(test, derive(EnumDebug))]
 #[cfg_attr(not(test), derive(Debug))]
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq)]
 pub enum SequenceComponent {
     Member(SequenceOrSetMember),

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -171,7 +171,7 @@ pub fn asn1_type(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             time,
             octet_string,
             character_string,
-            map(object_class_field_type, |i| ASN1Type::ObjectClassField(i)),
+            map(object_class_field_type, ASN1Type::ObjectClassField),
             elsewhere_declared_type,
         )),
     ))

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 
 use nom::{
-    Parser,
     branch::alt,
     bytes::complete::tag,
     character::complete::u128,
     combinator::{into, map, opt},
     multi::many1,
     sequence::{pair, preceded},
+    Parser,
 };
 
 use super::{
@@ -40,7 +40,8 @@ pub fn object_identifier_value(input: Input<'_>) -> ParserResult<'_, ObjectIdent
         // TODO: store info whether the object id is relative
         opt(alt((tag(OBJECT_IDENTIFIER), tag(RELATIVE_OID)))),
         in_braces(many1(skip_ws(object_identifier_arc))),
-    ))).parse(input)
+    )))
+    .parse(input)
 }
 
 pub fn object_identifier(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
@@ -50,7 +51,8 @@ pub fn object_identifier(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             opt(skip_ws_and_comments(constraint)),
         )),
         ASN1Type::ObjectIdentifier,
-    ).parse(input)
+    )
+    .parse(input)
 }
 
 fn object_identifier_arc(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierArc> {
@@ -58,7 +60,8 @@ fn object_identifier_arc(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierA
         numeric_id,
         into(pair(value_reference, skip_ws(in_parentheses(u128)))),
         into(value_reference),
-    ))).parse(input)
+    )))
+    .parse(input)
 }
 
 fn numeric_id(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierArc> {

--- a/rasn-compiler/src/lexer/set.rs
+++ b/rasn-compiler/src/lexer/set.rs
@@ -1,9 +1,6 @@
 use nom::{
-    bytes::complete::tag,
-    character::complete::char,
-    combinator::opt,
-    multi::many0,
-    sequence::{terminated},
+    bytes::complete::tag, character::complete::char, combinator::opt, multi::many0,
+    sequence::terminated,
 };
 
 use crate::intermediate::*;
@@ -40,7 +37,8 @@ pub fn set(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             ),
         ),
         |m| ASN1Type::Set(m.into()),
-    ).parse(input)
+    )
+    .parse(input)
 }
 
 #[cfg(test)]

--- a/rasn-compiler/src/lib.rs
+++ b/rasn-compiler/src/lib.rs
@@ -256,7 +256,7 @@ impl<B: Backend> Compiler<B, CompilerMissingParams> {
 
     /// Set the output path for the generated rust representation.
     /// * `output_path` - path to an output file or directory, if path indicates
-    ///                   a directory, the output file is named `rasn_generated.rs`
+    ///   a directory, the output file is named `rasn_generated.rs`
     pub fn set_output_path(
         self,
         output_path: impl Into<PathBuf>,
@@ -371,8 +371,8 @@ impl<B: Backend> Compiler<B, CompilerSourcesSet> {
 
     /// Set the output path for the generated rust representation.
     /// * `output_path` - path to an output file or directory, if path points to
-    ///                   a directory, the compiler will generate a file for every ASN.1 module.
-    ///                   If the path points to a file, all modules will be written to that file.
+    ///   a directory, the compiler will generate a file for every ASN.1 module.
+    ///   If the path points to a file, all modules will be written to that file.
     pub fn set_output_path(self, output_path: impl Into<PathBuf>) -> Compiler<B, CompilerReady> {
         Compiler {
             state: CompilerReady {
@@ -528,19 +528,15 @@ impl<B: Backend> Compiler<B, CompilerReady> {
         }
         .internal_compile()?
         .fmt::<B>();
-        fs::write(
+
+        let output_file = if self.state.output_path.is_dir() {
             self.state
                 .output_path
-                .is_dir()
-                .then(|| {
-                    self.state
-                        .output_path
-                        .join(format!("generated{}", B::FILE_EXTENSION))
-                })
-                .unwrap_or(self.state.output_path),
-            result.generated,
-        )
-        .map_err(|e| GeneratorError {
+                .join(format!("generated{}", B::FILE_EXTENSION))
+        } else {
+            self.state.output_path
+        };
+        fs::write(output_file, result.generated).map_err(|e| GeneratorError {
             top_level_declaration: None,
             details: e.to_string(),
             kind: GeneratorErrorType::IO,


### PR DESCRIPTION
Fix all standard Clippy lints and format with `cargo fmt`.