### PR TITLE
Fix (U)PER generation when use more advanced constraints

### DIFF
--- a/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
+++ b/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
@@ -68,6 +68,15 @@ impl PerVisibleAlphabetConstraints {
         constraint: &Constraint,
         string_type: CharacterStringType,
     ) -> Result<Option<Self>, GrammarError> {
+        // ITU-T X.691 clause 30.1, 30.6: Known-multiplier character strings types
+        match string_type {
+            // 30.1: Known-multiplier character string types
+            CharacterStringType::NumericString | CharacterStringType::PrintableString |
+            CharacterStringType::VisibleString | CharacterStringType::IA5String |
+            CharacterStringType::BMPString | CharacterStringType::UniversalString => {},
+            // 30.6: Non-known-multiplier character string types
+            _ => return Ok(None),
+        }
         match constraint {
             Constraint::Subtype(c) => match &c.set {
                 ElementOrSetOperation::Element(e) => Self::from_subtype_elem(Some(e), string_type),


### PR DESCRIPTION
This PR fixes a number of bugs causing rasn to generate and decode invalid PER/UPER when certain constraints are placed on string types. The fixes are:

### Known-multiplier character string types

rasn treated all string types as known multiplier, this is wrong per ITU-T X.691 clause 30, subclauses 30.1 and 30.6.
This would cause, for example, no length byte to be output for a UTF8String with a fixed length constraint; and on decoding (U)PER from a compliant generator, the length byte would be included as part of the UTF8String data.

### Alphabet constraints

rasn incorrectly constructed the `#[rasn(from(...))]` annotation for alphabet constraints on a union of two strings.
Consider, for example, the following alphabet constraint:

```asn1
text IA5String (FROM ("a".."z"|"A".."Z"|"0".."9"|"."|"-"))
```

rasn would correctly coalesce `"."|"-"` to `#[rasn(from('.', '-'))]`, but `"0".."9"|"."|"-"` would be coalesced to `#[rasn(from('.'..= '9'))]`, and so on.
That is, when coalescing with ranges, it would create a whole new range, even if this range wasn't contiguous.
This increases `log2(|alphabet|)`, thus generating invalid (U)PER when the next power of two is crossed.

### Union/intersection of size and alphabet constraints

Consider the following:

```asn1
text IA5String (SIZE(1..50) ^ FROM ("a".."z"|"A".."Z"|"0".."9"|"."|"-"))
```

rasn would throw the following error when evaulating the size constraint:

```
Unsupported operation for values String("-.") and Some(String("0"))..Some(String("9"))
```

This error is thrown because the known alphabet is not available when evaluating size constraints.
Instead of ignoring such constraints and moving on, rasn throws an error.
Now, when evaluating a range/size constraint, alphabet constraints are ignored.

### Intersection of size and any other constraint

When evaluting size constraints, `is_size_constraint` would only be set correctly for primitive constraints, i.e. not those consisting of set operations. This resulted in size constraints being output as range constraints.

