### PR TITLE
feat(rasn-generator): impl Default for SEQUENCE

### DIFF
--- a/rasn-compiler-tests/tests/edge_cases.rs
+++ b/rasn-compiler-tests/tests/edge_cases.rs
@@ -136,6 +136,14 @@ e2e_pdu!(
                 Self { int, r_enum }
             }
         }
+        impl std::default::Default for Test {
+            fn default() -> Self {
+                Self {
+                    int: test_int_default(),
+                    r_enum: test_r_enum_default(),
+                }
+            }
+        }
         fn test_int_default() -> IntWithDefault {
             IntWithDefault(1)
         }

--- a/rasn-compiler-tests/tests/parameterization.rs
+++ b/rasn-compiler-tests/tests/parameterization.rs
@@ -320,6 +320,12 @@ r#"
                     Self {} 
                 }
             }
+
+            impl std::default::Default for LocationMeasurementIndicationIEsNonCriticalExtension {
+                fn default() -> Self {
+                    Self {}
+                }
+            }
             
             #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
             #[rasn(automatic_tags, identifier = "LocationMeasurementIndication-IEs")]

--- a/rasn-compiler-tests/tests/structured_types.rs
+++ b/rasn-compiler-tests/tests/structured_types.rs
@@ -255,6 +255,14 @@ e2e_pdu!(
                 Self { color }
             }
         }
+
+        impl std::default::Default for TestParameters {
+            fn default() -> Self {
+                Self {
+                    color: test_parameters_color_default(),
+                }
+            }
+        }
         
         fn test_parameters_color_default() -> Color {
             Color([false, true, false].into_iter().collect())
@@ -301,6 +309,14 @@ e2e_pdu!(
         impl TestParameters {
             pub fn new(color: Color) -> Self {
                 Self { color }
+            }
+        }
+
+        impl std::default::Default for TestParameters {
+            fn default() -> Self {
+                Self {
+                    color: test_parameters_color_default(),
+                }
             }
         }
         

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -777,6 +777,7 @@ impl Rasn {
                     self.join_annotations(annotations, false, true)?,
                     self.format_default_methods(&seq.members, &name.to_string())?,
                     self.format_new_impl(&name, formatted_members.name_types),
+                    self.format_default_impl(&tld.name, &seq.members),
                     class_fields,
                 ))
             }

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -8,6 +8,7 @@ use crate::intermediate::{
         ASN1Information, ClassLink, InformationObjectFields, ObjectClassDefn, ObjectSetValue,
         ToplevelInformationDefinition,
     },
+    types::Optionality,
     ASN1Type, ASN1Value, CharacterStringType, ToplevelDefinition, ToplevelTypeDefinition,
     ToplevelValueDefinition,
 };
@@ -732,7 +733,11 @@ impl Rasn {
                                     _ => todo!()
                                 };
                                 let field_enum_name = format_ident!("{obj_set_name}_{field_name}");
-                                let input = m.is_optional.then(|| quote!(self. #open_field_name .as_ref())).unwrap_or(quote!(Some(&self. #open_field_name)));
+                                let input = if m.optionality == Optionality::Required {
+                                    quote!(Some(&self. #open_field_name))
+                                } else {
+                                    quote!(self. #open_field_name .as_ref())
+                                };
                                 acc.append_all(quote! {
 
                                     impl #name {

--- a/rasn-compiler/src/generator/rasn/template.rs
+++ b/rasn-compiler/src/generator/rasn/template.rs
@@ -256,6 +256,7 @@ pub fn sequence_or_set_template(
     annotations: TokenStream,
     default_methods: TokenStream,
     new_impl: TokenStream,
+    default_impl: TokenStream,
     class_fields: TokenStream,
 ) -> TokenStream {
     quote! {
@@ -268,6 +269,8 @@ pub fn sequence_or_set_template(
         }
 
         #new_impl
+
+        #default_impl
 
         #class_fields
 

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -2,7 +2,7 @@ use std::{ops::Not, str::FromStr};
 
 use proc_macro2::{Ident, Literal, Punct, Spacing, Span, TokenStream};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
-use types::{BitString, OctetString};
+use types::{BitString, OctetString, Optionality};
 use utils::types::SequenceOrSetOf;
 
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
         encoding_rules::per_visible::{
             per_visible_range_constraints, CharsetSubset, PerVisibleAlphabetConstraints,
         },
-        information_object::{InformationObjectField, ObjectClassDefn, Optionality},
+        information_object::{InformationObjectField, ObjectClassDefn},
         types::{Choice, ChoiceOption, Enumerated, SequenceOrSet, SequenceOrSetMember},
         ASN1Type, ASN1Value, AsnTag, CharacterStringType, IntegerType, TagClass,
         TaggingEnvironment, ToplevelDefinition, ToplevelTypeDefinition,

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -384,8 +384,8 @@ impl Rasn {
     ) -> Result<(TokenStream, NameType), GeneratorError> {
         let name = self.to_rust_snake_case(&member.name);
         let default_annotation = member
-            .default_value
-            .as_ref()
+            .optionality
+            .default()
             .map(|_| {
                 let default_fn = self.default_method_name(parent_name, &member.name);
                 quote!(default = #default_fn)
@@ -401,7 +401,7 @@ impl Rasn {
             extension_annotation,
             Some(default_annotation),
         )?;
-        if (member.is_optional && member.default_value.is_none())
+        if (member.optionality == Optionality::Optional)
             || member
                 .name
                 .starts_with(INTERNAL_EXTENSION_GROUP_NAME_PREFIX)
@@ -690,7 +690,7 @@ impl Rasn {
     ) -> Result<TokenStream, GeneratorError> {
         let mut output = TokenStream::new();
         for member in members {
-            if let Some(value) = member.default_value.as_ref() {
+            if let Some(value) = member.optionality.default() {
                 let val = self.value_to_tokens(
                     value,
                     Some(&self.to_rust_title_case(&self.type_to_tokens(&member.ty)?.to_string())),
@@ -1489,8 +1489,7 @@ mod tests {
                                 ty: ASN1Type::Boolean(Boolean {
                                     constraints: vec![]
                                 }),
-                                default_value: None,
-                                is_optional: true,
+                                optionality: Optionality::Optional,
                                 constraints: vec![]
                             },
                             SequenceOrSetMember {
@@ -1509,8 +1508,7 @@ mod tests {
                             )
                         })]
                                 }),
-                                default_value: Some(ASN1Value::Integer(4)),
-                                is_optional: true,
+                                optionality: Optionality::Default(ASN1Value::Integer(4)),
                                 constraints: vec![]
                             }
                         ]

--- a/rasn-compiler/src/generator/typescript/utils.rs
+++ b/rasn-compiler/src/generator/typescript/utils.rs
@@ -3,7 +3,7 @@ use num::pow::Pow;
 use crate::generator::error::GeneratorError;
 
 use super::{
-    types::{BitString, Choice, SequenceOrSet},
+    types::{BitString, Choice, Optionality, SequenceOrSet},
     ASN1Type, ASN1Value,
 };
 
@@ -67,7 +67,11 @@ pub fn format_sequence_or_set_members(se: &SequenceOrSet) -> String {
             .map(|m| format!(
                 r#"{}{}: {},"#,
                 to_jer_identifier(&m.name),
-                if m.is_optional { "?" } else { "" },
+                if m.optionality != Optionality::Required {
+                    "?"
+                } else {
+                    ""
+                },
                 type_to_tokens(&m.ty)
             ))
             .collect::<Vec<_>>()

--- a/rasn-compiler/src/intermediate/information_object.rs
+++ b/rasn-compiler/src/intermediate/information_object.rs
@@ -349,17 +349,6 @@ pub struct InformationObjectClassField {
     pub is_unique: bool,
 }
 
-/// Defines the optionality of a class field.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Optionality<T> {
-    /// All definitions are required to specify this field.
-    Required,
-    /// The field can be left undefined.
-    Optional,
-    /// Default if the field is omitted.
-    Default(T),
-}
-
 impl
     From<(
         ObjectFieldIdentifier,

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -484,8 +484,7 @@ pub enum SequenceComponent {
 ///         ],
 ///         distinguished_values: None,
 ///     }),
-///     default_value: Some(ASN1Value::Integer(1)),
-///     is_optional: true,
+///     optionality: Optionality::Default(ASN1Value::Integer(1)),
 ///     constraints: vec![]
 /// }
 /// # ;
@@ -495,8 +494,7 @@ pub struct SequenceOrSetMember {
     pub name: String,
     pub tag: Option<AsnTag>,
     pub ty: ASN1Type,
-    pub default_value: Option<ASN1Value>,
-    pub is_optional: bool,
+    pub optionality: Optionality<ASN1Value>,
     pub is_recursive: bool,
     pub constraints: Vec<Constraint>,
 }
@@ -531,8 +529,7 @@ impl
         Option<AsnTag>,
         ASN1Type,
         Option<Vec<Constraint>>,
-        Option<OptionalMarker>,
-        Option<ASN1Value>,
+        Optionality<ASN1Value>,
     )> for SequenceOrSetMember
 {
     fn from(
@@ -541,16 +538,14 @@ impl
             Option<AsnTag>,
             ASN1Type,
             Option<Vec<Constraint>>,
-            Option<OptionalMarker>,
-            Option<ASN1Value>,
+            Optionality<ASN1Value>,
         ),
     ) -> Self {
         SequenceOrSetMember {
             name: value.0.into(),
             tag: value.1,
             ty: value.2,
-            is_optional: value.4.is_some() || value.5.is_some(),
-            default_value: value.5,
+            optionality: value.4,
             is_recursive: false,
             constraints: value.3.unwrap_or_default(),
         }

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -9,6 +9,35 @@ use crate::Backend;
 
 use super::{constraints::*, *};
 
+/// Defines the optionality of a field.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Optionality<T> {
+    /// All definitions are required to specify this field.
+    Required,
+    /// The field can be left undefined.
+    Optional,
+    /// Default if the field is omitted.
+    Default(T),
+}
+
+impl<T> Optionality<T> {
+    /// Get a reference to the default `T`, or None if there is no default.
+    pub fn default(&self) -> Option<&T> {
+        match self {
+            Optionality::Required | Optionality::Optional => None,
+            Optionality::Default(d) => Some(d),
+        }
+    }
+
+    /// Get a mutable reference to the default `T`, or None if there is no default.
+    pub fn default_mut(&mut self) -> Option<&mut T> {
+        match self {
+            Optionality::Required | Optionality::Optional => None,
+            Optionality::Default(d) => Some(d),
+        }
+    }
+}
+
 /// Trait shared by ASN1 `SET`, `SEQUENCE`, AND `CHOICE` that allows iterating
 /// over their field types.
 pub trait IterNameTypes {

--- a/rasn-compiler/src/lexer/common.rs
+++ b/rasn-compiler/src/lexer/common.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 
 use super::{
-    asn1_value,
     error::{MiscError, ParserResult},
     util::{map_into, opt_delimited, take_until_or, take_until_unbalanced},
 };
@@ -277,18 +276,6 @@ pub fn optional_comma(input: Input<'_>) -> ParserResult<'_, Option<char>> {
     skip_ws_and_comments(opt(char(COMMA))).parse(input)
 }
 
-pub fn optional_marker(input: Input<'_>) -> ParserResult<'_, Option<OptionalMarker>> {
-    opt(into(into_inner(skip_ws_and_comments(tag(OPTIONAL))))).parse(input)
-}
-
-pub fn default(input: Input<'_>) -> ParserResult<'_, Option<ASN1Value>> {
-    opt(preceded(
-        skip_ws_and_comments(tag(DEFAULT)),
-        skip_ws_and_comments(asn1_value),
-    ))
-    .parse(input)
-}
-
 pub fn uppercase_identifier(input: Input<'_>) -> ParserResult<'_, &str> {
     alt((
         into_inner(recognize(pair(
@@ -333,6 +320,8 @@ where
 
 #[cfg(test)]
 mod tests {
+
+    use crate::lexer::asn1_value;
 
     use super::*;
 

--- a/rasn-compiler/src/lexer/common.rs
+++ b/rasn-compiler/src/lexer/common.rs
@@ -4,7 +4,7 @@ use nom::{
     character::complete::{
         alpha1, alphanumeric1, char, i128, multispace0, multispace1, one_of, u64,
     },
-    combinator::{into, map, map_res, opt, peek, recognize, rest, value},
+    combinator::{cut, into, map, map_res, opt, peek, recognize, rest, success, value},
     multi::{many0, many1},
     sequence::{delimited, pair, preceded, terminated},
     Parser,
@@ -306,6 +306,31 @@ pub fn uppercase_identifier(input: Input<'_>) -> ParserResult<'_, &str> {
     .parse(input)
 }
 
+/// Parse the "optionality" of a field.
+///
+/// When optionality is DEFAULT, the argument `f` is used to parse the value.
+///
+/// # Syntax
+/// ```text
+/// OptionalitySpec ::= OPTIONAL | DEFAULT <f> | empty
+/// ```
+pub fn optionality<'a, F>(
+    f: F,
+) -> impl Parser<Input<'a>, Output = Optionality<F::Output>, Error = F::Error>
+where
+    F: Parser<Input<'a>, Error = ErrorTree<'a>>,
+    F::Output: Clone,
+{
+    alt((
+        value(Optionality::Optional, tag(OPTIONAL)),
+        preceded(
+            tag(DEFAULT),
+            cut(skip_ws_and_comments(f.map(Optionality::Default))),
+        ),
+        success(Optionality::Required),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -538,5 +563,74 @@ and one */"#
             line_comment(r#"-- LdapSystemSchema"#.into()).unwrap().1,
             " LdapSystemSchema"
         )
+    }
+
+    #[test]
+    fn parses_default_int() {
+        assert_eq!(
+            optionality(asn1_value)
+                .parse("DEFAULT\t-1".into())
+                .unwrap()
+                .1,
+            Optionality::Default(ASN1Value::Integer(-1))
+        );
+    }
+
+    #[test]
+    fn parses_default_boolean() {
+        assert_eq!(
+            optionality(asn1_value)
+                .parse("DEFAULT   TRUE".into())
+                .unwrap()
+                .1,
+            Optionality::Default(ASN1Value::Boolean(true))
+        );
+    }
+
+    #[test]
+    fn parses_default_bitstring() {
+        assert_eq!(
+            optionality(asn1_value)
+                .parse("DEFAULT '001010011'B".into())
+                .unwrap()
+                .1,
+            Optionality::Default(ASN1Value::BitString(vec![
+                false, false, true, false, true, false, false, true, true
+            ]))
+        );
+        assert_eq!(
+            optionality(asn1_value)
+                .parse("DEFAULT 'F60E'H".into())
+                .unwrap()
+                .1,
+            Optionality::Default(ASN1Value::BitString(vec![
+                true, true, true, true, false, true, true, false, false, false, false, false, true,
+                true, true, false
+            ]))
+        );
+    }
+
+    #[test]
+    fn parses_default_enumeral() {
+        assert_eq!(
+            optionality(asn1_value)
+                .parse("DEFAULT enumeral1".into())
+                .unwrap()
+                .1,
+            Optionality::Default(ASN1Value::ElsewhereDeclaredValue {
+                identifier: "enumeral1".into(),
+                parent: None
+            })
+        );
+        assert_eq!(
+            optionality(asn1_value)
+                .parse("DEFAULT enumeral1".into())
+                .unwrap()
+                .1,
+            Optionality::Default(ASN1Value::ElsewhereDeclaredValue {
+                identifier: "enumeral1".into(),
+                parent: None
+            })
+        );
     }
 }

--- a/rasn-compiler/src/lexer/sequence.rs
+++ b/rasn-compiler/src/lexer/sequence.rs
@@ -100,8 +100,7 @@ fn extension_group(input: Input<'_>) -> ParserResult<'_, SequenceComponent> {
                     constraints: vec![],
                     members,
                 }),
-                default_value: None,
-                is_optional: false,
+                optionality: Optionality::Required,
                 constraints: vec![],
             })
         },
@@ -132,8 +131,7 @@ pub fn sequence_or_set_member(input: Input<'_>) -> ParserResult<'_, SequenceOrSe
         opt(asn_tag),
         skip_ws_and_comments(asn1_type),
         opt(constraints),
-        optional_marker,
-        default,
+        skip_ws_and_comments(optionality(asn1_value)),
     ))
     .parse(input)
 }
@@ -145,66 +143,6 @@ mod tests {
     use crate::intermediate::constraints::*;
 
     use super::*;
-
-    #[test]
-    fn parses_optional_marker() {
-        assert_eq!(
-            optional_marker("\n\tOPTIONAL".into()).unwrap().1,
-            Some(OptionalMarker())
-        );
-        assert_eq!(optional_marker("DEFAULT".into()).unwrap().1, None);
-    }
-
-    #[test]
-    fn parses_default_int() {
-        assert_eq!(
-            default("\n\tDEFAULT\t-1".into()).unwrap().1,
-            Some(ASN1Value::Integer(-1))
-        );
-    }
-
-    #[test]
-    fn parses_default_boolean() {
-        assert_eq!(
-            default("  DEFAULT   TRUE".into()).unwrap().1,
-            Some(ASN1Value::Boolean(true))
-        );
-    }
-
-    #[test]
-    fn parses_default_bitstring() {
-        assert_eq!(
-            default("  DEFAULT '001010011'B".into()).unwrap().1,
-            Some(ASN1Value::BitString(vec![
-                false, false, true, false, true, false, false, true, true
-            ]))
-        );
-        assert_eq!(
-            default("DEFAULT 'F60E'H".into()).unwrap().1,
-            Some(ASN1Value::BitString(vec![
-                true, true, true, true, false, true, true, false, false, false, false, false, true,
-                true, true, false
-            ]))
-        );
-    }
-
-    #[test]
-    fn parses_default_enumeral() {
-        assert_eq!(
-            default("  DEFAULT enumeral1".into()).unwrap().1,
-            Some(ASN1Value::ElsewhereDeclaredValue {
-                identifier: "enumeral1".into(),
-                parent: None
-            })
-        );
-        assert_eq!(
-            default("DEFAULT enumeral1".into()).unwrap().1,
-            Some(ASN1Value::ElsewhereDeclaredValue {
-                identifier: "enumeral1".into(),
-                parent: None
-            })
-        );
-    }
 
     #[test]
     fn parses_subtyped_sequence() {
@@ -228,8 +166,7 @@ is_recursive: false,
                     ty: ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere { parent: None,
                         identifier: "Shape".into(), constraints: vec![Constraint::Subtype(ElementSetSpecs { set: ElementOrSetOperation::Element(SubtypeElements::MultipleTypeConstraints(InnerTypeConstraint { is_partial: true, constraints: vec![NamedConstraint { identifier: "elliptical".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radial".into(), constraints: vec![], presence: ComponentPresence::Absent },NamedConstraint { identifier: "radialShapes".into(), constraints: vec![], presence: ComponentPresence::Absent }] })), extensible: false })
                      ]}),
-                    default_value: None,
-                    is_optional: true,
+                    optionality: Optionality::Optional,
                     constraints: vec![],
                 }
             ]
@@ -263,8 +200,7 @@ is_recursive: false,
                             identifier: "AccelerationValue".into(),
                             constraints: vec![]
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![]
                     },
                     SequenceOrSetMember {
@@ -277,8 +213,7 @@ is_recursive: false,
                             identifier: "AccelerationConfidence".into(),
                             constraints: vec![]
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![],
                     }
                 ]
@@ -315,8 +250,7 @@ is_recursive: false,
                             identifier: "CartesianCoordinateWithConfidence".into(),
                             constraints: vec![]
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![],
                     },
                     SequenceOrSetMember {
@@ -328,8 +262,7 @@ is_recursive: false,
                             identifier: "CartesianCoordinateWithConfidence".into(),
                             constraints: vec![]
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![],
                     },
                     SequenceOrSetMember {
@@ -341,8 +274,7 @@ is_recursive: false,
                             identifier: "CartesianCoordinateWithConfidence".into(),
                             constraints: vec![]
                         }),
-                        default_value: None,
-                        is_optional: true,
+                        optionality: Optionality::Optional,
                         constraints: vec![],
                     }
                 ]
@@ -379,8 +311,7 @@ is_recursive: false,
                             identifier: "PosConfidenceEllipse".into(),
                             constraints: vec![]
                         }),
-                        default_value: None,
-                        is_optional: true,
+                        optionality: Optionality::Optional,
                         constraints: vec![],
                     },
                     SequenceOrSetMember {
@@ -392,11 +323,10 @@ is_recursive: false,
                             identifier: "DeltaAltitude".into(),
                             constraints: vec![]
                         }),
-                        default_value: Some(ASN1Value::ElsewhereDeclaredValue {
+                        optionality: Optionality::Default(ASN1Value::ElsewhereDeclaredValue {
                             identifier: "unavailable".into(),
                             parent: None
                         }),
-                        is_optional: true,
                         constraints: vec![],
                     },
                     SequenceOrSetMember {
@@ -408,11 +338,10 @@ is_recursive: false,
                             identifier: "AltitudeConfidence".into(),
                             constraints: vec![]
                         }),
-                        default_value: Some(ASN1Value::ElsewhereDeclaredValue {
+                        optionality: Optionality::Default(ASN1Value::ElsewhereDeclaredValue {
                             identifier: "unavailable".into(),
                             parent: None
                         }),
-                        is_optional: true,
                         constraints: vec![],
                     }
                 ]
@@ -454,8 +383,7 @@ is_recursive: false,
                             })],
                             distinguished_values: None,
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![],
                     },
                     SequenceOrSetMember {
@@ -465,8 +393,7 @@ is_recursive: false,
                         ty: ASN1Type::Boolean(Boolean {
                             constraints: vec![]
                         }),
-                        default_value: Some(ASN1Value::Boolean(false)),
-                        is_optional: true,
+                        optionality: Optionality::Default(ASN1Value::Boolean(false)),
                         constraints: vec![],
                     },
                     SequenceOrSetMember {
@@ -489,8 +416,7 @@ is_recursive: false,
                                 extensible: false
                             })],
                         }),
-                        default_value: None,
-                        is_optional: true,
+                        optionality: Optionality::Optional,
                         constraints: vec![],
                     }
                 ]
@@ -543,8 +469,7 @@ is_recursive: false,
                                     identifier: "Wow".into(),
                                     constraints: vec![]
                                 }),
-                                default_value: None,
-                                is_optional: false,
+                                optionality: Optionality::Required,
                                 constraints: vec![],
                             },
                             SequenceOrSetMember {
@@ -555,8 +480,7 @@ is_recursive: false,
                                 ty: ASN1Type::Boolean(Boolean {
                                     constraints: vec![]
                                 }),
-                                default_value: Some(ASN1Value::Boolean(true)),
-                                is_optional: true,
+                                optionality: Optionality::Default(ASN1Value::Boolean(true)),
                                 constraints: vec![],
                             },
                             SequenceOrSetMember {
@@ -591,19 +515,18 @@ is_recursive: false,
                                             )],
                                             distinguished_values: None
                                         }),
-                                        default_value: Some(ASN1Value::BitString(vec![false])),
-                                        is_optional: true,
+                                        optionality: Optionality::Default(ASN1Value::BitString(
+                                            vec![false]
+                                        )),
                                         constraints: vec![],
                                     }]
                                 }),
-                                default_value: None,
-                                is_optional: true,
+                                optionality: Optionality::Optional,
                                 constraints: vec![],
                             }
                         ]
                     }),
-                    default_value: None,
-                    is_optional: false,
+                    optionality: Optionality::Required,
                     constraints: vec![],
                 }]
             })
@@ -669,8 +592,7 @@ is_recursive: false,
                             })],
                             distinguished_values: None,
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![]
                     },
                     SequenceOrSetMember {
@@ -699,8 +621,7 @@ is_recursive: false,
                                         })],
                                         distinguished_values: None,
                                     }),
-                                    default_value: None,
-                                    is_optional: false,
+                                    optionality: Optionality::Required,
                                     constraints: vec![]
                                 },
                                 SequenceOrSetMember {
@@ -710,14 +631,12 @@ is_recursive: false,
                                     ty: ASN1Type::Boolean(Boolean {
                                         constraints: vec![]
                                     }),
-                                    default_value: Some(ASN1Value::Boolean(true)),
-                                    is_optional: true,
+                                    optionality: Optionality::Default(ASN1Value::Boolean(true)),
                                     constraints: vec![]
                                 }
                             ]
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![]
                     }
                 ]
@@ -750,8 +669,7 @@ is_recursive: false,
                         identifier: "TypeB".into(),
                         constraints: vec![]
                     }),
-                    default_value: None,
-                    is_optional: false,
+                    optionality: Optionality::Required,
                     constraints: vec![]
                 }]
             })
@@ -867,8 +785,7 @@ integrityCheckValue     ICV OPTIONAL
                         },)),
                         is_recursive: false,
                     },),
-                    default_value: None,
-                    is_optional: false,
+                    optionality: Optionality::Required,
                     is_recursive: false,
                     constraints: vec![],
                 }],
@@ -910,8 +827,7 @@ integrityCheckValue     ICV OPTIONAL
                         },),
                         is_recursive: false,
                     },),
-                    default_value: None,
-                    is_optional: false,
+                    optionality: Optionality::Required,
                     is_recursive: false,
                     constraints: vec![],
                 },],

--- a/rasn-compiler/src/lexer/set.rs
+++ b/rasn-compiler/src/lexer/set.rs
@@ -43,7 +43,9 @@ pub fn set(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
 
 #[cfg(test)]
 mod tests {
-    use set::types::{CharacterString, SequenceOrSet, SequenceOrSetMember, SequenceOrSetOf};
+    use set::types::{
+        CharacterString, Optionality, SequenceOrSet, SequenceOrSetMember, SequenceOrSetOf,
+    };
 
     use super::*;
 
@@ -70,8 +72,7 @@ mod tests {
                             constraints: vec![],
                             ty: CharacterStringType::VisibleString
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![],
                     },
                     SequenceOrSetMember {
@@ -87,8 +88,7 @@ mod tests {
                                 ty: CharacterStringType::VisibleString
                             }))
                         }),
-                        default_value: Some(ASN1Value::SequenceOrSet(vec![])),
-                        is_optional: true,
+                        optionality: Optionality::Default(ASN1Value::SequenceOrSet(vec![])),
                         constraints: vec![]
                     }
                 ]

--- a/rasn-compiler/src/lexer/tests/mod.rs
+++ b/rasn-compiler/src/lexer/tests/mod.rs
@@ -442,8 +442,7 @@ fn parses_parameterized_declaration() {
                                 linked_fields: vec![]
                             })]
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![]
                     },
                     SequenceOrSetMember {
@@ -464,8 +463,7 @@ fn parses_parameterized_declaration() {
                                 }]
                             })]
                         }),
-                        default_value: None,
-                        is_optional: false,
+                        optionality: Optionality::Required,
                         constraints: vec![]
                     }
                 ]

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -267,8 +267,8 @@ impl ASN1Type {
             ASN1Type::Set(ref mut s) | ASN1Type::Sequence(ref mut s) => {
                 s.members.iter_mut().try_for_each(|m| {
                     m.ty.collect_supertypes(tlds)?;
-                    m.default_value
-                        .as_mut()
+                    m.optionality
+                        .default_mut()
                         .map(|d| d.link_with_type(tlds, &m.ty, Some(&m.ty.as_str().into_owned())))
                         .unwrap_or(Ok(()))
                 })
@@ -773,8 +773,8 @@ impl ASN1Type {
                 s.constraints.iter().any(|c| c.has_cross_reference())
                     || s.members.iter().any(|m| {
                         m.ty.contains_constraint_reference()
-                            || m.default_value
-                                .as_ref()
+                            || m.optionality
+                                .default()
                                 .is_some_and(|d| d.is_elsewhere_declared())
                             || m.constraints.iter().any(|c| c.has_cross_reference())
                     })
@@ -1418,8 +1418,8 @@ impl ASN1Value {
                             .then_some(StructLikeFieldValue::Explicit(value.clone()))
                     })
                     .or(member
-                        .default_value
-                        .as_ref()
+                        .optionality
+                        .default()
                         .map(|d| StructLikeFieldValue::Implicit(Box::new(d.clone()))))
                     .ok_or_else(|| {
                         grammar_error!(LinkerError, "No value for field {} found!", member.name)


### PR DESCRIPTION
Implement `std::default::Default` for SEQUENCEs where all members have a DEFAULT.

Builds on PR #145 "SequenceOrSetMember optionality".

Partly fixes issue #8.