### PR TITLE
Support qualified type references

### DIFF
--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -103,10 +103,11 @@ impl Rasn {
         if let ASN1Type::ElsewhereDeclaredType(dec) = &tld.ty {
             let (name, mut annotations) = self.format_name_and_common_annotations(&tld)?;
             annotations.push(self.format_range_annotations(true, &dec.constraints)?);
+            let alias = self.to_rust_qualified_type(dec.module.as_deref(), &dec.identifier);
             Ok(typealias_template(
                 self.format_comments(&tld.comments)?,
                 name,
-                self.to_rust_title_case(&dec.identifier),
+                alias,
                 self.join_annotations(annotations, false, true)?,
             ))
         } else {
@@ -813,7 +814,9 @@ impl Rasn {
         }
         .unwrap_or_default();
         let member_type = match seq_or_set_of.element_type.as_ref() {
-            ASN1Type::ElsewhereDeclaredType(d) => self.to_rust_title_case(&d.identifier),
+            ASN1Type::ElsewhereDeclaredType(d) => {
+                self.to_rust_qualified_type(d.module.as_deref(), &d.identifier)
+            }
             _ => format_ident!("Anonymous{}", &name.to_string()).to_token_stream(),
         };
         let mut annotations = vec![

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -611,7 +611,7 @@ impl Rasn {
                 (s.constraints().clone(), quote!(SetOf<#inner_type>))
             }
             ASN1Type::ElsewhereDeclaredType(e) => {
-                let mut tokenized = self.to_rust_title_case(&e.identifier).to_token_stream();
+                let mut tokenized = self.to_rust_qualified_type(e.module.as_deref(), &e.identifier);
                 if is_recursive {
                     tokenized = boxed_type(tokenized);
                 };
@@ -741,7 +741,9 @@ impl Rasn {
                 NotYetInplemented,
                 "Set values are currently unsupported!"
             )),
-            ASN1Type::ElsewhereDeclaredType(e) => Ok(self.to_rust_title_case(&e.identifier)),
+            ASN1Type::ElsewhereDeclaredType(e) => {
+                Ok(self.to_rust_qualified_type(e.module.as_deref(), &e.identifier))
+            }
             ASN1Type::ObjectClassField(_) => Err(error!(
                 NotYetInplemented,
                 "Object class field types are currently unsupported!"
@@ -1258,6 +1260,21 @@ impl Rasn {
             input
         };
         TokenStream::from_str(&name).unwrap()
+    }
+
+    /// Generate a `TokenStream` containing a type identifier, optionally qualified by module.
+    ///
+    /// Module name is converted to snake case, and type name converted to title case.
+    ///
+    /// If qualified with a module, then path is `super::#module::#ty`, else it is just `#ty`.
+    pub(crate) fn to_rust_qualified_type(&self, module: Option<&str>, ty: &str) -> TokenStream {
+        let ty = self.to_rust_title_case(ty);
+        if let Some(module) = module {
+            let module = self.to_rust_snake_case(module).to_token_stream();
+            quote!(super::#module::#ty)
+        } else {
+            ty
+        }
     }
 
     pub(super) fn format_name_and_common_annotations(

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -907,6 +907,7 @@ impl ASN1Type {
 
     pub fn builtin_or_elsewhere(
         parent: Option<&str>,
+        module: Option<&str>,
         identifier: &str,
         constraints: Vec<Constraint>,
     ) -> ASN1Type {
@@ -972,7 +973,12 @@ impl ASN1Type {
                 constraints,
                 ty: CharacterStringType::NumericString,
             }),
-            _ => ASN1Type::ElsewhereDeclaredType((parent, identifier, Some(constraints)).into()),
+            _ => ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                parent: parent.map(str::to_string),
+                module: module.map(str::to_string),
+                identifier: identifier.to_string(),
+                constraints,
+            }),
         }
     }
 
@@ -1336,6 +1342,8 @@ impl ASN1Value {
 pub struct DeclarationElsewhere {
     /// Chain of parent declaration leading back to a basic ASN1 type
     pub parent: Option<String>,
+    /// Name of the module where the identifier should be found.
+    pub module: Option<String>,
     pub identifier: String,
     pub constraints: Vec<Constraint>,
 }
@@ -1344,6 +1352,7 @@ impl From<(Option<&str>, &str, Option<Vec<Constraint>>)> for DeclarationElsewher
     fn from(value: (Option<&str>, &str, Option<Vec<Constraint>>)) -> Self {
         DeclarationElsewhere {
             parent: value.0.map(ToString::to_string),
+            module: None,
             identifier: value.1.into(),
             constraints: value.2.unwrap_or_default(),
         }

--- a/rasn-compiler/src/lexer/choice.rs
+++ b/rasn-compiler/src/lexer/choice.rs
@@ -194,6 +194,7 @@ mod tests {
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "GeographicLocationContainer".into(),
                             constraints: vec![],
                         },),
@@ -205,6 +206,7 @@ mod tests {
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "AutomatedVehicleContainer".into(),
                             constraints: vec![],
                         },),
@@ -216,6 +218,7 @@ mod tests {
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "RoadSurfaceContainer".into(),
                             constraints: vec![],
                         },),
@@ -227,6 +230,7 @@ mod tests {
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "InfrastructureSupportContainer".into(),
                             constraints: vec![],
                         },),

--- a/rasn-compiler/src/lexer/constraint.rs
+++ b/rasn-compiler/src/lexer/constraint.rs
@@ -1188,16 +1188,19 @@ mod tests {
                         ObjectSetValue::Inline(InformationObjectFields::CustomSyntax(vec![
                             SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                                 parent: None,
+                                module: None,
                                 identifier: "ConnectionManeuverAssist-addGrpC".into(),
                                 constraints: vec![]
                             }),
                             SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                                 parent: None,
+                                module: None,
                                 identifier: "IDENTIFIED".into(),
                                 constraints: vec![]
                             }),
                             SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                                 parent: None,
+                                module: None,
                                 identifier: "BY".into(),
                                 constraints: vec![]
                             }),
@@ -1511,6 +1514,7 @@ mod tests {
                                     subtype: ASN1Type::ElsewhereDeclaredType(
                                         DeclarationElsewhere {
                                             parent: None,
+                                            module: None,
                                             identifier: "EtsiTs103097Certificate".into(),
                                             constraints: vec![],
                                         }

--- a/rasn-compiler/src/lexer/enumerated.rs
+++ b/rasn-compiler/src/lexer/enumerated.rs
@@ -346,6 +346,7 @@ mod tests {
                 name: String::from("enumeral-alias"),
                 associated_type: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: String::from("Test-Enum"),
                     constraints: vec![],
                 }),

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -120,6 +120,7 @@ pub fn instance_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
         |(id, constraints)| {
             ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                 parent: None,
+                module: None,
                 identifier: id.into(),
                 constraints,
             })
@@ -421,6 +422,7 @@ mod tests {
                         identifier: ObjectFieldIdentifier::MultipleValue("&Errors".into()),
                         ty: Some(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             constraints: vec![],
                             identifier: "ERROR".into()
                         })),
@@ -521,6 +523,7 @@ mod tests {
                         identifier: ObjectFieldIdentifier::SingleValue("&itsaidCtxRef".into()),
                         ty: Some(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "ItsAidCtxRef".into(),
                             constraints: vec![]
                         })),

--- a/rasn-compiler/src/lexer/macros.rs
+++ b/rasn-compiler/src/lexer/macros.rs
@@ -660,6 +660,7 @@ mod tests {
                                     local_value_reference: "vartype",
                                     ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                                         parent: None,
+                                        module: None,
                                         identifier: "ObjectName".to_string(),
                                         constraints: vec![]
                                     })
@@ -679,6 +680,7 @@ mod tests {
                                             ty: ASN1Type::ElsewhereDeclaredType(
                                                 DeclarationElsewhere {
                                                     parent: None,
+                                                    module: None,
                                                     identifier: "DisplayString".to_string(),
                                                     constraints: vec![]
                                                 }
@@ -702,6 +704,7 @@ mod tests {
                                             ty: ASN1Type::ElsewhereDeclaredType(
                                                 DeclarationElsewhere {
                                                     parent: None,
+                                                    module: None,
                                                     identifier: "DisplayString".to_string(),
                                                     constraints: vec![]
                                                 }

--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -12,7 +12,7 @@ use error::ParserResult;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_until},
-    character::complete::multispace1,
+    character::complete::{char, multispace1},
     combinator::{into, map, opt, recognize},
     multi::{many0, many1},
     sequence::{delimited, pair, preceded, terminated},
@@ -220,12 +220,17 @@ pub fn elsewhere_declared_type(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
                 identifier,
                 tag(".&"),
             ))))),
+            opt(skip_ws_and_comments(terminated(
+                module_reference,
+                skip_ws_and_comments(char(DOT)),
+            ))),
             skip_ws_and_comments(type_reference),
             opt(skip_ws_and_comments(constraints)),
         ),
-        |(parent, id, constraints)| {
+        |(parent, module, id, constraints)| {
             ASN1Type::builtin_or_elsewhere(
                 parent.map(|p| p.into_inner()),
+                module,
                 id,
                 constraints.unwrap_or_default(),
             )

--- a/rasn-compiler/src/lexer/sequence.rs
+++ b/rasn-compiler/src/lexer/sequence.rs
@@ -225,8 +225,11 @@ mod tests {
 is_recursive: false,
                     name: "clusterBoundingBoxShape".into(),
                     tag: None,
-                    ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere { parent: None,
-                        identifier: "Shape".into(), constraints: vec![Constraint::Subtype(ElementSetSpecs { set: ElementOrSetOperation::Element(SubtypeElements::MultipleTypeConstraints(InnerTypeConstraint { is_partial: true, constraints: vec![NamedConstraint { identifier: "elliptical".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radial".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radialShapes".into(), constraints: vec![], presence: ComponentPresence::Absent }] })), extensible: false })
+                    ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                        parent: None,
+                        module: None,
+                        identifier: "Shape".into(),
+                        constraints: vec![Constraint::Subtype(ElementSetSpecs { set: ElementOrSetOperation::Element(SubtypeElements::MultipleTypeConstraints(InnerTypeConstraint { is_partial: true, constraints: vec![NamedConstraint { identifier: "elliptical".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radial".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radialShapes".into(), constraints: vec![], presence: ComponentPresence::Absent }] })), extensible: false })
                      ]}),
                     default_value: None,
                     is_optional: true,
@@ -260,6 +263,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "AccelerationValue".into(),
                             constraints: vec![]
                         }),
@@ -274,6 +278,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "AccelerationConfidence".into(),
                             constraints: vec![]
                         }),
@@ -312,6 +317,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "CartesianCoordinateWithConfidence".into(),
                             constraints: vec![]
                         }),
@@ -325,6 +331,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "CartesianCoordinateWithConfidence".into(),
                             constraints: vec![]
                         }),
@@ -338,6 +345,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "CartesianCoordinateWithConfidence".into(),
                             constraints: vec![]
                         }),
@@ -376,6 +384,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "PosConfidenceEllipse".into(),
                             constraints: vec![]
                         }),
@@ -389,6 +398,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "DeltaAltitude".into(),
                             constraints: vec![]
                         }),
@@ -405,6 +415,7 @@ is_recursive: false,
                         tag: None,
                         ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "AltitudeConfidence".into(),
                             constraints: vec![]
                         }),
@@ -540,6 +551,7 @@ is_recursive: false,
                                 tag: None,
                                 ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                                     parent: None,
+                                    module: None,
                                     identifier: "Wow".into(),
                                     constraints: vec![]
                                 }),
@@ -747,6 +759,7 @@ is_recursive: false,
                     tag: None,
                     ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                         parent: None,
+                        module: None,
                         identifier: "TypeB".into(),
                         constraints: vec![]
                     }),
@@ -916,6 +929,37 @@ integrityCheckValue     ICV OPTIONAL
                     constraints: vec![],
                 },],
             },)
+        )
+    }
+
+    #[test]
+    fn sequence_with_qualified_symbols() {
+        let input = Input::from("SEQUENCE { name ETSI-Common-Types.Name }");
+
+        let (rest, output) = sequence(input).unwrap();
+        assert!(rest.inner().trim().is_empty());
+
+        assert_eq!(
+            output,
+            ASN1Type::Sequence(SequenceOrSet {
+                components_of: vec![],
+                extensible: None,
+                constraints: vec![],
+                members: vec![SequenceOrSetMember {
+                    name: "name".to_string(),
+                    tag: None,
+                    ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
+                        parent: None,
+                        module: Some("ETSI-Common-Types".to_string()),
+                        identifier: "Name".to_string(),
+                        constraints: vec![],
+                    }),
+                    default_value: None,
+                    is_optional: false,
+                    is_recursive: false,
+                    constraints: vec![],
+                }],
+            })
         )
     }
 }

--- a/rasn-compiler/src/lexer/sequence_of.rs
+++ b/rasn-compiler/src/lexer/sequence_of.rs
@@ -74,6 +74,7 @@ mod tests {
                 constraints: vec![],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "Things".into(),
                     constraints: vec![]
                 }))
@@ -102,6 +103,7 @@ mod tests {
                 })],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "CorrelationCellValue".into(),
                     constraints: vec![]
                 }))
@@ -130,6 +132,7 @@ mod tests {
                 })],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "CorrelationCellValue".into(),
                     constraints: vec![]
                 }))
@@ -204,6 +207,7 @@ mod tests {
                 })],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "RegionalExtension".into(),
                     constraints: vec![Constraint::Parameter(vec![Parameter::ObjectSetParameter(
                         ObjectSet {

--- a/rasn-compiler/src/lexer/set_of.rs
+++ b/rasn-compiler/src/lexer/set_of.rs
@@ -73,6 +73,7 @@ mod tests {
                 constraints: vec![],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "Things".into(),
                     constraints: vec![]
                 }))
@@ -101,6 +102,7 @@ mod tests {
                 })],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "CorrelationCellValue".into(),
                     constraints: vec![]
                 }))
@@ -129,6 +131,7 @@ mod tests {
                 })],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "CorrelationCellValue".into(),
                     constraints: vec![]
                 }))
@@ -203,6 +206,7 @@ mod tests {
                 })],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "RegionalExtension".into(),
                     constraints: vec![Constraint::Parameter(vec![Parameter::ObjectSetParameter(
                         ObjectSet {

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -172,6 +172,7 @@ fn parses_toplevel_crossrefering_declaration() {
             name: "EventZone".into(),
             ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                 parent: None,
+                module: None,
                 identifier: "EventHistory".into(),
                 constraints: vec![Constraint::Subtype(ElementSetSpecs {
                     set: ElementOrSetOperation::SetOperation(SetOperation {
@@ -250,6 +251,7 @@ fn parses_anonymous_sequence_of_declaration() {
                 })],
                 element_type: Box::new(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "InterferenceManagementZone".into(),
                     constraints: vec![]
                 }))
@@ -285,16 +287,19 @@ fn parses_object_set_value() {
                     ObjectSetValue::Inline(InformationObjectFields::CustomSyntax(vec![
                         SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "OriginatingVehicleContainer".into(),
                             constraints: vec![]
                         }),
                         SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "IDENTIFIED".into(),
                             constraints: vec![]
                         }),
                         SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "BY".into(),
                             constraints: vec![]
                         }),
@@ -306,16 +311,19 @@ fn parses_object_set_value() {
                     ObjectSetValue::Inline(InformationObjectFields::CustomSyntax(vec![
                         SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "PerceivedObjectContainer".into(),
                             constraints: vec![]
                         }),
                         SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "IDENTIFIED".into(),
                             constraints: vec![]
                         }),
                         SyntaxApplication::LiteralOrTypeReference(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "BY".into(),
                             constraints: vec![]
                         }),
@@ -376,6 +384,7 @@ fn parses_class_declaration() {
                         identifier: ObjectFieldIdentifier::SingleValue("&id".into()),
                         ty: Some(ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                             parent: None,
+                            module: None,
                             identifier: "RegionId".into(),
                             constraints: vec![]
                         })),

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -1630,6 +1630,7 @@ mod tests {
                     "IntermediateBool",
                     ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                         parent: None,
+                        module: None,
                         identifier: String::from("RootBool"),
                         constraints: vec![]
                     })
@@ -1649,6 +1650,7 @@ mod tests {
                             tag: None,
                             ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                                 parent: None,
+                                module: None,
                                 identifier: String::from("IntermediateBool"),
                                 constraints: vec![]
                             })
@@ -1664,6 +1666,7 @@ mod tests {
             parameterization: None,
             associated_type: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                 parent: None,
+                module: None,
                 identifier: "BaseChoice".into(),
                 constraints: vec![],
             }),
@@ -1682,6 +1685,7 @@ mod tests {
                 name: "exampleValue".into(),
                 associated_type: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere {
                     parent: None,
+                    module: None,
                     identifier: "BaseChoice".into(),
                     constraints: vec![]
                 }),


### PR DESCRIPTION
Add support for having type references qualified with module.

That is, partially support the following syntax:

```asn1
MainModule DEFINITIONS ::= BEGIN

IMPORTS
  Name FROM ETSI-Common-Types
    { itu-t(0) identified-organization(4) etsi(0) common-parameters(3280) version241(241) }

  Name FROM Vendor-Types
    { iso(1) org(3) dod(6) internet(1) private(4) enterprise(1) 99999 42 };

-- Naming collision is resolved by module prefix
ServiceA ::= SEQUENCE {
  name ETSI-Common-Types.Name
}

ServiceB ::= SEQUENCE {
  name Vendor-Types.Name
}

END
```

That generates:

```rust
#[allow(
    non_camel_case_types,
    non_snake_case,
    non_upper_case_globals,
    unused,
    clippy::too_many_arguments
)]
pub mod main_module {
    extern crate alloc;
    use super::etsi_common_types::Name;
    use super::vendor_types::Name;
    use core::borrow::Borrow;
    use rasn::prelude::*;
    use std::sync::LazyLock;
    #[doc = " Naming collision is resolved by module prefix"]
    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
    pub struct ServiceA {
        pub name: super::etsi_common_types::Name,
    }
    impl ServiceA {
        pub fn new(name: super::etsi_common_types::Name) -> Self {
            Self { name }
        }
    }
    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
    pub struct ServiceB {
        pub name: super::vendor_types::Name,
    }
    impl ServiceB {
        pub fn new(name: super::vendor_types::Name) -> Self {
            Self { name }
        }
    }
}
```

Partially fixes Github issue #110. It is still not possible to have the same name in multiple modules since they are not namespaced internally.