### PR TITLE
Renames to better follow specification

### DIFF
--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -716,7 +716,7 @@ impl Rasn {
                         .concat()
                         .iter()
                         .for_each(|c| {
-                            if let (Constraint::TableConstraint(t), ASN1Type::ObjectClassField(iofr)) = (c, &m.ty) {
+                            if let (Constraint::Table(t), ASN1Type::ObjectClassField(iofr)) = (c, &m.ty) {
                                 let decode_fn = format_ident!("decode_{}", self.to_rust_snake_case(&m.name));
                                 let open_field_name = self.to_rust_snake_case(&m.name);
                                 let identifier = t.linked_fields.iter().map(|l|

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -1357,7 +1357,7 @@ mod tests {
     use quote::quote;
 
     use crate::intermediate::{
-        constraints::ElementSet,
+        constraints::ElementSetSpecs,
         types::{Boolean, Enumeral, Integer},
         AsnTag,
     };
@@ -1451,10 +1451,10 @@ mod tests {
                                 tag: None,
                                 ty: ASN1Type::Integer(Integer {
                                     distinguished_values: None,
-                                    constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                                    constraints: vec![Constraint::Subtype(ElementSetSpecs {
                             extensible: false,
                             set: crate::intermediate::constraints::ElementOrSetOperation::Element(
-                                crate::intermediate::constraints::SubtypeElement::SingleValue {
+                                crate::intermediate::constraints::SubtypeElements::SingleValue {
                                     value: ASN1Value::Integer(4),
                                     extensible: true
                                 }
@@ -1546,10 +1546,10 @@ is_recursive: false,
                             tag: None,
                             ty: ASN1Type::Integer(Integer {
                                 distinguished_values: None,
-                                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                                constraints: vec![Constraint::Subtype(ElementSetSpecs {
                                     extensible: false,
                                     set: crate::intermediate::constraints::ElementOrSetOperation::Element(
-                                        crate::intermediate::constraints::SubtypeElement::SingleValue {
+                                        crate::intermediate::constraints::SubtypeElements::SingleValue {
                                             value: ASN1Value::Integer(4),
                                             extensible: true
                                         }
@@ -1656,11 +1656,11 @@ is_recursive: false,
     fn detects_fixed_octet_string() {
         assert_eq!(
             OctetString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
                     set: constraints::ElementOrSetOperation::Element(
-                        constraints::SubtypeElement::SizeConstraint(Box::new(
+                        constraints::SubtypeElements::SizeConstraint(Box::new(
                             constraints::ElementOrSetOperation::Element(
-                                constraints::SubtypeElement::SingleValue {
+                                constraints::SubtypeElements::SingleValue {
                                     value: ASN1Value::Integer(4),
                                     extensible: false,
                                 },
@@ -1675,11 +1675,11 @@ is_recursive: false,
         );
         assert_eq!(
             OctetString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
                     set: constraints::ElementOrSetOperation::Element(
-                        constraints::SubtypeElement::SizeConstraint(Box::new(
+                        constraints::SubtypeElements::SizeConstraint(Box::new(
                             constraints::ElementOrSetOperation::Element(
-                                constraints::SubtypeElement::ValueRange {
+                                constraints::SubtypeElements::ValueRange {
                                     min: Some(ASN1Value::Integer(1)),
                                     max: Some(ASN1Value::Integer(4)),
                                     extensible: false

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -871,81 +871,71 @@ impl ASN1Type {
     pub fn builtin_or_elsewhere(
         parent: Option<&str>,
         identifier: &str,
-        constraints: Option<Vec<Constraint>>,
+        constraints: Vec<Constraint>,
     ) -> ASN1Type {
         match (parent, identifier) {
             (None, NULL) => ASN1Type::Null,
-            (None, BOOLEAN) => ASN1Type::Boolean(Boolean {
-                constraints: constraints.unwrap_or_default(),
-            }),
-            (None, REAL) => ASN1Type::Real(Real {
-                constraints: constraints.unwrap_or_default(),
-            }),
+            (None, BOOLEAN) => ASN1Type::Boolean(Boolean { constraints }),
+            (None, REAL) => ASN1Type::Real(Real { constraints }),
             (None, INTEGER) => ASN1Type::Integer(Integer {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 distinguished_values: None,
             }),
             (None, BIT_STRING) => ASN1Type::BitString(BitString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 distinguished_values: None,
             }),
-            (None, OCTET_STRING) => ASN1Type::OctetString(OctetString {
-                constraints: constraints.unwrap_or_default(),
-            }),
-            (None, GENERALIZED_TIME) => ASN1Type::GeneralizedTime(GeneralizedTime {
-                constraints: constraints.unwrap_or_default(),
-            }),
-            (None, UTC_TIME) => ASN1Type::UTCTime(UTCTime {
-                constraints: constraints.unwrap_or_default(),
-            }),
-            (None, OBJECT_IDENTIFIER) => ASN1Type::ObjectIdentifier(ObjectIdentifier {
-                constraints: constraints.unwrap_or_default(),
-            }),
+            (None, OCTET_STRING) => ASN1Type::OctetString(OctetString { constraints }),
+            (None, GENERALIZED_TIME) => ASN1Type::GeneralizedTime(GeneralizedTime { constraints }),
+            (None, UTC_TIME) => ASN1Type::UTCTime(UTCTime { constraints }),
+            (None, OBJECT_IDENTIFIER) => {
+                ASN1Type::ObjectIdentifier(ObjectIdentifier { constraints })
+            }
             (None, BMP_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::BMPString,
             }),
             (None, UTF8_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::UTF8String,
             }),
             (None, PRINTABLE_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::PrintableString,
             }),
             (None, TELETEX_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::TeletexString,
             }),
             (None, IA5_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::IA5String,
             }),
             (None, UNIVERSAL_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::UniversalString,
             }),
             (None, VISIBLE_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::VisibleString,
             }),
             (None, GENERAL_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::GeneralString,
             }),
             (None, VIDEOTEX_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::VideotexString,
             }),
             (None, GRAPHIC_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::GraphicString,
             }),
             (None, NUMERIC_STRING) => ASN1Type::CharacterString(CharacterString {
-                constraints: constraints.unwrap_or_default(),
+                constraints,
                 ty: CharacterStringType::NumericString,
             }),
-            _ => ASN1Type::ElsewhereDeclaredType((parent, identifier, constraints).into()),
+            _ => ASN1Type::ElsewhereDeclaredType((parent, identifier, Some(constraints)).into()),
         }
     }
 

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -102,8 +102,8 @@ impl Integer {
 impl From<(i128, i128, bool)> for Integer {
     fn from(value: (i128, i128, bool)) -> Self {
         Self {
-            constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+            constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                     min: Some(ASN1Value::Integer(value.0)),
                     max: Some(ASN1Value::Integer(value.1)),
                     extensible: value.2,
@@ -118,8 +118,8 @@ impl From<(i128, i128, bool)> for Integer {
 impl From<(Option<i128>, Option<i128>, bool)> for Integer {
     fn from(value: (Option<i128>, Option<i128>, bool)) -> Self {
         Self {
-            constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+            constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                     min: value.0.map(ASN1Value::Integer),
                     max: value.1.map(ASN1Value::Integer),
                     extensible: value.2,
@@ -443,8 +443,8 @@ pub enum SequenceComponent {
 ///     }),
 ///     ty: ASN1Type::Integer(Integer {
 ///         constraints: vec![
-///             Constraint::SubtypeConstraint(ElementSet {
-///                 set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+///             Constraint::Subtype(ElementSetSpecs {
+///                 set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
 ///                     min: Some(ASN1Value::Integer(0)),
 ///                     max: Some(ASN1Value::Integer(2)),
 ///                     extensible: false

--- a/rasn-compiler/src/lexer/bit_string.rs
+++ b/rasn-compiler/src/lexer/bit_string.rs
@@ -10,7 +10,7 @@ use nom::{
 
 use crate::{input::Input, intermediate::*};
 
-use super::{common::*, constraint::constraint, error::ParserResult, util::hex_to_bools};
+use super::{common::*, constraint::constraints, error::ParserResult, util::hex_to_bools};
 
 /// Parses a BIT STRING value. Currently, the lexer only supports parsing binary and
 /// hexadecimal values, but not the named bit notation in curly braces.
@@ -62,7 +62,7 @@ pub fn bit_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         preceded(
             skip_ws_and_comments(tag(BIT_STRING)),
-            pair(opt(distinguished_values), opt(constraint)),
+            pair(opt(distinguished_values), opt(constraints)),
         ),
         |m| ASN1Type::BitString(m.into()),
     )
@@ -95,9 +95,9 @@ mod tests {
             bit_string(sample).unwrap().1,
             ASN1Type::BitString(BitString {
                 distinguished_values: None,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::SingleValue {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::SingleValue {
                             value: ASN1Value::Integer(8),
                             extensible: false
                         })
@@ -115,9 +115,9 @@ mod tests {
             bit_string(sample).unwrap().1,
             ASN1Type::BitString(BitString {
                 distinguished_values: None,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(8)),
                             max: Some(ASN1Value::Integer(18)),
                             extensible: false
@@ -136,9 +136,9 @@ mod tests {
             bit_string(sample).unwrap().1,
             ASN1Type::BitString(BitString {
                 distinguished_values: None,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::SingleValue {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::SingleValue {
                             value: ASN1Value::Integer(2),
                             extensible: true
                         })
@@ -156,9 +156,9 @@ mod tests {
             bit_string(sample).unwrap().1,
             ASN1Type::BitString(BitString {
                 distinguished_values: None,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(8)),
                             max: Some(ASN1Value::Integer(18)),
                             extensible: true
@@ -200,9 +200,9 @@ mod tests {
                         value: 3
                     },
                 ]),
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::SingleValue {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::SingleValue {
                             value: ASN1Value::Integer(4),
                             extensible: false
                         })

--- a/rasn-compiler/src/lexer/boolean.rs
+++ b/rasn-compiler/src/lexer/boolean.rs
@@ -11,7 +11,7 @@ use crate::{
     intermediate::{ASN1Type, ASN1Value, BOOLEAN, FALSE, TRUE},
 };
 
-use super::{common::skip_ws_and_comments, constraint::constraint, error::ParserResult};
+use super::{common::skip_ws_and_comments, constraint::constraints, error::ParserResult};
 
 pub fn boolean_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
     alt((
@@ -33,7 +33,7 @@ pub fn boolean(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         into(skip_ws_and_comments(preceded(
             tag(BOOLEAN),
-            skip_ws_and_comments(opt(constraint)),
+            skip_ws_and_comments(opt(constraints)),
         ))),
         ASN1Type::Boolean,
     )

--- a/rasn-compiler/src/lexer/character_string.rs
+++ b/rasn-compiler/src/lexer/character_string.rs
@@ -11,7 +11,7 @@ use crate::{input::Input, intermediate::*};
 
 use super::{
     common::*,
-    constraint::constraint,
+    constraint::constraints,
     error::{MiscError, ParserResult},
     util::take_until_and_not,
 };
@@ -126,7 +126,7 @@ pub fn character_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 tag(BMP_STRING),
                 tag(PRINTABLE_STRING),
             )))),
-            opt(constraint),
+            opt(constraints),
         ),
         |m| ASN1Type::CharacterString(m.into()),
     )
@@ -163,9 +163,9 @@ mod tests {
         assert_eq!(
             character_string(sample).unwrap().1,
             ASN1Type::CharacterString(CharacterString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::SingleValue {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::SingleValue {
                             value: ASN1Value::Integer(8),
                             extensible: false
                         })
@@ -183,9 +183,9 @@ mod tests {
         assert_eq!(
             character_string(sample).unwrap().1,
             ASN1Type::CharacterString(CharacterString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(8)),
                             max: Some(ASN1Value::Integer(18)),
                             extensible: false
@@ -206,9 +206,9 @@ mod tests {
         assert_eq!(
             character_string(sample).unwrap().1,
             ASN1Type::CharacterString(CharacterString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::SingleValue {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::SingleValue {
                             value: ASN1Value::Integer(2),
                             extensible: true
                         })
@@ -226,9 +226,9 @@ mod tests {
         assert_eq!(
             character_string(sample).unwrap().1,
             ASN1Type::CharacterString(CharacterString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(8)),
                             max: Some(ASN1Value::Integer(18)),
                             extensible: true

--- a/rasn-compiler/src/lexer/choice.rs
+++ b/rasn-compiler/src/lexer/choice.rs
@@ -12,7 +12,7 @@ use crate::{
     intermediate::{types::*, *},
 };
 
-use super::{constraint::constraint, error::ParserResult, *};
+use super::{constraint::constraints, error::ParserResult, *};
 
 pub fn choice_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
     map(
@@ -109,7 +109,7 @@ fn choice_option(input: Input<'_>) -> ParserResult<'_, ChoiceOption> {
         skip_ws_and_comments(identifier),
         opt(asn_tag),
         skip_ws_and_comments(asn1_type),
-        opt(skip_ws_and_comments(constraint)),
+        opt(skip_ws_and_comments(constraints)),
     ))
     .parse(input)
 }

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -12,8 +12,7 @@ use crate::{
     input::{context_boundary, Input},
     intermediate::{
         information_object::*, types::ObjectIdentifier, ASN1Type, DeclarationElsewhere, AMPERSAND,
-        CLASS, COMMA, DEFAULT, DOT, INSTANCE_OF, OPTIONAL, PIPE, TYPE_IDENTIFIER, UNION, UNIQUE,
-        WITH_SYNTAX,
+        CLASS, COMMA, DEFAULT, DOT, INSTANCE_OF, OPTIONAL, TYPE_IDENTIFIER, UNIQUE, WITH_SYNTAX,
     },
     lexer::{
         common::{assignment, comment, skip_ws},
@@ -28,7 +27,7 @@ use super::{
         extension_marker, identifier, in_braces, in_brackets, optional_comma, skip_ws_and_comments,
         uppercase_identifier,
     },
-    constraint::constraint,
+    constraint::{constraints, union_mark},
     error::ParserResult,
     into_inner,
 };
@@ -115,7 +114,7 @@ pub fn instance_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
             tag(INSTANCE_OF),
             pair(
                 skip_ws_and_comments(uppercase_identifier),
-                skip_ws_and_comments(constraint),
+                skip_ws_and_comments(constraints),
             ),
         ),
         |(id, constraints)| {
@@ -172,7 +171,7 @@ pub fn object_class_field_type(input: Input<'_>) -> ParserResult<'_, ObjectClass
             char(DOT),
             skip_ws_and_comments(object_field_identifier),
         ))),
-        opt(constraint),
+        opt(constraints),
     ))
     .parse(input)
 }
@@ -188,7 +187,7 @@ pub fn information_object(input: Input<'_>) -> ParserResult<'_, InformationObjec
 pub fn object_set(input: Input<'_>) -> ParserResult<'_, ObjectSet> {
     into(in_braces((
         separated_list0(
-            skip_ws_and_comments(alt((tag(PIPE), tag(UNION)))),
+            skip_ws_and_comments(union_mark),
             skip_ws_and_comments(alt((
                 into(information_object),
                 into(skip_ws_and_comments(identifier)),
@@ -201,7 +200,7 @@ pub fn object_set(input: Input<'_>) -> ParserResult<'_, ObjectSet> {
         opt(skip_ws_and_comments(preceded(
             char(COMMA),
             separated_list1(
-                skip_ws_and_comments(alt((tag(PIPE), tag(UNION)))),
+                skip_ws_and_comments(union_mark),
                 skip_ws_and_comments(alt((
                     into(information_object),
                     into(skip_ws_and_comments(identifier)),

--- a/rasn-compiler/src/lexer/integer.rs
+++ b/rasn-compiler/src/lexer/integer.rs
@@ -27,7 +27,7 @@ pub fn integer(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
         (
             into_inner(skip_ws_and_comments(tag(INTEGER))),
             opt(skip_ws_and_comments(distinguished_values)),
-            opt(skip_ws_and_comments(constraint)),
+            opt(skip_ws_and_comments(constraints)),
         ),
         |m| ASN1Type::Integer(m.into()),
     )
@@ -50,8 +50,8 @@ mod tests {
         assert_eq!(
             integer("INTEGER  (-9..-4, ...)".into()).unwrap().1,
             ASN1Type::Integer(Integer {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                         min: Some(ASN1Value::Integer(-9)),
                         max: Some(ASN1Value::Integer(-4)),
                         extensible: true
@@ -64,8 +64,8 @@ mod tests {
         assert_eq!(
             integer("\r\nINTEGER(-9..-4)".into()).unwrap().1,
             ASN1Type::Integer(Integer {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                         min: Some(ASN1Value::Integer(-9)),
                         max: Some(ASN1Value::Integer(-4)),
                         extensible: false

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -221,10 +221,14 @@ pub fn elsewhere_declared_type(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 tag(".&"),
             ))))),
             skip_ws_and_comments(type_reference),
-            opt(skip_ws_and_comments(constraint)),
+            opt(skip_ws_and_comments(constraints)),
         ),
         |(parent, id, constraints)| {
-            ASN1Type::builtin_or_elsewhere(parent.map(|p| p.into_inner()), id, constraints)
+            ASN1Type::builtin_or_elsewhere(
+                parent.map(|p| p.into_inner()),
+                id,
+                constraints.unwrap_or_default(),
+            )
         },
     )
     .parse(input)

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -19,7 +19,7 @@ use nom::{
 
 use super::{
     common::{in_braces, in_parentheses, skip_ws, skip_ws_and_comments, value_reference},
-    constraint::constraint,
+    constraint::constraints,
     error::ParserResult,
     RELATIVE_OID,
 };
@@ -47,7 +47,7 @@ pub fn object_identifier(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         into(preceded(
             skip_ws_and_comments(alt((tag(OBJECT_IDENTIFIER), tag(RELATIVE_OID)))),
-            opt(skip_ws_and_comments(constraint)),
+            opt(skip_ws_and_comments(constraints)),
         )),
         ASN1Type::ObjectIdentifier,
     ).parse(input)

--- a/rasn-compiler/src/lexer/octet_string.rs
+++ b/rasn-compiler/src/lexer/octet_string.rs
@@ -7,7 +7,7 @@ use nom::{
 
 use crate::{input::Input, intermediate::*};
 
-use super::{common::*, constraint::constraint, error::ParserResult};
+use super::{common::*, constraint::constraints, error::ParserResult};
 
 /// Tries to parse an ASN1 OCTET STRING
 ///
@@ -19,7 +19,7 @@ use super::{common::*, constraint::constraint, error::ParserResult};
 /// If the match fails, the lexer will not consume the input and will return an error.
 pub fn octet_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
-        preceded(skip_ws_and_comments(tag(OCTET_STRING)), opt(constraint)),
+        preceded(skip_ws_and_comments(tag(OCTET_STRING)), opt(constraints)),
         |m| ASN1Type::OctetString(m.into()),
     )
     .parse(input)
@@ -48,9 +48,9 @@ mod tests {
         assert_eq!(
             octet_string(sample).unwrap().1,
             ASN1Type::OctetString(OctetString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::SingleValue {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::SingleValue {
                             value: ASN1Value::Integer(8),
                             extensible: false
                         })
@@ -67,9 +67,9 @@ mod tests {
         assert_eq!(
             octet_string(sample).unwrap().1,
             ASN1Type::OctetString(OctetString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(8)),
                             max: Some(ASN1Value::Integer(18)),
                             extensible: false
@@ -87,9 +87,9 @@ mod tests {
         assert_eq!(
             octet_string(sample).unwrap().1,
             ASN1Type::OctetString(OctetString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::SingleValue {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::SingleValue {
                             value: ASN1Value::Integer(2),
                             extensible: true
                         })
@@ -106,9 +106,9 @@ mod tests {
         assert_eq!(
             octet_string(sample).unwrap().1,
             ASN1Type::OctetString(OctetString {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(8)),
                             max: Some(ASN1Value::Integer(18)),
                             extensible: true

--- a/rasn-compiler/src/lexer/real.rs
+++ b/rasn-compiler/src/lexer/real.rs
@@ -10,7 +10,7 @@ use nom::{
 
 use super::{
     common::{in_braces, skip_ws_and_comments},
-    constraint::constraint,
+    constraint::constraints,
     error::ParserResult,
 };
 
@@ -34,7 +34,7 @@ pub fn real(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         preceded(
             skip_ws_and_comments(tag(REAL)),
-            opt(skip_ws_and_comments(constraint)),
+            opt(skip_ws_and_comments(constraints)),
         ),
         |m| ASN1Type::Real(m.into()),
     )
@@ -86,8 +86,8 @@ fn mbe_notation(input: Input<'_>) -> ParserResult<'_, f64> {
 mod tests {
     use crate::intermediate::{
         constraints::{
-            ComponentPresence, ConstrainedComponent, Constraint, ElementOrSetOperation, ElementSet,
-            InnerTypeConstraint, SubtypeElement,
+            ComponentPresence, Constraint, ElementOrSetOperation, ElementSetSpecs,
+            InnerTypeConstraint, NamedConstraint, SubtypeElements,
         },
         types::Real,
         ASN1Type, ASN1Value,
@@ -126,16 +126,16 @@ mod tests {
             .unwrap()
             .1,
             ASN1Type::Real(Real {
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::MultipleTypeConstraints(
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::MultipleTypeConstraints(
                         InnerTypeConstraint {
                             is_partial: false,
                             constraints: vec![
-                                ConstrainedComponent {
+                                NamedConstraint {
                                     identifier: "mantissa".into(),
-                                    constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                                    constraints: vec![Constraint::Subtype(ElementSetSpecs {
                                         set: ElementOrSetOperation::Element(
-                                            SubtypeElement::ValueRange {
+                                            SubtypeElements::ValueRange {
                                                 min: Some(ASN1Value::Integer(-16777215)),
                                                 max: Some(ASN1Value::Integer(16777215)),
                                                 extensible: false
@@ -145,11 +145,11 @@ mod tests {
                                     })],
                                     presence: ComponentPresence::Unspecified
                                 },
-                                ConstrainedComponent {
+                                NamedConstraint {
                                     identifier: "base".into(),
-                                    constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                                    constraints: vec![Constraint::Subtype(ElementSetSpecs {
                                         set: ElementOrSetOperation::Element(
-                                            SubtypeElement::SingleValue {
+                                            SubtypeElements::SingleValue {
                                                 value: ASN1Value::Integer(2),
                                                 extensible: false
                                             }
@@ -158,11 +158,11 @@ mod tests {
                                     })],
                                     presence: ComponentPresence::Unspecified
                                 },
-                                ConstrainedComponent {
+                                NamedConstraint {
                                     identifier: "exponent".into(),
-                                    constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                                    constraints: vec![Constraint::Subtype(ElementSetSpecs {
                                         set: ElementOrSetOperation::Element(
-                                            SubtypeElement::ValueRange {
+                                            SubtypeElements::ValueRange {
                                                 min: Some(ASN1Value::Integer(-125)),
                                                 max: Some(ASN1Value::Integer(128)),
                                                 extensible: false

--- a/rasn-compiler/src/lexer/sequence.rs
+++ b/rasn-compiler/src/lexer/sequence.rs
@@ -11,7 +11,7 @@ use crate::{
     intermediate::{types::*, *},
 };
 
-use super::{common::optional_comma, constraint::constraint, *};
+use super::{common::optional_comma, constraint::constraints, *};
 
 pub fn sequence_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
     map(
@@ -60,7 +60,7 @@ pub fn sequence(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                         optional_comma,
                     ))),
                 )),
-                opt(constraint),
+                opt(constraints),
             ),
         ),
         |m| ASN1Type::Sequence(m.into()),
@@ -131,7 +131,7 @@ pub fn sequence_or_set_member(input: Input<'_>) -> ParserResult<'_, SequenceOrSe
         skip_ws_and_comments(identifier),
         opt(asn_tag),
         skip_ws_and_comments(asn1_type),
-        opt(constraint),
+        opt(constraints),
         optional_marker,
         default,
     ))
@@ -226,7 +226,7 @@ is_recursive: false,
                     name: "clusterBoundingBoxShape".into(),
                     tag: None,
                     ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere { parent: None,
-                        identifier: "Shape".into(), constraints: vec![Constraint::SubtypeConstraint(ElementSet { set: ElementOrSetOperation::Element(SubtypeElement::MultipleTypeConstraints(InnerTypeConstraint { is_partial: true, constraints: vec![ConstrainedComponent { identifier: "elliptical".into(), constraints: vec![], presence: ComponentPresence::Absent },ConstrainedComponent { identifier: "radial".into(), constraints: vec![], presence: ComponentPresence::Absent },ConstrainedComponent { identifier: "radialShapes".into(), constraints: vec![], presence: ComponentPresence::Absent }] })), extensible: false })
+                        identifier: "Shape".into(), constraints: vec![Constraint::Subtype(ElementSetSpecs { set: ElementOrSetOperation::Element(SubtypeElements::MultipleTypeConstraints(InnerTypeConstraint { is_partial: true, constraints: vec![NamedConstraint { identifier: "elliptical".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radial".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radialShapes".into(), constraints: vec![], presence: ComponentPresence::Absent }] })), extensible: false })
                      ]}),
                     default_value: None,
                     is_optional: true,
@@ -444,8 +444,8 @@ is_recursive: false,
                         name: "unNumber".into(),
                         tag: None,
                         ty: ASN1Type::Integer(Integer {
-                            constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                                set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                            constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                                set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                                     min: Some(ASN1Value::Integer(0)),
                                     max: Some(ASN1Value::Integer(9999)),
                                     extensible: false
@@ -474,11 +474,11 @@ is_recursive: false,
                         name: "emergencyActionCode".into(),
                         tag: None,
                         ty: ASN1Type::OctetString(OctetString {
-                            constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                            constraints: vec![Constraint::Subtype(ElementSetSpecs {
                                 set: ElementOrSetOperation::Element(
-                                    SubtypeElement::SizeConstraint(Box::new(
+                                    SubtypeElements::SizeConstraint(Box::new(
                                         ElementOrSetOperation::Element(
-                                            SubtypeElement::ValueRange {
+                                            SubtypeElements::ValueRange {
                                                 min: Some(ASN1Value::Integer(1)),
                                                 max: Some(ASN1Value::Integer(24)),
                                                 extensible: false
@@ -574,12 +574,12 @@ is_recursive: false,
 
                                         tag: None,
                                         ty: ASN1Type::BitString(BitString {
-                                            constraints: vec![Constraint::SubtypeConstraint(
-                                                ElementSet {
+                                            constraints: vec![Constraint::Subtype(
+                                                ElementSetSpecs {
                                                     set: ElementOrSetOperation::Element(
-                                                        SubtypeElement::SizeConstraint(Box::new(
+                                                        SubtypeElements::SizeConstraint(Box::new(
                                                             ElementOrSetOperation::Element(
-                                                                SubtypeElement::SingleValue {
+                                                                SubtypeElements::SingleValue {
                                                                     value: ASN1Value::Integer(1),
                                                                     extensible: true
                                                                 }
@@ -659,8 +659,8 @@ is_recursive: false,
                         name: "item-code".into(),
                         tag: None,
                         ty: ASN1Type::Integer(Integer {
-                            constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                                set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                            constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                                set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                                     min: Some(ASN1Value::Integer(0)),
                                     max: Some(ASN1Value::Integer(254)),
                                     extensible: false
@@ -687,18 +687,16 @@ is_recursive: false,
                                     name: "alternate-item-code".into(),
                                     tag: None,
                                     ty: ASN1Type::Integer(Integer {
-                                        constraints: vec![Constraint::SubtypeConstraint(
-                                            ElementSet {
-                                                set: ElementOrSetOperation::Element(
-                                                    SubtypeElement::ValueRange {
-                                                        min: Some(ASN1Value::Integer(0)),
-                                                        max: Some(ASN1Value::Integer(254)),
-                                                        extensible: false
-                                                    }
-                                                ),
-                                                extensible: false
-                                            }
-                                        )],
+                                        constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                                            set: ElementOrSetOperation::Element(
+                                                SubtypeElements::ValueRange {
+                                                    min: Some(ASN1Value::Integer(0)),
+                                                    max: Some(ASN1Value::Integer(254)),
+                                                    extensible: false
+                                                }
+                                            ),
+                                            extensible: false
+                                        })],
                                         distinguished_values: None,
                                     }),
                                     default_value: None,
@@ -857,8 +855,8 @@ integrityCheckValue     ICV OPTIONAL
                         element_tag: None,
                         constraints: vec![],
                         element_type: Box::new(ASN1Type::Integer(Integer {
-                            constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                                set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                            constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                                set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                                     min: Some(ASN1Value::Integer(1,),),
                                     max: Some(ASN1Value::Integer(5,),),
                                     extensible: false,

--- a/rasn-compiler/src/lexer/sequence_of.rs
+++ b/rasn-compiler/src/lexer/sequence_of.rs
@@ -9,7 +9,7 @@ use nom::{
 use super::{
     asn1_type,
     common::{asn_tag, opt_parentheses, skip_ws_and_comments, value_reference},
-    constraint::constraint,
+    constraint::constraints,
     error::ParserResult,
 };
 
@@ -26,7 +26,7 @@ pub fn sequence_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
         pair(
             preceded(
                 skip_ws_and_comments(tag(SEQUENCE)),
-                opt(opt_parentheses(constraint)),
+                opt(opt_parentheses(constraints)),
             ),
             preceded(
                 skip_ws_and_comments(pair(tag(OF), opt(skip_ws_and_comments(value_reference)))),
@@ -90,9 +90,9 @@ mod tests {
             ASN1Type::SequenceOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -118,9 +118,9 @@ mod tests {
             ASN1Type::SequenceOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -151,9 +151,9 @@ mod tests {
             ASN1Type::SequenceOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -162,8 +162,8 @@ mod tests {
                     extensible: false
                 })],
                 element_type: Box::new(ASN1Type::Integer(Integer {
-                    constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                        set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                    constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                        set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -192,9 +192,9 @@ mod tests {
             ASN1Type::SequenceOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(4)),
                             extensible: false

--- a/rasn-compiler/src/lexer/set.rs
+++ b/rasn-compiler/src/lexer/set.rs
@@ -8,7 +8,7 @@ use nom::{
 
 use crate::intermediate::*;
 
-use super::{common::optional_comma, constraint::constraint, sequence::sequence_component, *};
+use super::{common::optional_comma, constraint::constraints, sequence::sequence_component, *};
 
 /// Tries to parse an ASN1 SET
 ///
@@ -36,7 +36,7 @@ pub fn set(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                         optional_comma,
                     ))),
                 )),
-                opt(constraint),
+                opt(constraints),
             ),
         ),
         |m| ASN1Type::Set(m.into()),

--- a/rasn-compiler/src/lexer/set_of.rs
+++ b/rasn-compiler/src/lexer/set_of.rs
@@ -9,7 +9,7 @@ use nom::{
 use super::{
     asn1_type,
     common::{asn_tag, opt_parentheses, skip_ws_and_comments, value_reference},
-    constraint::constraint,
+    constraint::constraints,
     error::ParserResult,
 };
 
@@ -26,7 +26,7 @@ pub fn set_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
         pair(
             preceded(
                 skip_ws_and_comments(tag(SET)),
-                opt(opt_parentheses(constraint)),
+                opt(opt_parentheses(constraints)),
             ),
             preceded(
                 skip_ws_and_comments(pair(tag(OF), opt(skip_ws_and_comments(value_reference)))),
@@ -89,9 +89,9 @@ mod tests {
             ASN1Type::SetOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -117,9 +117,9 @@ mod tests {
             ASN1Type::SetOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -150,9 +150,9 @@ mod tests {
             ASN1Type::SetOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -161,8 +161,8 @@ mod tests {
                     extensible: false
                 })],
                 element_type: Box::new(ASN1Type::Integer(Integer {
-                    constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                        set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                    constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                        set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(13)),
                             extensible: true
@@ -191,9 +191,9 @@ mod tests {
             ASN1Type::SetOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(4)),
                             extensible: false

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -32,8 +32,8 @@ fn parses_toplevel_simple_integer_declaration() {
         assert!(!int.constraints.is_empty());
         assert_eq!(
             *int.constraints.first().unwrap(),
-            Constraint::SubtypeConstraint(ElementSet {
-                set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+            Constraint::Subtype(ElementSetSpecs {
+                set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                     min: Some(ASN1Value::Integer(1)),
                     max: Some(ASN1Value::Integer(8)),
                     extensible: false
@@ -70,8 +70,8 @@ fn parses_toplevel_macro_integer_declaration() {
     if let ASN1Type::Integer(int) = tld.ty {
         assert_eq!(
             *int.constraints.first().unwrap(),
-            Constraint::SubtypeConstraint(ElementSet {
-                set: ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+            Constraint::Subtype(ElementSetSpecs {
+                set: ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                     min: Some(ASN1Value::Integer(0)),
                     max: Some(ASN1Value::Integer(161)),
                     extensible: true
@@ -173,33 +173,33 @@ fn parses_toplevel_crossrefering_declaration() {
             ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                 parent: None,
                 identifier: "EventHistory".into(),
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
                     set: ElementOrSetOperation::SetOperation(SetOperation {
-                        base: SubtypeElement::SingleTypeConstraint(vec![
-                            Constraint::SubtypeConstraint(ElementSet {
+                        base: SubtypeElements::SingleTypeConstraint(vec![Constraint::Subtype(
+                            ElementSetSpecs {
                                 extensible: false,
                                 set: ElementOrSetOperation::Element(
-                                    SubtypeElement::MultipleTypeConstraints(InnerTypeConstraint {
+                                    SubtypeElements::MultipleTypeConstraints(InnerTypeConstraint {
                                         is_partial: true,
-                                        constraints: vec![ConstrainedComponent {
+                                        constraints: vec![NamedConstraint {
                                             identifier: "eventDeltaTime".into(),
                                             constraints: vec![],
                                             presence: ComponentPresence::Present
                                         }]
                                     })
                                 )
-                            })
-                        ]),
+                            }
+                        )]),
                         operator: SetOperator::Union,
                         operant: Box::new(ElementOrSetOperation::Element(
-                            SubtypeElement::SingleTypeConstraint(vec![
-                                Constraint::SubtypeConstraint(ElementSet {
+                            SubtypeElements::SingleTypeConstraint(vec![Constraint::Subtype(
+                                ElementSetSpecs {
                                     extensible: false,
                                     set: ElementOrSetOperation::Element(
-                                        SubtypeElement::MultipleTypeConstraints(
+                                        SubtypeElements::MultipleTypeConstraints(
                                             InnerTypeConstraint {
                                                 is_partial: true,
-                                                constraints: vec![ConstrainedComponent {
+                                                constraints: vec![NamedConstraint {
                                                     identifier: "eventDeltaTime".into(),
                                                     constraints: vec![],
                                                     presence: ComponentPresence::Absent
@@ -207,8 +207,8 @@ fn parses_toplevel_crossrefering_declaration() {
                                             }
                                         )
                                     )
-                                })
-                            ])
+                                }
+                            )])
                         ))
                     }),
                     extensible: false
@@ -238,9 +238,9 @@ fn parses_anonymous_sequence_of_declaration() {
             ty: ASN1Type::SequenceOf(SequenceOrSetOf {
                 element_tag: None,
                 is_recursive: false,
-                constraints: vec![Constraint::SubtypeConstraint(ElementSet {
-                    set: ElementOrSetOperation::Element(SubtypeElement::SizeConstraint(Box::new(
-                        ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+                constraints: vec![Constraint::Subtype(ElementSetSpecs {
+                    set: ElementOrSetOperation::Element(SubtypeElements::SizeConstraint(Box::new(
+                        ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                             min: Some(ASN1Value::Integer(1)),
                             max: Some(ASN1Value::Integer(16)),
                             extensible: false
@@ -434,7 +434,7 @@ fn parses_parameterized_declaration() {
                         ty: ASN1Type::ObjectClassField(ObjectClassFieldType {
                             class: "REG-EXT-ID-AND-TYPE".into(),
                             field_path: vec![ObjectFieldIdentifier::SingleValue("&id".into())],
-                            constraints: vec![Constraint::TableConstraint(TableConstraint {
+                            constraints: vec![Constraint::Table(TableConstraint {
                                 object_set: ObjectSet {
                                     values: vec![ObjectSetValue::Reference("Set".into())],
                                     extensible: None
@@ -453,7 +453,7 @@ fn parses_parameterized_declaration() {
                         ty: ASN1Type::ObjectClassField(ObjectClassFieldType {
                             class: "REG-EXT-ID-AND-TYPE".into(),
                             field_path: vec![ObjectFieldIdentifier::MultipleValue("&Type".into())],
-                            constraints: vec![Constraint::TableConstraint(TableConstraint {
+                            constraints: vec![Constraint::Table(TableConstraint {
                                 object_set: ObjectSet {
                                     values: vec![ObjectSetValue::Reference("Set".into())],
                                     extensible: None

--- a/rasn-compiler/src/lexer/time.rs
+++ b/rasn-compiler/src/lexer/time.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{
     common::skip_ws_and_comments,
-    constraint::constraint,
+    constraint::constraints,
     error::{MiscError, ParserResult},
     into_inner,
 };
@@ -31,7 +31,7 @@ pub fn time_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
 
 pub fn time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
-        skip_ws_and_comments(preceded(tag(TIME), opt(constraint))),
+        skip_ws_and_comments(preceded(tag(TIME), opt(constraints))),
         |t| ASN1Type::Time(t.into()),
     )
     .parse(input)
@@ -39,7 +39,7 @@ pub fn time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
 
 pub fn generalized_time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
-        skip_ws_and_comments(preceded(tag(GENERALIZED_TIME), opt(constraint))),
+        skip_ws_and_comments(preceded(tag(GENERALIZED_TIME), opt(constraints))),
         |cnst| {
             ASN1Type::GeneralizedTime(GeneralizedTime {
                 constraints: cnst.unwrap_or_default(),
@@ -51,7 +51,7 @@ pub fn generalized_time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
 
 pub fn utc_time(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
-        skip_ws_and_comments(preceded(tag(UTC_TIME), opt(constraint))),
+        skip_ws_and_comments(preceded(tag(UTC_TIME), opt(constraints))),
         |cnst| {
             ASN1Type::UTCTime(UTCTime {
                 constraints: cnst.unwrap_or_default(),

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -668,7 +668,7 @@ impl ASN1Type {
                 for m in &mut s.members {
                     if let Some(constraints) = m.ty.constraints_mut() {
                         for c in constraints {
-                            if let Constraint::TableConstraint(TableConstraint {
+                            if let Constraint::Table(TableConstraint {
                                 object_set: ObjectSet { values, .. },
                                 ..
                             }) = c

--- a/rasn-compiler/src/validator/mod.rs
+++ b/rasn-compiler/src/validator/mod.rs
@@ -446,8 +446,8 @@ impl Validate for CharacterString {
 
 impl Validate for Constraint {
     fn validate(&self) -> Result<(), LinkerError> {
-        if let Constraint::SubtypeConstraint(c) = self {
-            if let ElementOrSetOperation::Element(SubtypeElement::ValueRange {
+        if let Constraint::Subtype(c) = self {
+            if let ElementOrSetOperation::Element(SubtypeElements::ValueRange {
                 min,
                 max,
                 extensible: _,


### PR DESCRIPTION
Rename types/functions to better follow the specification, and add more comments. Most changes are related to constraints.