### PR TITLE
feat: Output modes

### DIFF
--- a/rasn-compiler-tests/tests/parse_test.rs
+++ b/rasn-compiler-tests/tests/parse_test.rs
@@ -1,4 +1,4 @@
-use rasn_compiler::{prelude::RasnBackend, Compiler};
+use rasn_compiler::{prelude::RasnBackend, Compiler, OutputMode};
 
 #[test]
 #[ignore]
@@ -57,7 +57,7 @@ fn compile_etsi() {
             // .add_asn_by_path("../rasn-compiler/test_asn1/ngap_ies.asn")
             // .add_asn_by_path("../rasn-compiler/test_asn1/ngap_pdus.asn")
             .add_asn_by_path("../rasn-compiler/test_asn1/test.asn")
-            .set_output_path("./tests")
+            .set_output_mode(OutputMode::SingleFile("./tests".into()))
             .compile()
     );
 }

--- a/rasn-compiler/src/bin.rs
+++ b/rasn-compiler/src/bin.rs
@@ -3,18 +3,17 @@ use std::process::ExitCode;
 
 use clap::{arg, command, Parser};
 use colored::Colorize;
-use rasn_compiler::{RasnCompiler, TsCompiler};
+use rasn_compiler::{OutputMode, RasnCompiler, TsCompiler};
 use walkdir::WalkDir;
 
 #[derive(clap::Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct CompilerArgs {
-    #[clap(flatten)]
+    #[clap(flatten, next_help_heading = "Input")]
     source: SourceArgsGroup,
 
-    /// Set the output path for the generated rust module
-    #[arg(short, long, default_value = ".")]
-    output_path: PathBuf,
+    #[clap(flatten, next_help_heading = "Output")]
+    output: OutputArgGroup,
 
     /// Specify which compiler backend to use
     #[arg(short, long, default_value = "rasn")]
@@ -26,12 +25,32 @@ pub struct CompilerArgs {
 pub struct SourceArgsGroup {
     /// Specify a directory for the compiler to search for ASN1 modules.
     /// The compiler will search recursively for `.asn` and `.asn1` files
-    #[arg(short, long)]
+    #[arg(short, long, value_name = "DIR")]
     directory: Option<PathBuf>,
 
     /// Add an ASN1 module by path. Multiple modules can be added by appending "-m PATH_TO_MODULE"
-    #[arg(short, long = "module", num_args(0..))]
+    #[arg(short, long = "module", value_name="FILE", num_args(0..))]
     module_files: Vec<PathBuf>,
+}
+
+#[derive(clap::Args, Debug)]
+#[group(required = false, multiple = false)]
+pub struct OutputArgGroup {
+    /// Write all compiled modules to a single file at PATH.
+    ///
+    /// If PATH is a directory, a default filename will be used in that directory.
+    ///
+    /// If no output is specified, a default filename in current directory will be used.
+    #[arg(short, long, value_name = "PATH")]
+    output_path: Option<PathBuf>,
+
+    /// Write all compiled modules to stdout.
+    #[arg(long)]
+    stdout: bool,
+
+    /// Do not write anything, only check.
+    #[arg(long)]
+    no_output: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,14 +101,15 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    let output = make_output_mode(args.output);
     let results = match args.backend {
         BackendArg::Rasn => RasnCompiler::new()
             .add_asn_sources_by_path(modules.into_iter())
-            .set_output_path(args.output_path)
+            .set_output_mode(output)
             .compile(),
         BackendArg::Typescript => TsCompiler::new()
             .add_asn_sources_by_path(modules.into_iter())
-            .set_output_path(args.output_path)
+            .set_output_mode(output)
             .compile(),
     };
 
@@ -104,5 +124,20 @@ fn main() -> ExitCode {
             println!("{}: {error}", "error".red());
             ExitCode::FAILURE
         }
+    }
+}
+
+/// Create an [OutputConf] from command arguments, that can be used with
+/// [RasnCompiler::set_output].
+fn make_output_mode(args: OutputArgGroup) -> OutputMode {
+    // Only zero or one output argument is allowed, and enforced by Clap.
+    if let Some(v) = args.output_path {
+        OutputMode::SingleFile(v)
+    } else if args.stdout {
+        OutputMode::Stdout
+    } else if args.no_output {
+        OutputMode::NoOutput
+    } else {
+        OutputMode::SingleFile(".".into())
     }
 }


### PR DESCRIPTION
# feat(compiler): Allow more output modes

Allow to configure the compiler with multiple "output modes", and add two new:

- `OutputMode::SingleFile`: Write all bindings to a single file. Previously the only mode.
- `OutputMode::Stdout`: Write all bindings to stdout.
- `OutputMode::NoOutput`: Do not write anything. Useful when only checking.

Marks `Compiler::set_output_path` as deprecated. Use `Compiler::set_output_mode` instead.

This is a small step towards outputting a file per module (issue https://github.com/librasn/compiler/issues/53).

# feat(cli) Add --stdout and --no-out

Add two new args:

- `--stdout`: Output generated bindings to stdout.
- `--no-out`: Do not output generated bindings. Useful when checking.