### PR TITLE
Remove indexes for ToplevelDefinitions

### DIFF
--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -807,7 +807,7 @@ impl Rasn {
                     name: String::from(INNER_ARRAY_LIKE_PREFIX) + &name.to_string(),
                     ty: n.clone(),
                     tag: None,
-                    index: None,
+                    module_header: None,
                 }))?,
             ),
         }

--- a/rasn-compiler/src/generator/rasn/mod.rs
+++ b/rasn-compiler/src/generator/rasn/mod.rs
@@ -137,7 +137,7 @@ impl Backend for Rasn {
         &mut self,
         tlds: Vec<ToplevelDefinition>,
     ) -> Result<GeneratedModule, GeneratorError> {
-        if let Some((module_ref, _)) = tlds.first().and_then(|tld| tld.get_index().cloned()) {
+        if let Some(module_ref) = tlds.first().and_then(|tld| tld.get_module_header()) {
             let module = module_ref.borrow();
             self.tagging_environment = module.tagging_environment;
             self.extensibility_environment = module.extensibility_environment;

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -344,7 +344,7 @@ impl Rasn {
                             name: self.inner_name(&m.name, parent_name).to_string(),
                             ty: m.ty.clone(),
                             tag: None,
-                            index: None,
+                            module_header: None,
                         })),
                     )
                     .transpose()
@@ -437,7 +437,7 @@ impl Rasn {
                             name: self.inner_name(&o.name, parent_name).to_string(),
                             ty: o.ty.clone(),
                             tag: None,
-                            index: None,
+                            module_header: None,
                         })),
                     )
                     .transpose()

--- a/rasn-compiler/src/generator/typescript/mod.rs
+++ b/rasn-compiler/src/generator/typescript/mod.rs
@@ -43,7 +43,7 @@ impl Backend for Typescript {
         &mut self,
         tlds: Vec<ToplevelDefinition>,
     ) -> Result<GeneratedModule, GeneratorError> {
-        if let Some((module_ref, _)) = tlds.first().and_then(|tld| tld.get_index().cloned()) {
+        if let Some(module_ref) = tlds.first().and_then(|tld| tld.get_module_header()) {
             let module = module_ref.borrow();
             let namespace = to_jer_identifier(&module.name);
             let imports = module

--- a/rasn-compiler/src/intermediate/information_object.rs
+++ b/rasn-compiler/src/intermediate/information_object.rs
@@ -16,7 +16,7 @@ pub struct ObjectClassAssignment {
     pub name: String,
     pub parameterization: Parameterization,
     pub definition: ObjectClassDefn,
-    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
+    pub module_header: Option<Rc<RefCell<ModuleHeader>>>,
 }
 
 impl ObjectClassAssignment {
@@ -32,7 +32,7 @@ pub struct ToplevelInformationDefinition {
     pub parameterization: Option<Parameterization>,
     pub class: ClassLink,
     pub value: ASN1Information,
-    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
+    pub module_header: Option<Rc<RefCell<ModuleHeader>>>,
 }
 
 impl From<(&str, ASN1Information, &str)> for ToplevelInformationDefinition {
@@ -43,7 +43,7 @@ impl From<(&str, ASN1Information, &str)> for ToplevelInformationDefinition {
             parameterization: None,
             class: ClassLink::ByName(value.2.to_owned()),
             value: value.1,
-            index: None,
+            module_header: None,
         }
     }
 }
@@ -89,7 +89,7 @@ impl
                 class_name: value.3.into(),
                 fields: value.4,
             }),
-            index: None,
+            module_header: None,
         }
     }
 }
@@ -104,7 +104,7 @@ impl From<(Vec<&str>, &str, Option<Parameterization>, &str, ObjectSet)>
             parameterization: value.2,
             class: ClassLink::ByName(value.3.into()),
             value: ASN1Information::ObjectSet(value.4),
-            index: None,
+            module_header: None,
         }
     }
 }

--- a/rasn-compiler/src/intermediate/macros.rs
+++ b/rasn-compiler/src/intermediate/macros.rs
@@ -7,14 +7,14 @@ use crate::lexer::macros::MacroDefinition;
 #[derive(Debug, Clone, PartialEq)]
 pub struct ToplevelMacroDefinition {
     pub name: String,
-    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
+    pub module_header: Option<Rc<RefCell<ModuleHeader>>>,
 }
 
 impl From<MacroDefinition<'_>> for ToplevelMacroDefinition {
     fn from(macro_def: MacroDefinition<'_>) -> Self {
         ToplevelMacroDefinition {
             name: macro_def.name.to_string(),
-            index: None,
+            module_header: None,
         }
     }
 }

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -588,43 +588,33 @@ impl ToplevelDefinition {
         }
     }
 
-    pub(crate) fn set_index(&mut self, module_header: Rc<RefCell<ModuleHeader>>, item_no: usize) {
+    pub(crate) fn set_module_header(&mut self, module_header: Rc<RefCell<ModuleHeader>>) {
         match self {
             ToplevelDefinition::Type(ref mut t) => {
-                t.index = Some((module_header, item_no));
+                t.module_header = Some(module_header);
             }
             ToplevelDefinition::Value(ref mut v) => {
-                v.index = Some((module_header, item_no));
+                v.module_header = Some(module_header);
             }
             ToplevelDefinition::Class(ref mut c) => {
-                c.index = Some((module_header, item_no));
+                c.module_header = Some(module_header);
             }
             ToplevelDefinition::Object(ref mut o) => {
-                o.index = Some((module_header, item_no));
+                o.module_header = Some(module_header);
             }
             ToplevelDefinition::Macro(ref mut m) => {
-                m.index = Some((module_header, item_no));
+                m.module_header = Some(module_header);
             }
-        }
-    }
-
-    pub(crate) fn get_index(&self) -> Option<&(Rc<RefCell<ModuleHeader>>, usize)> {
-        match self {
-            ToplevelDefinition::Type(ref t) => t.index.as_ref(),
-            ToplevelDefinition::Value(ref v) => v.index.as_ref(),
-            ToplevelDefinition::Class(ref c) => c.index.as_ref(),
-            ToplevelDefinition::Object(ref o) => o.index.as_ref(),
-            ToplevelDefinition::Macro(ref m) => m.index.as_ref(),
         }
     }
 
     pub(crate) fn get_module_header(&self) -> Option<Rc<RefCell<ModuleHeader>>> {
         match self {
-            ToplevelDefinition::Type(ref t) => t.index.as_ref().map(|(m, _)| m.clone()),
-            ToplevelDefinition::Value(ref v) => v.index.as_ref().map(|(m, _)| m.clone()),
-            ToplevelDefinition::Class(ref c) => c.index.as_ref().map(|(m, _)| m.clone()),
-            ToplevelDefinition::Object(ref o) => o.index.as_ref().map(|(m, _)| m.clone()),
-            ToplevelDefinition::Macro(ref m) => m.index.as_ref().map(|(m, _)| m.clone()),
+            ToplevelDefinition::Type(ref t) => t.module_header.as_ref().cloned(),
+            ToplevelDefinition::Value(ref v) => v.module_header.as_ref().cloned(),
+            ToplevelDefinition::Class(ref c) => c.module_header.as_ref().cloned(),
+            ToplevelDefinition::Object(ref o) => o.module_header.as_ref().cloned(),
+            ToplevelDefinition::Macro(ref m) => m.module_header.as_ref().cloned(),
         }
     }
 
@@ -696,7 +686,7 @@ pub struct ToplevelValueDefinition {
     pub associated_type: ASN1Type,
     pub parameterization: Option<Parameterization>,
     pub value: ASN1Value,
-    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
+    pub module_header: Option<Rc<RefCell<ModuleHeader>>>,
 }
 
 impl From<(&str, ASN1Value, ASN1Type)> for ToplevelValueDefinition {
@@ -707,7 +697,7 @@ impl From<(&str, ASN1Value, ASN1Type)> for ToplevelValueDefinition {
             associated_type: value.2.to_owned(),
             parameterization: None,
             value: value.1,
-            index: None,
+            module_header: None,
         }
     }
 }
@@ -736,7 +726,7 @@ impl
             parameterization: value.2,
             associated_type: value.3,
             value: value.4,
-            index: None,
+            module_header: None,
         }
     }
 }
@@ -748,7 +738,7 @@ pub struct ToplevelTypeDefinition {
     pub name: String,
     pub ty: ASN1Type,
     pub parameterization: Option<Parameterization>,
-    pub index: Option<(Rc<RefCell<ModuleHeader>>, usize)>,
+    pub module_header: Option<Rc<RefCell<ModuleHeader>>>,
 }
 
 impl ToplevelTypeDefinition {
@@ -765,7 +755,7 @@ impl From<(&str, ASN1Type)> for ToplevelTypeDefinition {
             name: value.0.to_owned(),
             ty: value.1,
             parameterization: None,
-            index: None,
+            module_header: None,
         }
     }
 }
@@ -792,7 +782,7 @@ impl
             parameterization: value.2,
             ty: value.3 .1,
             tag: value.3 .0,
-            index: None,
+            module_header: None,
         }
     }
 }

--- a/rasn-compiler/src/lexer/enumerated.rs
+++ b/rasn-compiler/src/lexer/enumerated.rs
@@ -43,7 +43,7 @@ pub fn enumerated_value(input: Input<'_>) -> ParserResult<'_, ToplevelValueDefin
                 enumerated: p.as_str().into_owned(),
                 enumerable: e.to_string(),
             },
-            index: None,
+            module_header: None,
         },
     )
     .parse(input)
@@ -354,7 +354,7 @@ mod tests {
                     enumerated: String::from("Test-Enum"),
                     enumerable: String::from("enumeral")
                 },
-                index: None
+                module_header: None
             }
         )
     }

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -55,7 +55,7 @@ pub fn object_class_assignement(input: Input<'_>) -> ParserResult<'_, ObjectClas
             name: v.1.into(),
             parameterization: v.2.unwrap_or_default(),
             definition: v.3,
-            index: None,
+            module_header: None,
         },
     )
     .parse(input)
@@ -582,7 +582,7 @@ mod tests {
                     constraints: vec![]
                 }),
                 parameterization: None,
-                index: None
+                module_header: None
             }
         )
     }

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -215,7 +215,7 @@ fn parses_toplevel_crossrefering_declaration() {
                 })]
             }),
             tag: None,
-            index: None
+            module_header: None
         }
     );
 }
@@ -255,7 +255,7 @@ fn parses_anonymous_sequence_of_declaration() {
                 }))
             }),
             tag: None,
-            index: None
+            module_header: None
         }
     );
 }
@@ -277,7 +277,7 @@ fn parses_object_set_value() {
         ToplevelInformationDefinition {
             comments: "comments".into(),
             name: "CpmContainers".into(),
-            index: None,
+            module_header: None,
             parameterization: None,
             class: ClassLink::ByName("CPM-CONTAINER-ID-AND-TYPE".into()),
             value: ASN1Information::ObjectSet(ObjectSet {
@@ -341,7 +341,7 @@ fn parses_empty_extensible_object_set() {
         .1,
         ToplevelInformationDefinition {
             comments: "".into(),
-            index: None,
+            module_header: None,
             parameterization: None,
             name: "Reg-AdvisorySpeed".into(),
             class: ClassLink::ByName("REG-EXT-ID-AND-TYPE".into()),
@@ -368,7 +368,7 @@ fn parses_class_declaration() {
         ObjectClassAssignment {
             comments: "".into(),
             name: "REG-EXT-ID-AND-TYPE".into(),
-            index: None,
+            module_header: None,
             parameterization: Parameterization::default(),
             definition: ObjectClassDefn {
                 fields: vec![
@@ -420,7 +420,7 @@ fn parses_parameterized_declaration() {
         .1,
         ToplevelTypeDefinition {
             comments: "".into(),
-            index: None,
+            module_header: None,
             name: "RegionalExtension".into(),
             ty: ASN1Type::Sequence(SequenceOrSet {
                 extensible: None,
@@ -496,7 +496,7 @@ fn parses_choice() {
         .1,
         ToplevelTypeDefinition {
             comments: "".into(),
-            index: None,
+            module_header: None,
             name: "Choice-example".into(),
             ty: ASN1Type::Choice(Choice {
                 extensible: Some(2),
@@ -552,7 +552,7 @@ fn parses_sequence_of_value() {
                 (None, Box::new(ASN1Value::Integer(2))),
                 (None, Box::new(ASN1Value::Integer(3)))
             ]),
-            index: None
+            module_header: None
         },
         top_level_value_declaration(r#"test-Sequence SEQUENCE OF INTEGER ::= { 1, 2, 3 }"#.into())
             .unwrap()

--- a/rasn-compiler/src/lib.rs
+++ b/rasn-compiler/src/lib.rs
@@ -405,9 +405,9 @@ impl<B: Backend> Compiler<B, CompilerSourcesSet> {
                     .into_iter()
                     .flat_map(|(header, tlds)| {
                         let header_ref = Rc::new(RefCell::new(header));
-                        tlds.into_iter().enumerate().map(move |(index, mut tld)| {
+                        tlds.into_iter().map(move |mut tld| {
                             tld.apply_tagging_environment(&header_ref.borrow().tagging_environment);
-                            tld.set_index(header_ref.clone(), index);
+                            tld.set_module_header(header_ref.clone());
                             tld
                         })
                     })
@@ -419,8 +419,8 @@ impl<B: Backend> Compiler<B, CompilerSourcesSet> {
             BTreeMap::<String, Vec<ToplevelDefinition>>::new(),
             |mut modules, tld| {
                 let key = tld
-                    .get_index()
-                    .map_or(<_>::default(), |(module, _)| module.borrow().name.clone());
+                    .get_module_header()
+                    .map_or(<_>::default(), |module| module.borrow().name.clone());
                 match modules.entry(key) {
                     std::collections::btree_map::Entry::Vacant(v) => {
                         v.insert(vec![tld]);

--- a/rasn-compiler/src/tests.rs
+++ b/rasn-compiler/src/tests.rs
@@ -151,9 +151,9 @@ fn validator_io(literal: &str) -> (String, String) {
         .into_iter()
         .flat_map(|(header, tlds)| {
             let header_ref = Rc::new(RefCell::new(header));
-            tlds.into_iter().enumerate().map(move |(index, mut tld)| {
+            tlds.into_iter().map(move |mut tld| {
                 tld.apply_tagging_environment(&header_ref.borrow().tagging_environment);
-                tld.set_index(header_ref.clone(), index);
+                tld.set_module_header(header_ref.clone());
                 tld
             })
         })

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -1603,7 +1603,7 @@ mod tests {
             ToplevelTypeDefinition {
                 comments: String::new(),
                 tag: None,
-                index: None,
+                module_header: None,
                 name: $name.into(),
                 ty: $ty,
                 parameterization: None,
@@ -1667,7 +1667,7 @@ mod tests {
                 identifier: "BaseChoice".into(),
                 constraints: vec![],
             }),
-            index: None,
+            module_header: None,
             value: ASN1Value::Choice {
                 type_name: None,
                 variant_name: "first".into(),
@@ -1694,7 +1694,7 @@ mod tests {
                         value: Box::new(ASN1Value::Boolean(true))
                     })
                 },
-                index: None
+                module_header: None
             }
         )
     }

--- a/rasn-compiler/src/validator/mod.rs
+++ b/rasn-compiler/src/validator/mod.rs
@@ -250,7 +250,7 @@ impl Validator {
         if let Some(ToplevelDefinition::Type(ToplevelTypeDefinition {
             name,
             parameterization,
-            index: Some((m_hdr, _)),
+            module_header: Some(m_hdr),
             ..
         })) = self.tlds.get(associated_type)
         {


### PR DESCRIPTION
Only the first tuple member, `ModuleHeader`, is actually used. The second member, `usize`, is unused.

So rename `ToplevelXxxDefinitions::index` field to `module_header` and only store that.