### PR TITLE
Include file name in compiler errors

### DIFF
--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -19,12 +19,12 @@ use nom::{
     Parser,
 };
 
-use crate::intermediate::macros::ToplevelMacroDefinition;
 use crate::lexer::macros::macro_definition;
 use crate::{
     input::{context_boundary, Input},
     intermediate::{information_object::*, *},
 };
+use crate::{intermediate::macros::ToplevelMacroDefinition, AsnSourceUnit};
 
 use self::{
     bit_string::*, boolean::*, character_string::*, choice::*, common::*, constraint::*,
@@ -62,9 +62,11 @@ mod util;
 #[cfg(test)]
 mod tests;
 
-pub fn asn_spec(input: &str) -> Result<Vec<(ModuleHeader, Vec<ToplevelDefinition>)>, LexerError> {
+pub fn asn_spec(
+    input: AsnSourceUnit,
+) -> Result<Vec<(ModuleHeader, Vec<ToplevelDefinition>)>, LexerError> {
     let mut result = Vec::new();
-    let mut remaining_input = Input::from(input);
+    let mut remaining_input = Input::from(&input);
     loop {
         match asn_module(remaining_input) {
             Ok((remaining, res)) => {

--- a/rasn-compiler/src/tests.rs
+++ b/rasn-compiler/src/tests.rs
@@ -142,11 +142,11 @@ fn as_decl_string<I: std::fmt::Debug>(input: I) -> String {
 }
 
 fn expected_lexer_result(literal: &str) -> String {
-    as_decl_string(crate::lexer::asn_spec(literal).unwrap())
+    as_decl_string(crate::lexer::asn_spec(literal.into()).unwrap())
 }
 
 fn validator_io(literal: &str) -> (String, String) {
-    let input = crate::lexer::asn_spec(literal)
+    let input = crate::lexer::asn_spec(literal.into())
         .unwrap()
         .into_iter()
         .flat_map(|(header, tlds)| {


### PR DESCRIPTION
Includes the filename in the description of errors for some compiler errors (LexerError::MatchingErrorr)

Formats the filename so it can be clicked on in VS Code output windows, which means adjusting the index of line number by +1.