### PR TITLE
Reserved char seq

### DIFF
--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235.0_2005_H235-SECURITY-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235.0_2005_H235-SECURITY-MESSAGES.asn1.snap
@@ -2,42 +2,1040 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_h_h235.0_2005_H235-SECURITY-MESSAGES.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 254, column 2]
-     │
-     │ 
- 254 │  CryptoToken ::= CHOICE { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 255 │    cryptoEncryptedToken
- 256 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 257 │                                                                 OBJECT
- 258 │                                                                   IDENTIFIER,
- 259 │                                                               token
- 260 │                                                                 ENCRYPTED
- 261 │                                                                   {EncodedGeneralToken}
- 262 │    },
- 263 │    cryptoSignedToken
- 264 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 265 │                                                                 OBJECT
- 266 │                                                                   IDENTIFIER,
- 267 │                                                               token
- 268 │                                                                 SIGNED
- 269 │                                                                   {EncodedGeneralToken}
- 270 │    },
- 271 │    cryptoHashedToken
- 272 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 273 │                                                                 OBJECT
- 274 │                                                                   IDENTIFIER,
- 275 │                                                               hashedVals
- 276 │                                                                 ClearToken,
- 277 │                                                               token
- 278 │                                                                 HASHED
- 279 │                                                                   {EncodedGeneralToken}
- 280 │    },
- 281 │    cryptoPwdEncr         ENCRYPTED{EncodedPwdCertToken},
- 282 │    ...
- 283 │  }
- 285 │  -- These allow the passing of session keys within the H.245 OLC structure.
- 286 │  -- They are encoded as standalone ASN.1 and based as an OCTET STRING within
- 287 │  -- H.245
-     │
-─────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod h235_security_messages {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationBES {
+        default(()),
+        radius(()),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationMechanism {
+        dhExch(()),
+        pwdSymEnc(()),
+        pwdHash(()),
+        certSign(()),
+        ipsec(()),
+        tls(()),
+        nonStandard(NonStandardParameter),
+        #[rasn(extension_addition)]
+        authenticationBES(AuthenticationBES),
+        #[rasn(extension_addition)]
+        keyExch(ObjectIdentifier),
+    }
+    #[doc = " EXPORTS All"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("8..=128"))]
+    pub struct ChallengeString(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClearToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub password: Option<Password>,
+        pub dhkey: Option<DHset>,
+        pub challenge: Option<ChallengeString>,
+        pub random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "nonStandard")]
+        pub non_standard: Option<NonStandardParameter>,
+        #[rasn(extension_addition)]
+        pub eckasdhkey: Option<ECKASDH>,
+        #[rasn(extension_addition, identifier = "sendersID")]
+        pub senders_id: Option<Identifier>,
+        #[rasn(extension_addition, identifier = "h235Key")]
+        pub h235_key: Option<H235Key>,
+        #[rasn(extension_addition, identifier = "profileInfo")]
+        pub profile_info: Option<SequenceOf<ProfileElement>>,
+    }
+    impl ClearToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            time_stamp: Option<TimeStamp>,
+            password: Option<Password>,
+            dhkey: Option<DHset>,
+            challenge: Option<ChallengeString>,
+            random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+            general_id: Option<Identifier>,
+            non_standard: Option<NonStandardParameter>,
+            eckasdhkey: Option<ECKASDH>,
+            senders_id: Option<Identifier>,
+            h235_key: Option<H235Key>,
+            profile_info: Option<SequenceOf<ProfileElement>>,
+        ) -> Self {
+            Self {
+                token_oid,
+                time_stamp,
+                password,
+                dhkey,
+                challenge,
+                random,
+                certificate,
+                general_id,
+                non_standard,
+                eckasdhkey,
+                senders_id,
+                h235_key,
+                profile_info,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoEncryptedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoEncryptedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoEncryptedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoEncryptedTokenToken,
+    }
+    impl CryptoTokenCryptoEncryptedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            token: CryptoTokenCryptoEncryptedTokenToken,
+        ) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoSignedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoSignedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedTokenToken {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedGeneralToken,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+        pub signature: BitString,
+    }
+    impl CryptoTokenCryptoSignedTokenToken {
+        pub fn new(
+            to_be_signed: EncodedGeneralToken,
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoSignedTokenToken,
+    }
+    impl CryptoTokenCryptoSignedToken {
+        pub fn new(token_oid: ObjectIdentifier, token: CryptoTokenCryptoSignedTokenToken) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoHashedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoHashedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+        pub hash: BitString,
+    }
+    impl CryptoTokenCryptoHashedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+            hash: BitString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                hash,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "hashedVals")]
+        pub hashed_vals: ClearToken,
+        pub token: CryptoTokenCryptoHashedTokenToken,
+    }
+    impl CryptoTokenCryptoHashedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            hashed_vals: ClearToken,
+            token: CryptoTokenCryptoHashedTokenToken,
+        ) -> Self {
+            Self {
+                token_oid,
+                hashed_vals,
+                token,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoPwdEncrParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoPwdEncrParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoPwdEncr {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoPwdEncrParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoPwdEncr {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoPwdEncrParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum CryptoToken {
+        cryptoEncryptedToken(CryptoTokenCryptoEncryptedToken),
+        cryptoSignedToken(CryptoTokenCryptoSignedToken),
+        cryptoHashedToken(CryptoTokenCryptoHashedToken),
+        cryptoPwdEncr(CryptoTokenCryptoPwdEncr),
+    }
+    #[doc = " if local octet representations of these bit strings are used they shall"]
+    #[doc = " utilize standard Network Octet ordering (e.g., Big Endian)"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct DHset {
+        #[rasn(size("0..=2048"))]
+        pub halfkey: BitString,
+        #[rasn(size("0..=2048"), identifier = "modSize")]
+        pub mod_size: BitString,
+        #[rasn(size("0..=2048"))]
+        pub generator: BitString,
+    }
+    impl DHset {
+        pub fn new(halfkey: BitString, mod_size: BitString, generator: BitString) -> Self {
+            Self {
+                halfkey,
+                mod_size,
+                generator,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECGDSASignature {
+        #[rasn(size("0..=511"))]
+        pub r: BitString,
+        #[rasn(size("0..=511"))]
+        pub s: BitString,
+    }
+    impl ECGDSASignature {
+        pub fn new(r: BitString, s: BitString) -> Self {
+            Self { r, s }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdhp {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"))]
+        pub modulus: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdhp {
+        pub fn new(
+            public_key: ECpoint,
+            modulus: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                modulus,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdh2 {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"), identifier = "fieldSize")]
+        pub field_size: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdh2 {
+        pub fn new(
+            public_key: ECpoint,
+            field_size: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                field_size,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ECKASDH {
+        eckasdhp(ECKASDHEckasdhp),
+        eckasdh2(ECKASDHEckasdh2),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ECpoint {
+        #[rasn(size("0..=511"))]
+        pub x: Option<BitString>,
+        #[rasn(size("0..=511"))]
+        pub y: Option<BitString>,
+    }
+    impl ECpoint {
+        pub fn new(x: Option<BitString>, y: Option<BitString>) -> Self {
+            Self { x, y }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum Element {
+        octets(OctetString),
+        integer(Integer),
+        bits(BitString),
+        name(BmpString),
+        flag(bool),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedGeneralToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySignedMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySyncMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedPwdCertToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedReturnSig(pub Any);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignatureSignatureParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235CertificateSignatureSignatureParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235CertificateSignatureSignature {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedReturnSig,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235CertificateSignatureSignatureParamS,
+        pub signature: BitString,
+    }
+    impl H235CertificateSignatureSignature {
+        pub fn new(
+            to_be_signed: EncodedReturnSig,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235CertificateSignatureSignatureParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignature {
+        pub certificate: TypedCertificate,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requesterRandom")]
+        pub requester_random: Option<RandomVal>,
+        pub signature: H235CertificateSignatureSignature,
+    }
+    impl H235CertificateSignature {
+        pub fn new(
+            certificate: TypedCertificate,
+            response_random: RandomVal,
+            requester_random: Option<RandomVal>,
+            signature: H235CertificateSignatureSignature,
+        ) -> Self {
+            Self {
+                certificate,
+                response_random,
+                requester_random,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeySharedSecretParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235KeySharedSecretParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeySharedSecret {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeySharedSecretParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl H235KeySharedSecret {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeySharedSecretParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeyCertProtectedKeyParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235KeyCertProtectedKeyParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeyCertProtectedKey {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedKeySignedMaterial,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeyCertProtectedKeyParamS,
+        pub signature: BitString,
+    }
+    impl H235KeyCertProtectedKey {
+        pub fn new(
+            to_be_signed: EncodedKeySignedMaterial,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeyCertProtectedKeyParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " These allow the passing of session keys within the H.245 OLC structure."]
+    #[doc = " They are encoded as standalone ASN.1 and based as an OCTET STRING within"]
+    #[doc = " H.245"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum H235Key {
+        secureChannel(KeyMaterial),
+        sharedSecret(H235KeySharedSecret),
+        certProtectedKey(H235KeyCertProtectedKey),
+        #[rasn(extension_addition)]
+        secureSharedSecret(V3KeySyncMaterial),
+    }
+    #[doc = " initial value for 64-bit block ciphers"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV16(pub FixedOctetString<16usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV8(pub FixedOctetString<8usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Identifier(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=2048"))]
+    pub struct KeyMaterial(pub BitString);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySignedMaterialEncrptvalParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl KeySignedMaterialEncrptvalParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterialEncrptval {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: KeySignedMaterialEncrptvalParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl KeySignedMaterialEncrptval {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: KeySignedMaterialEncrptvalParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterial {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        pub mrandom: RandomVal,
+        pub srandom: Option<RandomVal>,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub encrptval: KeySignedMaterialEncrptval,
+    }
+    impl KeySignedMaterial {
+        pub fn new(
+            general_id: Identifier,
+            mrandom: RandomVal,
+            srandom: Option<RandomVal>,
+            time_stamp: Option<TimeStamp>,
+            encrptval: KeySignedMaterialEncrptval,
+        ) -> Self {
+            Self {
+                general_id,
+                mrandom,
+                srandom,
+                time_stamp,
+                encrptval,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "keyMaterial")]
+        pub key_material: KeyMaterial,
+    }
+    impl KeySyncMaterial {
+        pub fn new(general_id: Identifier, key_material: KeyMaterial) -> Self {
+            Self {
+                general_id,
+                key_material,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct NonStandardParameter {
+        #[rasn(identifier = "nonStandardIdentifier")]
+        pub non_standard_identifier: ObjectIdentifier,
+        pub data: OctetString,
+    }
+    impl NonStandardParameter {
+        pub fn new(non_standard_identifier: ObjectIdentifier, data: OctetString) -> Self {
+            Self {
+                non_standard_identifier,
+                data,
+            }
+        }
+    }
+    #[doc = " initial value for 128-bit block ciphers"]
+    #[doc = " signing algorithm used must select one of these types of parameters"]
+    #[doc = " needed by receiving end of signature."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct Params {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl Params {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " 32-bit Integer"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Password(pub BmpString);
+    #[doc = "\tAn object identifier should be placed in the tokenOID field when a"]
+    #[doc = "\tClearToken is included directly in a message (as opposed to being"]
+    #[doc = "\tencrypted). In all other cases, an application should use the"]
+    #[doc = "\tobject identifier { 0 0 } to indicate that the tokenOID value is not"]
+    #[doc = "\tpresent."]
+    #[doc = "\tStart all the cryptographic parameterized types here..."]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ProfileElement {
+        #[rasn(value("0..=255"), identifier = "elementID")]
+        pub element_id: u8,
+        #[rasn(identifier = "paramS")]
+        pub param_s: Option<Params>,
+        pub element: Option<Element>,
+    }
+    impl ProfileElement {
+        pub fn new(element_id: u8, param_s: Option<Params>, element: Option<Element>) -> Self {
+            Self {
+                element_id,
+                param_s,
+                element,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PwdCertToken(pub ClearToken);
+    #[doc = " seconds since 00:00"]
+    #[doc = " 1/1/1970 UTC"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RandomVal(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ReturnSig {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requestRandom")]
+        pub request_random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+    }
+    impl ReturnSig {
+        pub fn new(
+            general_id: Identifier,
+            response_random: RandomVal,
+            request_random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+        ) -> Self {
+            Self {
+                general_id,
+                response_random,
+                request_random,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=4294967295"))]
+    pub struct TimeStamp(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TypedCertificate {
+        #[rasn(identifier = "type")]
+        pub r_type: ObjectIdentifier,
+        pub certificate: OctetString,
+    }
+    impl TypedCertificate {
+        pub fn new(r_type: ObjectIdentifier, certificate: OctetString) -> Self {
+            Self {
+                r_type,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct V3KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: Option<ObjectIdentifier>,
+        #[rasn(identifier = "paramS")]
+        pub param_s: Params,
+        #[rasn(identifier = "encryptedSessionKey")]
+        pub encrypted_session_key: Option<OctetString>,
+        #[rasn(identifier = "encryptedSaltingKey")]
+        pub encrypted_salting_key: Option<OctetString>,
+        #[rasn(identifier = "clearSaltingKey")]
+        pub clear_salting_key: Option<OctetString>,
+        #[rasn(identifier = "paramSsalt")]
+        pub param_ssalt: Option<Params>,
+        #[rasn(identifier = "keyDerivationOID")]
+        pub key_derivation_oid: Option<ObjectIdentifier>,
+        #[rasn(extension_addition, identifier = "genericKeyMaterial")]
+        pub generic_key_material: Option<OctetString>,
+    }
+    impl V3KeySyncMaterial {
+        pub fn new(
+            general_id: Option<Identifier>,
+            algorithm_oid: Option<ObjectIdentifier>,
+            param_s: Params,
+            encrypted_session_key: Option<OctetString>,
+            encrypted_salting_key: Option<OctetString>,
+            clear_salting_key: Option<OctetString>,
+            param_ssalt: Option<Params>,
+            key_derivation_oid: Option<ObjectIdentifier>,
+            generic_key_material: Option<OctetString>,
+        ) -> Self {
+            Self {
+                general_id,
+                algorithm_oid,
+                param_s,
+                encrypted_session_key,
+                encrypted_salting_key,
+                clear_salting_key,
+                param_ssalt,
+                key_derivation_oid,
+                generic_key_material,
+            }
+        }
+    }
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_1998_H235-SECURITY-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_1998_H235-SECURITY-MESSAGES.asn1.snap
@@ -2,41 +2,657 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_h_h235_1998_H235-SECURITY-MESSAGES.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 116, column 2]
-     │
-     │ 
- 116 │  CryptoToken ::= CHOICE { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 117 │    cryptoEncryptedToken
- 118 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 119 │                                                                 OBJECT
- 120 │                                                                   IDENTIFIER,
- 121 │                                                               token
- 122 │                                                                 ENCRYPTED
- 123 │                                                                   {EncodedGeneralToken}
- 124 │    },
- 125 │    cryptoSignedToken
- 126 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 127 │                                                                 OBJECT
- 128 │                                                                   IDENTIFIER,
- 129 │                                                               token
- 130 │                                                                 SIGNED
- 131 │                                                                   {EncodedGeneralToken}
- 132 │    },
- 133 │    cryptoHashedToken
- 134 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 135 │                                                                 OBJECT
- 136 │                                                                   IDENTIFIER,
- 137 │                                                               hashedVals
- 138 │                                                                 ClearToken,
- 139 │                                                               token
- 140 │                                                                 HASHED
- 141 │                                                                   {EncodedGeneralToken}
- 142 │    },
- 143 │    cryptoPwdEncr         ENCRYPTED{EncodedPwdCertToken},
- 144 │    ...
- 145 │  }
- 147 │  -- These allow the passing of session keys within the H.245 OLC structure.
- 148 │  -- They are encoded as standalone ASN.1 and based as an OCTET STRING within H.245
-     │
-─────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod h235_security_messages {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationMechanism {
+        dhExch(()),
+        pwdSymEnc(()),
+        pwdHash(()),
+        certSign(()),
+        ipsec(()),
+        tls(()),
+        nonStandard(NonStandardParameter),
+    }
+    #[doc = " EXPORTS All"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("8..=128"))]
+    pub struct ChallengeString(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClearToken {
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub password: Option<Password>,
+        pub dhkey: Option<DHset>,
+        pub challenge: Option<ChallengeString>,
+        pub random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "nonStandard")]
+        pub non_standard: Option<NonStandardParameter>,
+    }
+    impl ClearToken {
+        pub fn new(
+            time_stamp: Option<TimeStamp>,
+            password: Option<Password>,
+            dhkey: Option<DHset>,
+            challenge: Option<ChallengeString>,
+            random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+            general_id: Option<Identifier>,
+            non_standard: Option<NonStandardParameter>,
+        ) -> Self {
+            Self {
+                time_stamp,
+                password,
+                dhkey,
+                challenge,
+                random,
+                certificate,
+                general_id,
+                non_standard,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoEncryptedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl CryptoTokenCryptoEncryptedTokenTokenParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoEncryptedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoEncryptedTokenToken,
+    }
+    impl CryptoTokenCryptoEncryptedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            token: CryptoTokenCryptoEncryptedTokenToken,
+        ) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoSignedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl CryptoTokenCryptoSignedTokenTokenParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedTokenToken {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedGeneralToken,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+        pub signature: BitString,
+    }
+    impl CryptoTokenCryptoSignedTokenToken {
+        pub fn new(
+            to_be_signed: EncodedGeneralToken,
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoSignedTokenToken,
+    }
+    impl CryptoTokenCryptoSignedToken {
+        pub fn new(token_oid: ObjectIdentifier, token: CryptoTokenCryptoSignedTokenToken) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoHashedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl CryptoTokenCryptoHashedTokenTokenParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+        pub hash: BitString,
+    }
+    impl CryptoTokenCryptoHashedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+            hash: BitString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                hash,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "hashedVals")]
+        pub hashed_vals: ClearToken,
+        pub token: CryptoTokenCryptoHashedTokenToken,
+    }
+    impl CryptoTokenCryptoHashedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            hashed_vals: ClearToken,
+            token: CryptoTokenCryptoHashedTokenToken,
+        ) -> Self {
+            Self {
+                token_oid,
+                hashed_vals,
+                token,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoPwdEncrParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl CryptoTokenCryptoPwdEncrParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoPwdEncr {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoPwdEncrParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoPwdEncr {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoPwdEncrParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum CryptoToken {
+        cryptoEncryptedToken(CryptoTokenCryptoEncryptedToken),
+        cryptoSignedToken(CryptoTokenCryptoSignedToken),
+        cryptoHashedToken(CryptoTokenCryptoHashedToken),
+        cryptoPwdEncr(CryptoTokenCryptoPwdEncr),
+    }
+    #[doc = " if local octet representations of these bit strings are used they shall"]
+    #[doc = " utilize standard Network Octet ordering (e.g. Big Endian)"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct DHset {
+        #[rasn(size("0..=2048"))]
+        pub halfkey: BitString,
+        #[rasn(size("0..=2048"), identifier = "modSize")]
+        pub mod_size: BitString,
+        #[rasn(size("0..=2048"))]
+        pub generator: BitString,
+    }
+    impl DHset {
+        pub fn new(halfkey: BitString, mod_size: BitString, generator: BitString) -> Self {
+            Self {
+                halfkey,
+                mod_size,
+                generator,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedGeneralToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySignedMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySyncMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedPwdCertToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedReturnSig(pub Any);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignatureSignatureParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl H235CertificateSignatureSignatureParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235CertificateSignatureSignature {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedReturnSig,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235CertificateSignatureSignatureParamS,
+        pub signature: BitString,
+    }
+    impl H235CertificateSignatureSignature {
+        pub fn new(
+            to_be_signed: EncodedReturnSig,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235CertificateSignatureSignatureParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignature {
+        pub certificate: TypedCertificate,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requesterRandom")]
+        pub requester_random: Option<RandomVal>,
+        pub signature: H235CertificateSignatureSignature,
+    }
+    impl H235CertificateSignature {
+        pub fn new(
+            certificate: TypedCertificate,
+            response_random: RandomVal,
+            requester_random: Option<RandomVal>,
+            signature: H235CertificateSignatureSignature,
+        ) -> Self {
+            Self {
+                certificate,
+                response_random,
+                requester_random,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeySharedSecretParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl H235KeySharedSecretParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeySharedSecret {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeySharedSecretParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl H235KeySharedSecret {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeySharedSecretParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeyCertProtectedKeyParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl H235KeyCertProtectedKeyParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeyCertProtectedKey {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedKeySignedMaterial,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeyCertProtectedKeyParamS,
+        pub signature: BitString,
+    }
+    impl H235KeyCertProtectedKey {
+        pub fn new(
+            to_be_signed: EncodedKeySignedMaterial,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeyCertProtectedKeyParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " These allow the passing of session keys within the H.245 OLC structure."]
+    #[doc = " They are encoded as standalone ASN.1 and based as an OCTET STRING within H.245"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum H235Key {
+        secureChannel(KeyMaterial),
+        sharedSecret(H235KeySharedSecret),
+        certProtectedKey(H235KeyCertProtectedKey),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV8(pub FixedOctetString<8usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Identifier(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=2048"))]
+    pub struct KeyMaterial(pub BitString);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySignedMaterialEncrptvalParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl KeySignedMaterialEncrptvalParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterialEncrptval {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: KeySignedMaterialEncrptvalParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl KeySignedMaterialEncrptval {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: KeySignedMaterialEncrptvalParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterial {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        pub mrandom: RandomVal,
+        pub srandom: Option<RandomVal>,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub encrptval: KeySignedMaterialEncrptval,
+    }
+    impl KeySignedMaterial {
+        pub fn new(
+            general_id: Identifier,
+            mrandom: RandomVal,
+            srandom: Option<RandomVal>,
+            time_stamp: Option<TimeStamp>,
+            encrptval: KeySignedMaterialEncrptval,
+        ) -> Self {
+            Self {
+                general_id,
+                mrandom,
+                srandom,
+                time_stamp,
+                encrptval,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "keyMaterial")]
+        pub key_material: KeyMaterial,
+    }
+    impl KeySyncMaterial {
+        pub fn new(general_id: Identifier, key_material: KeyMaterial) -> Self {
+            Self {
+                general_id,
+                key_material,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct NonStandardParameter {
+        #[rasn(identifier = "nonStandardIdentifier")]
+        pub non_standard_identifier: ObjectIdentifier,
+        pub data: OctetString,
+    }
+    impl NonStandardParameter {
+        pub fn new(non_standard_identifier: ObjectIdentifier, data: OctetString) -> Self {
+            Self {
+                non_standard_identifier,
+                data,
+            }
+        }
+    }
+    #[doc = " signing algorithm used must select one of these types of parameters"]
+    #[doc = " needed by receiving end of signature."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct Params {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+    }
+    impl Params {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>) -> Self {
+            Self { ran_int, iv8 }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Password(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PwdCertToken(pub ClearToken);
+    #[doc = " seconds since 00:00 1/1/1970 UTC"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RandomVal(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ReturnSig {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requestRandom")]
+        pub request_random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+    }
+    impl ReturnSig {
+        pub fn new(
+            general_id: Identifier,
+            response_random: RandomVal,
+            request_random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+        ) -> Self {
+            Self {
+                general_id,
+                response_random,
+                request_random,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=4294967295"))]
+    pub struct TimeStamp(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TypedCertificate {
+        #[rasn(identifier = "type")]
+        pub r_type: ObjectIdentifier,
+        pub certificate: OctetString,
+    }
+    impl TypedCertificate {
+        pub fn new(r_type: ObjectIdentifier, certificate: OctetString) -> Self {
+            Self {
+                r_type,
+                certificate,
+            }
+        }
+    }
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_2000_H235-SECURITY-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_2000_H235-SECURITY-MESSAGES.asn1.snap
@@ -2,41 +2,798 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_h_h235_2000_H235-SECURITY-MESSAGES.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 208, column 2]
-     │
-     │ 
- 208 │  CryptoToken ::= CHOICE { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 209 │    cryptoEncryptedToken
- 210 │      SEQUENCE -- General purpose/application specific token-- {tokenOID
- 211 │                                                                  OBJECT
- 212 │                                                                    IDENTIFIER,
- 213 │                                                                token
- 214 │                                                                  ENCRYPTED
- 215 │                                                                    {EncodedGeneralToken}
- 216 │    },
- 217 │    cryptoSignedToken
- 218 │      SEQUENCE -- General purpose/application specific token-- {tokenOID
- 219 │                                                                  OBJECT
- 220 │                                                                    IDENTIFIER,
- 221 │                                                                token
- 222 │                                                                  SIGNED
- 223 │                                                                    {EncodedGeneralToken}
- 224 │    },
- 225 │    cryptoHashedToken
- 226 │      SEQUENCE -- General purpose/application specific token-- {tokenOID
- 227 │                                                                  OBJECT
- 228 │                                                                    IDENTIFIER,
- 229 │                                                                hashedVals
- 230 │                                                                  ClearToken,
- 231 │                                                                token
- 232 │                                                                  HASHED
- 233 │                                                                    {EncodedGeneralToken}
- 234 │    },
- 235 │    cryptoPwdEncr         ENCRYPTED{EncodedPwdCertToken},
- 236 │    ...
- 237 │  }
- 239 │  -- These allow the passing of session keys within the H.245 OLC structure.
- 240 │  -- They are encoded as standalone ASN.1 and based as an OCTET STRING within H.245
-     │
-─────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod h235_security_messages {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationBES {
+        default(()),
+        radius(()),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationMechanism {
+        dhExch(()),
+        pwdSymEnc(()),
+        pwdHash(()),
+        certSign(()),
+        ipsec(()),
+        tls(()),
+        nonStandard(NonStandardParameter),
+        #[rasn(extension_addition)]
+        authenticationBES(AuthenticationBES),
+    }
+    #[doc = " EXPORTS All"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("8..=128"))]
+    pub struct ChallengeString(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClearToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub password: Option<Password>,
+        pub dhkey: Option<DHset>,
+        pub challenge: Option<ChallengeString>,
+        pub random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "nonStandard")]
+        pub non_standard: Option<NonStandardParameter>,
+        #[rasn(extension_addition)]
+        pub eckasdhkey: Option<ECKASDH>,
+        #[rasn(extension_addition, identifier = "sendersID")]
+        pub senders_id: Option<Identifier>,
+    }
+    impl ClearToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            time_stamp: Option<TimeStamp>,
+            password: Option<Password>,
+            dhkey: Option<DHset>,
+            challenge: Option<ChallengeString>,
+            random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+            general_id: Option<Identifier>,
+            non_standard: Option<NonStandardParameter>,
+            eckasdhkey: Option<ECKASDH>,
+            senders_id: Option<Identifier>,
+        ) -> Self {
+            Self {
+                token_oid,
+                time_stamp,
+                password,
+                dhkey,
+                challenge,
+                random,
+                certificate,
+                general_id,
+                non_standard,
+                eckasdhkey,
+                senders_id,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoEncryptedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl CryptoTokenCryptoEncryptedTokenTokenParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoEncryptedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoEncryptedTokenToken,
+    }
+    impl CryptoTokenCryptoEncryptedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            token: CryptoTokenCryptoEncryptedTokenToken,
+        ) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoSignedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl CryptoTokenCryptoSignedTokenTokenParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedTokenToken {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedGeneralToken,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+        pub signature: BitString,
+    }
+    impl CryptoTokenCryptoSignedTokenToken {
+        pub fn new(
+            to_be_signed: EncodedGeneralToken,
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoSignedTokenToken,
+    }
+    impl CryptoTokenCryptoSignedToken {
+        pub fn new(token_oid: ObjectIdentifier, token: CryptoTokenCryptoSignedTokenToken) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoHashedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl CryptoTokenCryptoHashedTokenTokenParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+        pub hash: BitString,
+    }
+    impl CryptoTokenCryptoHashedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+            hash: BitString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                hash,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "hashedVals")]
+        pub hashed_vals: ClearToken,
+        pub token: CryptoTokenCryptoHashedTokenToken,
+    }
+    impl CryptoTokenCryptoHashedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            hashed_vals: ClearToken,
+            token: CryptoTokenCryptoHashedTokenToken,
+        ) -> Self {
+            Self {
+                token_oid,
+                hashed_vals,
+                token,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoPwdEncrParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl CryptoTokenCryptoPwdEncrParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoPwdEncr {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoPwdEncrParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoPwdEncr {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoPwdEncrParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum CryptoToken {
+        cryptoEncryptedToken(CryptoTokenCryptoEncryptedToken),
+        cryptoSignedToken(CryptoTokenCryptoSignedToken),
+        cryptoHashedToken(CryptoTokenCryptoHashedToken),
+        cryptoPwdEncr(CryptoTokenCryptoPwdEncr),
+    }
+    #[doc = " if local octet representations of these bit strings are used they shall"]
+    #[doc = " utilize standard Network Octet ordering (e.g. Big Endian)"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct DHset {
+        #[rasn(size("0..=2048"))]
+        pub halfkey: BitString,
+        #[rasn(size("0..=2048"), identifier = "modSize")]
+        pub mod_size: BitString,
+        #[rasn(size("0..=2048"))]
+        pub generator: BitString,
+    }
+    impl DHset {
+        pub fn new(halfkey: BitString, mod_size: BitString, generator: BitString) -> Self {
+            Self {
+                halfkey,
+                mod_size,
+                generator,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECGDSASignature {
+        #[rasn(size("0..=511"))]
+        pub r: BitString,
+        #[rasn(size("0..=511"))]
+        pub s: BitString,
+    }
+    impl ECGDSASignature {
+        pub fn new(r: BitString, s: BitString) -> Self {
+            Self { r, s }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdhp {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"))]
+        pub modulus: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdhp {
+        pub fn new(
+            public_key: ECpoint,
+            modulus: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                modulus,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdh2 {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"), identifier = "fieldSize")]
+        pub field_size: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdh2 {
+        pub fn new(
+            public_key: ECpoint,
+            field_size: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                field_size,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ECKASDH {
+        eckasdhp(ECKASDHEckasdhp),
+        eckasdh2(ECKASDHEckasdh2),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ECpoint {
+        #[rasn(size("0..=511"))]
+        pub x: Option<BitString>,
+        #[rasn(size("0..=511"))]
+        pub y: Option<BitString>,
+    }
+    impl ECpoint {
+        pub fn new(x: Option<BitString>, y: Option<BitString>) -> Self {
+            Self { x, y }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedGeneralToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySignedMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySyncMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedPwdCertToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedReturnSig(pub Any);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignatureSignatureParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl H235CertificateSignatureSignatureParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235CertificateSignatureSignature {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedReturnSig,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235CertificateSignatureSignatureParamS,
+        pub signature: BitString,
+    }
+    impl H235CertificateSignatureSignature {
+        pub fn new(
+            to_be_signed: EncodedReturnSig,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235CertificateSignatureSignatureParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignature {
+        pub certificate: TypedCertificate,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requesterRandom")]
+        pub requester_random: Option<RandomVal>,
+        pub signature: H235CertificateSignatureSignature,
+    }
+    impl H235CertificateSignature {
+        pub fn new(
+            certificate: TypedCertificate,
+            response_random: RandomVal,
+            requester_random: Option<RandomVal>,
+            signature: H235CertificateSignatureSignature,
+        ) -> Self {
+            Self {
+                certificate,
+                response_random,
+                requester_random,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeySharedSecretParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl H235KeySharedSecretParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeySharedSecret {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeySharedSecretParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl H235KeySharedSecret {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeySharedSecretParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeyCertProtectedKeyParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl H235KeyCertProtectedKeyParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeyCertProtectedKey {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedKeySignedMaterial,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeyCertProtectedKeyParamS,
+        pub signature: BitString,
+    }
+    impl H235KeyCertProtectedKey {
+        pub fn new(
+            to_be_signed: EncodedKeySignedMaterial,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeyCertProtectedKeyParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " These allow the passing of session keys within the H.245 OLC structure."]
+    #[doc = " They are encoded as standalone ASN.1 and based as an OCTET STRING within H.245"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum H235Key {
+        secureChannel(KeyMaterial),
+        sharedSecret(H235KeySharedSecret),
+        certProtectedKey(H235KeyCertProtectedKey),
+    }
+    #[doc = " initial value for 64-bit block ciphers"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV16(pub FixedOctetString<16usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV8(pub FixedOctetString<8usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Identifier(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=2048"))]
+    pub struct KeyMaterial(pub BitString);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySignedMaterialEncrptvalParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl KeySignedMaterialEncrptvalParamS {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterialEncrptval {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: KeySignedMaterialEncrptvalParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl KeySignedMaterialEncrptval {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: KeySignedMaterialEncrptvalParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterial {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        pub mrandom: RandomVal,
+        pub srandom: Option<RandomVal>,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub encrptval: KeySignedMaterialEncrptval,
+    }
+    impl KeySignedMaterial {
+        pub fn new(
+            general_id: Identifier,
+            mrandom: RandomVal,
+            srandom: Option<RandomVal>,
+            time_stamp: Option<TimeStamp>,
+            encrptval: KeySignedMaterialEncrptval,
+        ) -> Self {
+            Self {
+                general_id,
+                mrandom,
+                srandom,
+                time_stamp,
+                encrptval,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "keyMaterial")]
+        pub key_material: KeyMaterial,
+    }
+    impl KeySyncMaterial {
+        pub fn new(general_id: Identifier, key_material: KeyMaterial) -> Self {
+            Self {
+                general_id,
+                key_material,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct NonStandardParameter {
+        #[rasn(identifier = "nonStandardIdentifier")]
+        pub non_standard_identifier: ObjectIdentifier,
+        pub data: OctetString,
+    }
+    impl NonStandardParameter {
+        pub fn new(non_standard_identifier: ObjectIdentifier, data: OctetString) -> Self {
+            Self {
+                non_standard_identifier,
+                data,
+            }
+        }
+    }
+    #[doc = " initial value for 128-bit block ciphers"]
+    #[doc = " signing algorithm used must select one of these types of parameters"]
+    #[doc = " needed by receiving end of signature."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct Params {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+    }
+    impl Params {
+        pub fn new(ran_int: Option<Integer>, iv8: Option<IV8>, iv16: Option<IV16>) -> Self {
+            Self { ran_int, iv8, iv16 }
+        }
+    }
+    #[doc = " 32-bit Integer"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Password(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PwdCertToken(pub ClearToken);
+    #[doc = " seconds since 00:00 1/1/1970 UTC"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RandomVal(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ReturnSig {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requestRandom")]
+        pub request_random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+    }
+    impl ReturnSig {
+        pub fn new(
+            general_id: Identifier,
+            response_random: RandomVal,
+            request_random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+        ) -> Self {
+            Self {
+                general_id,
+                response_random,
+                request_random,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=4294967295"))]
+    pub struct TimeStamp(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TypedCertificate {
+        #[rasn(identifier = "type")]
+        pub r_type: ObjectIdentifier,
+        pub certificate: OctetString,
+    }
+    impl TypedCertificate {
+        pub fn new(r_type: ObjectIdentifier, certificate: OctetString) -> Self {
+            Self {
+                r_type,
+                certificate,
+            }
+        }
+    }
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_2003-amd1_H235-SECURITY-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_2003-amd1_H235-SECURITY-MESSAGES.asn1.snap
@@ -2,42 +2,1035 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_h_h235_2003-amd1_H235-SECURITY-MESSAGES.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 252, column 2]
-     │
-     │ 
- 252 │  CryptoToken ::= CHOICE { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 253 │    cryptoEncryptedToken
- 254 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 255 │                                                                 OBJECT
- 256 │                                                                   IDENTIFIER,
- 257 │                                                               token
- 258 │                                                                 ENCRYPTED
- 259 │                                                                   {EncodedGeneralToken}
- 260 │    },
- 261 │    cryptoSignedToken
- 262 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 263 │                                                                 OBJECT
- 264 │                                                                   IDENTIFIER,
- 265 │                                                               token
- 266 │                                                                 SIGNED
- 267 │                                                                   {EncodedGeneralToken}
- 268 │    },
- 269 │    cryptoHashedToken
- 270 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 271 │                                                                 OBJECT
- 272 │                                                                   IDENTIFIER,
- 273 │                                                               hashedVals
- 274 │                                                                 ClearToken,
- 275 │                                                               token
- 276 │                                                                 HASHED
- 277 │                                                                   {EncodedGeneralToken}
- 278 │    },
- 279 │    cryptoPwdEncr         ENCRYPTED{EncodedPwdCertToken},
- 280 │    ...
- 281 │  }
- 283 │  -- These allow the passing of session keys within the H.245 OLC structure.
- 284 │  -- They are encoded as standalone ASN.1 and based as an OCTET STRING within
- 285 │  -- H.245
-     │
-─────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod h235_security_messages {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationBES {
+        default(()),
+        radius(()),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationMechanism {
+        dhExch(()),
+        pwdSymEnc(()),
+        pwdHash(()),
+        certSign(()),
+        ipsec(()),
+        tls(()),
+        nonStandard(NonStandardParameter),
+        #[rasn(extension_addition)]
+        authenticationBES(AuthenticationBES),
+        #[rasn(extension_addition)]
+        keyExch(ObjectIdentifier),
+    }
+    #[doc = " EXPORTS All"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("8..=128"))]
+    pub struct ChallengeString(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClearToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub password: Option<Password>,
+        pub dhkey: Option<DHset>,
+        pub challenge: Option<ChallengeString>,
+        pub random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "nonStandard")]
+        pub non_standard: Option<NonStandardParameter>,
+        #[rasn(extension_addition)]
+        pub eckasdhkey: Option<ECKASDH>,
+        #[rasn(extension_addition, identifier = "sendersID")]
+        pub senders_id: Option<Identifier>,
+        #[rasn(extension_addition, identifier = "h235Key")]
+        pub h235_key: Option<H235Key>,
+        #[rasn(extension_addition, identifier = "profileInfo")]
+        pub profile_info: Option<SequenceOf<ProfileElement>>,
+    }
+    impl ClearToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            time_stamp: Option<TimeStamp>,
+            password: Option<Password>,
+            dhkey: Option<DHset>,
+            challenge: Option<ChallengeString>,
+            random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+            general_id: Option<Identifier>,
+            non_standard: Option<NonStandardParameter>,
+            eckasdhkey: Option<ECKASDH>,
+            senders_id: Option<Identifier>,
+            h235_key: Option<H235Key>,
+            profile_info: Option<SequenceOf<ProfileElement>>,
+        ) -> Self {
+            Self {
+                token_oid,
+                time_stamp,
+                password,
+                dhkey,
+                challenge,
+                random,
+                certificate,
+                general_id,
+                non_standard,
+                eckasdhkey,
+                senders_id,
+                h235_key,
+                profile_info,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoEncryptedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoEncryptedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoEncryptedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoEncryptedTokenToken,
+    }
+    impl CryptoTokenCryptoEncryptedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            token: CryptoTokenCryptoEncryptedTokenToken,
+        ) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoSignedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoSignedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedTokenToken {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedGeneralToken,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+        pub signature: BitString,
+    }
+    impl CryptoTokenCryptoSignedTokenToken {
+        pub fn new(
+            to_be_signed: EncodedGeneralToken,
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoSignedTokenToken,
+    }
+    impl CryptoTokenCryptoSignedToken {
+        pub fn new(token_oid: ObjectIdentifier, token: CryptoTokenCryptoSignedTokenToken) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoHashedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoHashedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+        pub hash: BitString,
+    }
+    impl CryptoTokenCryptoHashedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+            hash: BitString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                hash,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "hashedVals")]
+        pub hashed_vals: ClearToken,
+        pub token: CryptoTokenCryptoHashedTokenToken,
+    }
+    impl CryptoTokenCryptoHashedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            hashed_vals: ClearToken,
+            token: CryptoTokenCryptoHashedTokenToken,
+        ) -> Self {
+            Self {
+                token_oid,
+                hashed_vals,
+                token,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoPwdEncrParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoPwdEncrParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoPwdEncr {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoPwdEncrParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoPwdEncr {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoPwdEncrParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum CryptoToken {
+        cryptoEncryptedToken(CryptoTokenCryptoEncryptedToken),
+        cryptoSignedToken(CryptoTokenCryptoSignedToken),
+        cryptoHashedToken(CryptoTokenCryptoHashedToken),
+        cryptoPwdEncr(CryptoTokenCryptoPwdEncr),
+    }
+    #[doc = " if local octet representations of these bit strings are used they shall"]
+    #[doc = " utilize standard Network Octet ordering (e.g., Big Endian)"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct DHset {
+        #[rasn(size("0..=2048"))]
+        pub halfkey: BitString,
+        #[rasn(size("0..=2048"), identifier = "modSize")]
+        pub mod_size: BitString,
+        #[rasn(size("0..=2048"))]
+        pub generator: BitString,
+    }
+    impl DHset {
+        pub fn new(halfkey: BitString, mod_size: BitString, generator: BitString) -> Self {
+            Self {
+                halfkey,
+                mod_size,
+                generator,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECGDSASignature {
+        #[rasn(size("0..=511"))]
+        pub r: BitString,
+        #[rasn(size("0..=511"))]
+        pub s: BitString,
+    }
+    impl ECGDSASignature {
+        pub fn new(r: BitString, s: BitString) -> Self {
+            Self { r, s }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdhp {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"))]
+        pub modulus: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdhp {
+        pub fn new(
+            public_key: ECpoint,
+            modulus: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                modulus,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdh2 {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"), identifier = "fieldSize")]
+        pub field_size: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdh2 {
+        pub fn new(
+            public_key: ECpoint,
+            field_size: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                field_size,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ECKASDH {
+        eckasdhp(ECKASDHEckasdhp),
+        eckasdh2(ECKASDHEckasdh2),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ECpoint {
+        #[rasn(size("0..=511"))]
+        pub x: Option<BitString>,
+        #[rasn(size("0..=511"))]
+        pub y: Option<BitString>,
+    }
+    impl ECpoint {
+        pub fn new(x: Option<BitString>, y: Option<BitString>) -> Self {
+            Self { x, y }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum Element {
+        octets(OctetString),
+        integer(Integer),
+        bits(BitString),
+        name(BmpString),
+        flag(bool),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedGeneralToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySignedMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySyncMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedPwdCertToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedReturnSig(pub Any);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignatureSignatureParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235CertificateSignatureSignatureParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235CertificateSignatureSignature {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedReturnSig,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235CertificateSignatureSignatureParamS,
+        pub signature: BitString,
+    }
+    impl H235CertificateSignatureSignature {
+        pub fn new(
+            to_be_signed: EncodedReturnSig,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235CertificateSignatureSignatureParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignature {
+        pub certificate: TypedCertificate,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requesterRandom")]
+        pub requester_random: Option<RandomVal>,
+        pub signature: H235CertificateSignatureSignature,
+    }
+    impl H235CertificateSignature {
+        pub fn new(
+            certificate: TypedCertificate,
+            response_random: RandomVal,
+            requester_random: Option<RandomVal>,
+            signature: H235CertificateSignatureSignature,
+        ) -> Self {
+            Self {
+                certificate,
+                response_random,
+                requester_random,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeySharedSecretParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235KeySharedSecretParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeySharedSecret {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeySharedSecretParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl H235KeySharedSecret {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeySharedSecretParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeyCertProtectedKeyParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235KeyCertProtectedKeyParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeyCertProtectedKey {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedKeySignedMaterial,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeyCertProtectedKeyParamS,
+        pub signature: BitString,
+    }
+    impl H235KeyCertProtectedKey {
+        pub fn new(
+            to_be_signed: EncodedKeySignedMaterial,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeyCertProtectedKeyParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " These allow the passing of session keys within the H.245 OLC structure."]
+    #[doc = " They are encoded as standalone ASN.1 and based as an OCTET STRING within"]
+    #[doc = " H.245"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum H235Key {
+        secureChannel(KeyMaterial),
+        sharedSecret(H235KeySharedSecret),
+        certProtectedKey(H235KeyCertProtectedKey),
+        #[rasn(extension_addition)]
+        secureSharedSecret(V3KeySyncMaterial),
+    }
+    #[doc = " initial value for 64-bit block ciphers"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV16(pub FixedOctetString<16usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV8(pub FixedOctetString<8usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Identifier(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=2048"))]
+    pub struct KeyMaterial(pub BitString);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySignedMaterialEncrptvalParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl KeySignedMaterialEncrptvalParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterialEncrptval {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: KeySignedMaterialEncrptvalParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl KeySignedMaterialEncrptval {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: KeySignedMaterialEncrptvalParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterial {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        pub mrandom: RandomVal,
+        pub srandom: Option<RandomVal>,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub encrptval: KeySignedMaterialEncrptval,
+    }
+    impl KeySignedMaterial {
+        pub fn new(
+            general_id: Identifier,
+            mrandom: RandomVal,
+            srandom: Option<RandomVal>,
+            time_stamp: Option<TimeStamp>,
+            encrptval: KeySignedMaterialEncrptval,
+        ) -> Self {
+            Self {
+                general_id,
+                mrandom,
+                srandom,
+                time_stamp,
+                encrptval,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "keyMaterial")]
+        pub key_material: KeyMaterial,
+    }
+    impl KeySyncMaterial {
+        pub fn new(general_id: Identifier, key_material: KeyMaterial) -> Self {
+            Self {
+                general_id,
+                key_material,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct NonStandardParameter {
+        #[rasn(identifier = "nonStandardIdentifier")]
+        pub non_standard_identifier: ObjectIdentifier,
+        pub data: OctetString,
+    }
+    impl NonStandardParameter {
+        pub fn new(non_standard_identifier: ObjectIdentifier, data: OctetString) -> Self {
+            Self {
+                non_standard_identifier,
+                data,
+            }
+        }
+    }
+    #[doc = " initial value for 128-bit block ciphers"]
+    #[doc = " signing algorithm used must select one of these types of parameters"]
+    #[doc = " needed by receiving end of signature."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct Params {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl Params {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " 32-bit Integer"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Password(pub BmpString);
+    #[doc = "\tAn object identifier should be placed in the tokenOID field when a"]
+    #[doc = "\tClearToken is included directly in a message (as opposed to being"]
+    #[doc = "\tencrypted). In all other cases, an application should use the"]
+    #[doc = "\tobject identifier { 0 0 } to indicate that the tokenOID value is not"]
+    #[doc = "\tpresent."]
+    #[doc = "\tStart all the cryptographic parameterized types here..."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ProfileElement {
+        #[rasn(value("0..=255"), identifier = "elementID")]
+        pub element_id: u8,
+        #[rasn(identifier = "parmS")]
+        pub parm_s: Option<Params>,
+        pub element: Option<Element>,
+    }
+    impl ProfileElement {
+        pub fn new(element_id: u8, parm_s: Option<Params>, element: Option<Element>) -> Self {
+            Self {
+                element_id,
+                parm_s,
+                element,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PwdCertToken(pub ClearToken);
+    #[doc = " seconds since 00:00"]
+    #[doc = " 1/1/1970 UTC"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RandomVal(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ReturnSig {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requestRandom")]
+        pub request_random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+    }
+    impl ReturnSig {
+        pub fn new(
+            general_id: Identifier,
+            response_random: RandomVal,
+            request_random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+        ) -> Self {
+            Self {
+                general_id,
+                response_random,
+                request_random,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=4294967295"))]
+    pub struct TimeStamp(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TypedCertificate {
+        #[rasn(identifier = "type")]
+        pub r_type: ObjectIdentifier,
+        pub certificate: OctetString,
+    }
+    impl TypedCertificate {
+        pub fn new(r_type: ObjectIdentifier, certificate: OctetString) -> Self {
+            Self {
+                r_type,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct V3KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: Option<ObjectIdentifier>,
+        #[rasn(identifier = "paramS")]
+        pub param_s: Params,
+        #[rasn(identifier = "encryptedSessionKey")]
+        pub encrypted_session_key: Option<OctetString>,
+        #[rasn(identifier = "encryptedSaltingKey")]
+        pub encrypted_salting_key: Option<OctetString>,
+        #[rasn(identifier = "clearSaltingKey")]
+        pub clear_salting_key: Option<OctetString>,
+        #[rasn(identifier = "paramSsalt")]
+        pub param_ssalt: Option<Params>,
+        #[rasn(identifier = "keyDerivationOID")]
+        pub key_derivation_oid: Option<ObjectIdentifier>,
+    }
+    impl V3KeySyncMaterial {
+        pub fn new(
+            general_id: Option<Identifier>,
+            algorithm_oid: Option<ObjectIdentifier>,
+            param_s: Params,
+            encrypted_session_key: Option<OctetString>,
+            encrypted_salting_key: Option<OctetString>,
+            clear_salting_key: Option<OctetString>,
+            param_ssalt: Option<Params>,
+            key_derivation_oid: Option<ObjectIdentifier>,
+        ) -> Self {
+            Self {
+                general_id,
+                algorithm_oid,
+                param_s,
+                encrypted_session_key,
+                encrypted_salting_key,
+                clear_salting_key,
+                param_ssalt,
+                key_derivation_oid,
+            }
+        }
+    }
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_2003_H235-SECURITY-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235_2003_H235-SECURITY-MESSAGES.asn1.snap
@@ -2,41 +2,992 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_h_h235_2003_H235-SECURITY-MESSAGES.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 221, column 2]
-     │
-     │ 
- 221 │  CryptoToken ::= CHOICE { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 222 │    cryptoEncryptedToken
- 223 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 224 │                                                                 OBJECT
- 225 │                                                                   IDENTIFIER,
- 226 │                                                               token
- 227 │                                                                 ENCRYPTED
- 228 │                                                                   {EncodedGeneralToken}
- 229 │    },
- 230 │    cryptoSignedToken
- 231 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 232 │                                                                 OBJECT
- 233 │                                                                   IDENTIFIER,
- 234 │                                                               token
- 235 │                                                                 SIGNED
- 236 │                                                                   {EncodedGeneralToken}
- 237 │    },
- 238 │    cryptoHashedToken
- 239 │      SEQUENCE-- General purpose/application specific token-- {tokenOID
- 240 │                                                                 OBJECT
- 241 │                                                                   IDENTIFIER,
- 242 │                                                               hashedVals
- 243 │                                                                 ClearToken,
- 244 │                                                               token
- 245 │                                                                 HASHED
- 246 │                                                                   {EncodedGeneralToken}
- 247 │    },
- 248 │    cryptoPwdEncr         ENCRYPTED{EncodedPwdCertToken},
- 249 │    ...
- 250 │  }
- 252 │  -- These allow the passing of session keys within the H.245 OLC structure.
- 253 │  -- They are encoded as standalone ASN.1 and based as an OCTET STRING within H.245
-     │
-─────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod h235_security_messages {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationBES {
+        default(()),
+        radius(()),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum AuthenticationMechanism {
+        dhExch(()),
+        pwdSymEnc(()),
+        pwdHash(()),
+        certSign(()),
+        ipsec(()),
+        tls(()),
+        nonStandard(NonStandardParameter),
+        #[rasn(extension_addition)]
+        authenticationBES(AuthenticationBES),
+    }
+    #[doc = " EXPORTS All"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("8..=128"))]
+    pub struct ChallengeString(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ClearToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub password: Option<Password>,
+        pub dhkey: Option<DHset>,
+        pub challenge: Option<ChallengeString>,
+        pub random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "nonStandard")]
+        pub non_standard: Option<NonStandardParameter>,
+        #[rasn(extension_addition)]
+        pub eckasdhkey: Option<ECKASDH>,
+        #[rasn(extension_addition, identifier = "sendersID")]
+        pub senders_id: Option<Identifier>,
+        #[rasn(extension_addition, identifier = "h235Key")]
+        pub h235_key: Option<H235Key>,
+    }
+    impl ClearToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            time_stamp: Option<TimeStamp>,
+            password: Option<Password>,
+            dhkey: Option<DHset>,
+            challenge: Option<ChallengeString>,
+            random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+            general_id: Option<Identifier>,
+            non_standard: Option<NonStandardParameter>,
+            eckasdhkey: Option<ECKASDH>,
+            senders_id: Option<Identifier>,
+            h235_key: Option<H235Key>,
+        ) -> Self {
+            Self {
+                token_oid,
+                time_stamp,
+                password,
+                dhkey,
+                challenge,
+                random,
+                certificate,
+                general_id,
+                non_standard,
+                eckasdhkey,
+                senders_id,
+                h235_key,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoEncryptedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoEncryptedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoEncryptedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoEncryptedTokenTokenParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoEncryptedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoEncryptedTokenToken,
+    }
+    impl CryptoTokenCryptoEncryptedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            token: CryptoTokenCryptoEncryptedTokenToken,
+        ) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoSignedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoSignedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedTokenToken {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedGeneralToken,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+        pub signature: BitString,
+    }
+    impl CryptoTokenCryptoSignedTokenToken {
+        pub fn new(
+            to_be_signed: EncodedGeneralToken,
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoSignedTokenTokenParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoSignedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        pub token: CryptoTokenCryptoSignedTokenToken,
+    }
+    impl CryptoTokenCryptoSignedToken {
+        pub fn new(token_oid: ObjectIdentifier, token: CryptoTokenCryptoSignedTokenToken) -> Self {
+            Self { token_oid, token }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoHashedTokenTokenParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoHashedTokenTokenParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedTokenToken {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+        pub hash: BitString,
+    }
+    impl CryptoTokenCryptoHashedTokenToken {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoHashedTokenTokenParamS,
+            hash: BitString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                hash,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoHashedToken {
+        #[rasn(identifier = "tokenOID")]
+        pub token_oid: ObjectIdentifier,
+        #[rasn(identifier = "hashedVals")]
+        pub hashed_vals: ClearToken,
+        pub token: CryptoTokenCryptoHashedTokenToken,
+    }
+    impl CryptoTokenCryptoHashedToken {
+        pub fn new(
+            token_oid: ObjectIdentifier,
+            hashed_vals: ClearToken,
+            token: CryptoTokenCryptoHashedTokenToken,
+        ) -> Self {
+            Self {
+                token_oid,
+                hashed_vals,
+                token,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct CryptoTokenCryptoPwdEncrParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl CryptoTokenCryptoPwdEncrParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct CryptoTokenCryptoPwdEncr {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: CryptoTokenCryptoPwdEncrParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl CryptoTokenCryptoPwdEncr {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: CryptoTokenCryptoPwdEncrParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum CryptoToken {
+        cryptoEncryptedToken(CryptoTokenCryptoEncryptedToken),
+        cryptoSignedToken(CryptoTokenCryptoSignedToken),
+        cryptoHashedToken(CryptoTokenCryptoHashedToken),
+        cryptoPwdEncr(CryptoTokenCryptoPwdEncr),
+    }
+    #[doc = " if local octet representations of these bit strings are used they shall"]
+    #[doc = " utilize standard Network Octet ordering (e.g. Big Endian)"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct DHset {
+        #[rasn(size("0..=2048"))]
+        pub halfkey: BitString,
+        #[rasn(size("0..=2048"), identifier = "modSize")]
+        pub mod_size: BitString,
+        #[rasn(size("0..=2048"))]
+        pub generator: BitString,
+    }
+    impl DHset {
+        pub fn new(halfkey: BitString, mod_size: BitString, generator: BitString) -> Self {
+            Self {
+                halfkey,
+                mod_size,
+                generator,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECGDSASignature {
+        #[rasn(size("0..=511"))]
+        pub r: BitString,
+        #[rasn(size("0..=511"))]
+        pub s: BitString,
+    }
+    impl ECGDSASignature {
+        pub fn new(r: BitString, s: BitString) -> Self {
+            Self { r, s }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdhp {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"))]
+        pub modulus: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdhp {
+        pub fn new(
+            public_key: ECpoint,
+            modulus: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                modulus,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ECKASDHEckasdh2 {
+        #[rasn(identifier = "public-key")]
+        pub public_key: ECpoint,
+        #[rasn(size("0..=511"), identifier = "fieldSize")]
+        pub field_size: BitString,
+        pub base: ECpoint,
+        #[rasn(size("0..=511"), identifier = "weierstrassA")]
+        pub weierstrass_a: BitString,
+        #[rasn(size("0..=511"), identifier = "weierstrassB")]
+        pub weierstrass_b: BitString,
+    }
+    impl ECKASDHEckasdh2 {
+        pub fn new(
+            public_key: ECpoint,
+            field_size: BitString,
+            base: ECpoint,
+            weierstrass_a: BitString,
+            weierstrass_b: BitString,
+        ) -> Self {
+            Self {
+                public_key,
+                field_size,
+                base,
+                weierstrass_a,
+                weierstrass_b,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ECKASDH {
+        eckasdhp(ECKASDHEckasdhp),
+        eckasdh2(ECKASDHEckasdh2),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ECpoint {
+        #[rasn(size("0..=511"))]
+        pub x: Option<BitString>,
+        #[rasn(size("0..=511"))]
+        pub y: Option<BitString>,
+    }
+    impl ECpoint {
+        pub fn new(x: Option<BitString>, y: Option<BitString>) -> Self {
+            Self { x, y }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedGeneralToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySignedMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedKeySyncMaterial(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedPwdCertToken(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedReturnSig(pub Any);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignatureSignatureParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235CertificateSignatureSignatureParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235CertificateSignatureSignature {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedReturnSig,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235CertificateSignatureSignatureParamS,
+        pub signature: BitString,
+    }
+    impl H235CertificateSignatureSignature {
+        pub fn new(
+            to_be_signed: EncodedReturnSig,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235CertificateSignatureSignatureParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235CertificateSignature {
+        pub certificate: TypedCertificate,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requesterRandom")]
+        pub requester_random: Option<RandomVal>,
+        pub signature: H235CertificateSignatureSignature,
+    }
+    impl H235CertificateSignature {
+        pub fn new(
+            certificate: TypedCertificate,
+            response_random: RandomVal,
+            requester_random: Option<RandomVal>,
+            signature: H235CertificateSignatureSignature,
+        ) -> Self {
+            Self {
+                certificate,
+                response_random,
+                requester_random,
+                signature,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeySharedSecretParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235KeySharedSecretParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeySharedSecret {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeySharedSecretParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl H235KeySharedSecret {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeySharedSecretParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct H235KeyCertProtectedKeyParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl H235KeyCertProtectedKeyParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct H235KeyCertProtectedKey {
+        #[rasn(identifier = "toBeSigned")]
+        pub to_be_signed: EncodedKeySignedMaterial,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: H235KeyCertProtectedKeyParamS,
+        pub signature: BitString,
+    }
+    impl H235KeyCertProtectedKey {
+        pub fn new(
+            to_be_signed: EncodedKeySignedMaterial,
+            algorithm_oid: ObjectIdentifier,
+            param_s: H235KeyCertProtectedKeyParamS,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                to_be_signed,
+                algorithm_oid,
+                param_s,
+                signature,
+            }
+        }
+    }
+    #[doc = " These allow the passing of session keys within the H.245 OLC structure."]
+    #[doc = " They are encoded as standalone ASN.1 and based as an OCTET STRING within H.245"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum H235Key {
+        secureChannel(KeyMaterial),
+        sharedSecret(H235KeySharedSecret),
+        certProtectedKey(H235KeyCertProtectedKey),
+        #[rasn(extension_addition)]
+        secureSharedSecret(V3KeySyncMaterial),
+    }
+    #[doc = " initial value for 64-bit block ciphers"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV16(pub FixedOctetString<16usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct IV8(pub FixedOctetString<8usize>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Identifier(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=2048"))]
+    pub struct KeyMaterial(pub BitString);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySignedMaterialEncrptvalParamS {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl KeySignedMaterialEncrptvalParamS {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterialEncrptval {
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: ObjectIdentifier,
+        #[rasn(identifier = "paramS")]
+        pub param_s: KeySignedMaterialEncrptvalParamS,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: OctetString,
+    }
+    impl KeySignedMaterialEncrptval {
+        pub fn new(
+            algorithm_oid: ObjectIdentifier,
+            param_s: KeySignedMaterialEncrptvalParamS,
+            encrypted_data: OctetString,
+        ) -> Self {
+            Self {
+                algorithm_oid,
+                param_s,
+                encrypted_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct KeySignedMaterial {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        pub mrandom: RandomVal,
+        pub srandom: Option<RandomVal>,
+        #[rasn(identifier = "timeStamp")]
+        pub time_stamp: Option<TimeStamp>,
+        pub encrptval: KeySignedMaterialEncrptval,
+    }
+    impl KeySignedMaterial {
+        pub fn new(
+            general_id: Identifier,
+            mrandom: RandomVal,
+            srandom: Option<RandomVal>,
+            time_stamp: Option<TimeStamp>,
+            encrptval: KeySignedMaterialEncrptval,
+        ) -> Self {
+            Self {
+                general_id,
+                mrandom,
+                srandom,
+                time_stamp,
+                encrptval,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "keyMaterial")]
+        pub key_material: KeyMaterial,
+    }
+    impl KeySyncMaterial {
+        pub fn new(general_id: Identifier, key_material: KeyMaterial) -> Self {
+            Self {
+                general_id,
+                key_material,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct NonStandardParameter {
+        #[rasn(identifier = "nonStandardIdentifier")]
+        pub non_standard_identifier: ObjectIdentifier,
+        pub data: OctetString,
+    }
+    impl NonStandardParameter {
+        pub fn new(non_standard_identifier: ObjectIdentifier, data: OctetString) -> Self {
+            Self {
+                non_standard_identifier,
+                data,
+            }
+        }
+    }
+    #[doc = " initial value for 128-bit block ciphers"]
+    #[doc = " signing algorithm used must select one of these types of parameters"]
+    #[doc = " needed by receiving end of signature."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct Params {
+        #[rasn(identifier = "ranInt")]
+        pub ran_int: Option<Integer>,
+        pub iv8: Option<IV8>,
+        #[rasn(extension_addition)]
+        pub iv16: Option<IV16>,
+        #[rasn(extension_addition)]
+        pub iv: Option<OctetString>,
+        #[rasn(extension_addition, identifier = "clearSalt")]
+        pub clear_salt: Option<OctetString>,
+    }
+    impl Params {
+        pub fn new(
+            ran_int: Option<Integer>,
+            iv8: Option<IV8>,
+            iv16: Option<IV16>,
+            iv: Option<OctetString>,
+            clear_salt: Option<OctetString>,
+        ) -> Self {
+            Self {
+                ran_int,
+                iv8,
+                iv16,
+                iv,
+                clear_salt,
+            }
+        }
+    }
+    #[doc = " 32-bit Integer"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct Password(pub BmpString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PwdCertToken(pub ClearToken);
+    #[doc = " seconds since 00:00 1/1/1970 UTC"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RandomVal(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ReturnSig {
+        #[rasn(identifier = "generalId")]
+        pub general_id: Identifier,
+        #[rasn(identifier = "responseRandom")]
+        pub response_random: RandomVal,
+        #[rasn(identifier = "requestRandom")]
+        pub request_random: Option<RandomVal>,
+        pub certificate: Option<TypedCertificate>,
+    }
+    impl ReturnSig {
+        pub fn new(
+            general_id: Identifier,
+            response_random: RandomVal,
+            request_random: Option<RandomVal>,
+            certificate: Option<TypedCertificate>,
+        ) -> Self {
+            Self {
+                general_id,
+                response_random,
+                request_random,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("1..=4294967295"))]
+    pub struct TimeStamp(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TypedCertificate {
+        #[rasn(identifier = "type")]
+        pub r_type: ObjectIdentifier,
+        pub certificate: OctetString,
+    }
+    impl TypedCertificate {
+        pub fn new(r_type: ObjectIdentifier, certificate: OctetString) -> Self {
+            Self {
+                r_type,
+                certificate,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct V3KeySyncMaterial {
+        #[rasn(identifier = "generalID")]
+        pub general_id: Option<Identifier>,
+        #[rasn(identifier = "algorithmOID")]
+        pub algorithm_oid: Option<ObjectIdentifier>,
+        #[rasn(identifier = "paramS")]
+        pub param_s: Params,
+        #[rasn(identifier = "encryptedSessionKey")]
+        pub encrypted_session_key: Option<OctetString>,
+        #[rasn(identifier = "encryptedSaltingKey")]
+        pub encrypted_salting_key: Option<OctetString>,
+        #[rasn(identifier = "clearSaltingKey")]
+        pub clear_salting_key: Option<OctetString>,
+        #[rasn(identifier = "paramSsalt")]
+        pub param_ssalt: Option<Params>,
+        #[rasn(identifier = "keyDerivationOID")]
+        pub key_derivation_oid: Option<ObjectIdentifier>,
+    }
+    impl V3KeySyncMaterial {
+        pub fn new(
+            general_id: Option<Identifier>,
+            algorithm_oid: Option<ObjectIdentifier>,
+            param_s: Params,
+            encrypted_session_key: Option<OctetString>,
+            encrypted_salting_key: Option<OctetString>,
+            clear_salting_key: Option<OctetString>,
+            param_ssalt: Option<Params>,
+            key_derivation_oid: Option<ObjectIdentifier>,
+        ) -> Self {
+            Self {
+                general_id,
+                algorithm_oid,
+                param_s,
+                encrypted_session_key,
+                encrypted_salting_key,
+                clear_salting_key,
+                param_ssalt,
+                key_derivation_oid,
+            }
+        }
+    }
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q1238.4_2000_IN-CS3-SCF-SDF-Additional-Definitions.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q1238.4_2000_IN-CS3-SCF-SDF-Additional-Definitions.asn1.snap
@@ -2,27 +2,99 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_q_q1238.4_2000_IN-CS3-SCF-SDF-Additional-Definitions.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 218, column 6]
-     │
-     │ 
- 218 │      (WITH COMPONENTS { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 219 │         ...,
- 220 │         toBeProtected  (WITH COMPONENTS {
- 221 │                           ...,
- 222 │                           searchInfo  (WITH COMPONENTS {
- 223 │                                          ...,
- 224 │                                          entries                  (WITH
- 225 │                                                                      COMPONENT
- 226 │                                                                      (IN-EntryInformation)),
- 227 │                                          partialOutcomeQualifier  (PartialOutcomeQualifier
- 228 │                                                                      (WITH COMPONENTS {
- 229 │                                                                      ...,
- 230 │                                                                      queryReference  ABSENT
- 231 │                                                                      }))OPTIONAL
- 232 │                                        })
- 233 │                         })
- 234 │       })
- 236 │  -- Errors definition
-     │
-─────╯
+Warnings:
+LinkerError in ASN grammar: Failed to resolve reference of ElsewhereDefined: ERROR
+LinkerError in ASN grammar: Failed to resolve reference of ElsewhereDefined: ERROR
+
+
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod in_cs3_scf_sdf_additional_definitions {
+    extern crate alloc;
+    use super::directory_abstract_service::{
+        AddEntryArgument, AddEntryResult, CommonArguments, DirectoryBindArgument,
+        DirectoryBindResult, EntryInformation, EntryInformationSelection, ModifyEntryArgument,
+        ModifyEntryResult, PartialOutcomeQualifier, RemoveEntryArgument, RemoveEntryResult,
+        SearchArgument, SearchResult, SecurityProblem, ServiceControls, ServiceProblem,
+        ATTRIBUTE_ERROR, DIRECTORY_BIND_ERROR, NAME_ERROR, REFERRAL, SECURITY_ERROR, SERVICE_ERROR,
+        UPDATE_ERROR,
+    };
+    use super::directory_access_protocol::{
+        ID_OPCODE_ADD_ENTRY, ID_OPCODE_MODIFY_ENTRY, ID_OPCODE_REMOVE_ENTRY, ID_OPCODE_SEARCH,
+    };
+    use super::in_cs3_errortypes::EXECUTION_ERROR;
+    use super::in_cs3_object_identifiers::{
+        DS_USEFUL_DEFINITIONS, ERRORTYPES, OPERATIONCODES, ROS_INFORMATION_OBJECTS,
+        SCF_SDF_OPERATIONS,
+    };
+    use super::in_cs3_operationcodes::OPCODE_EXECUTE;
+    use super::in_cs3_scf_sdf_operations::{ExecuteArgument, ExecuteResult, EXECUTE};
+    use super::remote_operations_information_objects::*;
+    use super::useful_definitions::{DAP, DIRECTORY_ABSTRACT_SERVICE};
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-AddEntryArgument")]
+    pub struct INAddEntryArgument(pub AddEntryArgument);
+    #[doc = " Information types and common procedures"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-CommonArguments")]
+    pub struct INCommonArguments(pub CommonArguments);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-EntryInformation")]
+    pub struct INEntryInformation(pub EntryInformation);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-EntryInformationSelection")]
+    pub struct INEntryInformationSelection(pub EntryInformationSelection);
+    #[doc = " Operations, Arguments and Results definition"]
+    #[doc = " EDITOR: \u{93}execute\u{94} has been imported and cannot be redefined"]
+    #[doc = "execute OPERATION ::= {"]
+    #[doc = "\tARGUMENT\tIN-ExecuteArgument"]
+    #[doc = "\tRESULT\t\tExecuteResult"]
+    #[doc = "\tERRORS \t\t{ attributeError | nameError |  in-ServiceError | referral |"]
+    #[doc = "\t\t\t\tsecurityError | updateError | executionError }"]
+    #[doc = "\tCODE\t\topcode-execute }"]
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ExecuteArgument")]
+    pub struct INExecuteArgument(pub ExecuteArgument);
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ModifyEntryArgument")]
+    pub struct INModifyEntryArgument(pub ModifyEntryArgument);
+    #[doc = " Note that CommonArguments in X.511 ModifyEntryArgument is replaced with IN-CommonArguments."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ModifyEntryResult")]
+    pub struct INModifyEntryResult(pub ModifyEntryResult);
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-RemoveEntryArgument")]
+    pub struct INRemoveEntryArgument(pub RemoveEntryArgument);
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-SearchArgument")]
+    pub struct INSearchArgument(pub SearchArgument);
+    #[doc = " Note that CommonArguments in X.511 SearchArgument is replaced with IN-CommonArguments."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-SearchResult")]
+    pub struct INSearchResult(pub SearchResult);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ServiceControls")]
+    pub struct INServiceControls(pub ServiceControls);
+    #[doc = " Errors definition"]
+    pub static IN_DIRECTORY_BIND_ERROR: LazyLock<ERROR> =
+        LazyLock::new(|| ERROR(DIRECTORY_BIND_ERROR));
+    #[doc = "EDITOR: The following constraint ought to be applied to the field \"&ParameterType\""]
+    #[doc = "of the **information object** \"directoryBindError\":"]
+    #[doc = " SecurityProblem 10 indicates that the supplied SPKM token was found to be valid."]
+    #[doc = " In reception, all the possible errors should be supported to understand a Bind error"]
+    pub static IN_SERVICE_ERROR: LazyLock<ERROR> = LazyLock::new(|| ERROR(SERVICE_ERROR));
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q1248.4_2001_IN-SCF-SDF-Additional-Definitions.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q1248.4_2001_IN-SCF-SDF-Additional-Definitions.asn1.snap
@@ -2,27 +2,95 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_q_q1248.4_2001_IN-SCF-SDF-Additional-Definitions.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 217, column 6]
-     │
-     │ 
- 217 │      (WITH COMPONENTS { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 218 │         ...,
- 219 │         toBeProtected  (WITH COMPONENTS {
- 220 │                           ...,
- 221 │                           searchInfo  (WITH COMPONENTS {
- 222 │                                          ...,
- 223 │                                          entries                  (WITH
- 224 │                                                                      COMPONENT
- 225 │                                                                      (IN-EntryInformation)),
- 226 │                                          partialOutcomeQualifier  (PartialOutcomeQualifier
- 227 │                                                                      (WITH COMPONENTS {
- 228 │                                                                      ...,
- 229 │                                                                      queryReference  ABSENT
- 230 │                                                                      }))OPTIONAL
- 231 │                                        })
- 232 │                         })
- 233 │       })
- 235 │  -- Errors definition
-     │
-─────╯
+Warnings:
+LinkerError in ASN grammar: Failed to resolve reference of ElsewhereDefined: ERROR
+LinkerError in ASN grammar: Failed to resolve reference of ElsewhereDefined: ERROR
+
+
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod in_scf_sdf_additional_definitions {
+    extern crate alloc;
+    use super::directory_abstract_service::{
+        AddEntryArgument, AddEntryResult, CommonArguments, DirectoryBindArgument,
+        DirectoryBindResult, EntryInformation, EntryInformationSelection, ModifyEntryArgument,
+        ModifyEntryResult, PartialOutcomeQualifier, RemoveEntryArgument, RemoveEntryResult,
+        SearchArgument, SearchResult, SecurityProblem, ServiceControls, ServiceProblem,
+        ATTRIBUTE_ERROR, DIRECTORY_BIND_ERROR, NAME_ERROR, REFERRAL, SECURITY_ERROR, SERVICE_ERROR,
+        UPDATE_ERROR,
+    };
+    use super::directory_access_protocol::{
+        ID_OPCODE_ADD_ENTRY, ID_OPCODE_MODIFY_ENTRY, ID_OPCODE_REMOVE_ENTRY, ID_OPCODE_SEARCH,
+    };
+    use super::in_errortypes::EXECUTION_ERROR;
+    use super::in_object_identifiers::{
+        DS_USEFUL_DEFINITIONS, ERRORTYPES, OPERATIONCODES, ROS_INFORMATION_OBJECTS,
+        SCF_SDF_OPERATIONS,
+    };
+    use super::in_operationcodes::OPCODE_EXECUTE;
+    use super::in_scf_sdf_operations::{ExecuteArgument, ExecuteResult};
+    use super::remote_operations_information_objects::*;
+    use super::useful_definitions::{DAP, DIRECTORY_ABSTRACT_SERVICE};
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-AddEntryArgument")]
+    pub struct INAddEntryArgument(pub AddEntryArgument);
+    #[doc = " Information types and common procedures"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-CommonArguments")]
+    pub struct INCommonArguments(pub CommonArguments);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-EntryInformation")]
+    pub struct INEntryInformation(pub EntryInformation);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-EntryInformationSelection")]
+    pub struct INEntryInformationSelection(pub EntryInformationSelection);
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ExecuteArgument")]
+    pub struct INExecuteArgument(pub ExecuteArgument);
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ModifyEntryArgument")]
+    pub struct INModifyEntryArgument(pub ModifyEntryArgument);
+    #[doc = " The last two elements belong to IN-CommonArgument type."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ModifyEntryResult")]
+    pub struct INModifyEntryResult(pub ModifyEntryResult);
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-RemoveEntryArgument")]
+    pub struct INRemoveEntryArgument(pub RemoveEntryArgument);
+    #[doc = " Direction: SCF->SDF"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-SearchArgument")]
+    pub struct INSearchArgument(pub SearchArgument);
+    #[doc = " The last two elements belong to IN-CommonArgument type."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-SearchResult")]
+    pub struct INSearchResult(pub SearchResult);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "IN-ServiceControls")]
+    pub struct INServiceControls(pub ServiceControls);
+    #[doc = " Errors definition"]
+    pub static IN_DIRECTORY_BIND_ERROR: LazyLock<ERROR> =
+        LazyLock::new(|| ERROR(DIRECTORY_BIND_ERROR));
+    #[doc = " the following constraint shall be applied to the parameter error"]
+    #[doc = " (WITH COMPONENTS{"]
+    #[doc = " \t...,"]
+    #[doc = " \terror (WITH COMPONENTS{"]
+    #[doc = " \t\tserviceError(ServiceProblem(2)),"]
+    #[doc = " \t\tsecurityError(SecurityProblem(1|2|7|10)) })})"]
+    #[doc = " SecurityProblem 10 indicates that the supplied SPKM token was found to be valid."]
+    #[doc = " In reception, all the possible errors should be supported to understand a Bind error"]
+    pub static IN_SERVICE_ERROR: LazyLock<ERROR> = LazyLock::new(|| ERROR(SERVICE_ERROR));
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q825_1998_ASN1DefinedTypesModuleNew.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q825_1998_ASN1DefinedTypesModuleNew.asn1.snap
@@ -2,12 +2,51 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_q_q825_1998_ASN1DefinedTypesModuleNew.asn1
 ---
-Error matching ASN syntax at while parsing:
-    ╭─[line 26, column 13]
-    │
-    │ 
- 26 │   OF MANAGEMENT-EXTENSION({AllowedAdditionalRecordTypes}) ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 28 │  -- The AllowedAdditionalRecordTypes is the constraint that allows only certain types to be set as
- 29 │  -- AdditionalRecordType.
-    │
-────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod asn1_defined_types_module_new {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct AdditionalRecordType(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " The AdditionalRecordTypes type is to be used in the RecordContent type of"]
+    #[doc = " ASN1DefinedTypesModule module."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct BlockExtension(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " The BlockExtensions type is to be used in the BlockHeaderRecord type of"]
+    #[doc = " ASN1DefinedTypesModule"]
+    #[doc = " module"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RecordExtension(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " The RecordExtensions type is to be used in the CallRecord type of"]
+    #[doc = " ASN1DefinedTypesModule module"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ServiceSpecificINInformation(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " TheServiceSpecificINInformations type is to be used in the CallRecord type of"]
+    #[doc = " ASN1DefinedTypesModule module."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct StandardAdditionalRecordType(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " TheStandardAdditionalRecordTypes type is to be used in the RecordContent type of"]
+    #[doc = " ASN1DefinedTypesModule module."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct StandardExtension(pub MANAGEMENTEXTENSION);
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x1085_2016_XBHSM.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x1085_2016_XBHSM.asn1.snap
@@ -2,11 +2,95 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_x_x1085_2016_XBHSM.asn1
 ---
-Error matching ASN syntax at while parsing:
-    ╭─[line 39, column 35]
-    │
-    │ 
- 39 │   OF BHSM-PSID({SupportedBHSM-PSID}) ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 40 │  	SupportedBHSM-PSID BHSM-PSID ::= {bioRef,...}
-    │
-────╯
+Warnings:
+LinkerError in ASN grammar: No syntax definition for information object class found!
+LinkerError in ASN grammar: No syntax definition for information object class found!
+LinkerError in ASN grammar: Failed to resolve supertype AlgorithmIdentifier of parameterized implementation.
+LinkerError in ASN grammar: Failed to resolve supertype AlgorithmIdentifier of parameterized implementation.
+
+
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod xbhsm {
+    extern crate alloc;
+    use super::authentication_framework::*;
+    use super::useful_definitions::AUTHENTICATION_FRAMEWORK;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct DataSetForEncryptedPSID {
+        #[rasn(default = "data_set_for_encrypted_psid_version_default")]
+        pub version: Integer,
+        #[rasn(identifier = "psidEncAlg")]
+        pub psid_enc_alg: PSIDEncryptionAlgorithm,
+        #[rasn(identifier = "encryptedPsid")]
+        pub encrypted_psid: EncryptedPsid,
+    }
+    impl DataSetForEncryptedPSID {
+        pub fn new(
+            version: Integer,
+            psid_enc_alg: PSIDEncryptionAlgorithm,
+            encrypted_psid: EncryptedPsid,
+        ) -> Self {
+            Self {
+                version,
+                psid_enc_alg,
+                encrypted_psid,
+            }
+        }
+    }
+    fn data_set_for_encrypted_psid_version_default() -> Integer {
+        Integer::from(0i128)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncryptedPsid(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct HashAlgorithm(pub AlgorithmIdentifier);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct HashContent {
+        #[rasn(identifier = "bR")]
+        pub b_r: PrintableString,
+        #[rasn(identifier = "randomNum")]
+        pub random_num: BitString,
+    }
+    impl HashContent {
+        pub fn new(b_r: PrintableString, random_num: BitString) -> Self {
+            Self { b_r, random_num }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "InstanceOfBHSM-PID")]
+    pub struct InstanceOfBHSMPID(pub BHSMPSID);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PSID {
+        #[rasn(identifier = "hashAlg")]
+        pub hash_alg: HashAlgorithm,
+        #[rasn(identifier = "hashContent")]
+        pub hash_content: HashContent,
+    }
+    impl PSID {
+        pub fn new(hash_alg: HashAlgorithm, hash_content: HashContent) -> Self {
+            Self {
+                hash_alg,
+                hash_content,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PSIDEncryptionAlgorithm(pub AlgorithmIdentifier);
+    pub static BHSMPSID: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::const_new(&[1u32, 0u32, 17922u32, 2u32, 1u32]).to_owned());
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x413_1999_MSAbstractService.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x413_1999_MSAbstractService.asn1.snap
@@ -3,9 +3,31 @@ source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_x_x413_1999_MSAbstractService.asn1
 ---
 Error matching ASN syntax at while parsing:
-     ╭─[line 237, column 31]
+     ╭─[line 391, column 2]
      │
      │ 
- 237 │   OF MS-EXTENSION ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
+ 391 │  FilterItem ::= CHOICE { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
+ 392 │    equality           [0]  AttributeValueAssertion,
+ 393 │    substrings
+ 394 │      [1]  SEQUENCE {type     X413ATTRIBUTE.&id({AttributeTable}),
+ 395 │                     strings
+ 396 │                       SEQUENCE OF
+ 397 │                         CHOICE {initial
+ 398 │                                   [0]  X413ATTRIBUTE.&Type
+ 399 │                                          ({AttributeTable}{@substrings.type}),
+ 400 │                                 any
+ 401 │                                   [1]  X413ATTRIBUTE.&Type
+ 402 │                                          ({AttributeTable}{@substrings.type}),
+ 403 │                                 final
+ 404 │                                   [2]  X413ATTRIBUTE.&Type
+ 405 │                                          ({AttributeTable}{@substrings.type})
+ 406 │                         }},
+ 407 │    greater-or-equal   [2]  AttributeValueAssertion,
+ 408 │    less-or-equal      [3]  AttributeValueAssertion,
+ 409 │    present            [4]  X413ATTRIBUTE.&id({AttributeTable}),
+ 410 │    approximate-match  [5]  AttributeValueAssertion,
+ 411 │    -- 1994 extension
+ 412 │    other-match        [6]  MatchingRuleAssertion
+ 413 │  }
      │
 ─────╯

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -59,8 +59,7 @@ pub const NULL: &str = "NULL";
 pub const BOOLEAN: &str = "BOOLEAN";
 pub const INTEGER: &str = "INTEGER";
 pub const REAL: &str = "REAL";
-pub const BIT_STRING: &str = "BIT STRING";
-pub const OCTET_STRING: &str = "OCTET STRING";
+pub const STRING: &str = "STRING";
 pub const IA5_STRING: &str = "IA5String";
 pub const UTF8_STRING: &str = "UTF8String";
 pub const NUMERIC_STRING: &str = "NumericString";
@@ -78,13 +77,11 @@ pub const UTC_TIME: &str = "UTCTime";
 pub const ENUMERATED: &str = "ENUMERATED";
 pub const CHOICE: &str = "CHOICE";
 pub const SEQUENCE: &str = "SEQUENCE";
-pub const SEQUENCE_OF: &str = "SEQUENCE OF";
-pub const SET_OF: &str = "SET OF";
 pub const OF: &str = "OF";
 pub const ALL: &str = "ALL";
 pub const SET: &str = "SET";
-pub const OBJECT_IDENTIFIER: &str = "OBJECT IDENTIFIER";
-pub const COMPONENTS_OF: &str = "COMPONENTS OF";
+pub const IDENTIFIER: &str = "IDENTIFIER";
+pub const COMPONENTS: &str = "COMPONENTS";
 pub const ANY: &str = "ANY";
 pub const DEFINED: &str = "DEFINED";
 pub const BY: &str = "BY";
@@ -110,29 +107,30 @@ pub const EXPORTS: &str = "EXPORTS";
 pub const FROM: &str = "FROM";
 pub const INSTRUCTIONS: &str = "INSTRUCTIONS";
 pub const TAGS: &str = "TAGS";
-pub const EXTENSIBILITY_IMPLIED: &str = "EXTENSIBILITY IMPLIED";
-pub const WITH_SUCCESSORS: &str = "WITH SUCCESSORS";
-pub const WITH_DESCENDANTS: &str = "WITH DESCENDANTS";
+pub const EXTENSIBILITY: &str = "EXTENSIBILITY";
+pub const IMPLIED: &str = "IMPLIED";
+pub const WITH: &str = "WITH";
+pub const SUCCESSORS: &str = "SUCCESSORS";
+pub const DESCENDANTS: &str = "DESCENDANTS";
 pub const SEMICOLON: char = ';';
 
 // Information Object Class tokens
 pub const AMPERSAND: char = '&';
 pub const CLASS: &str = "CLASS";
 pub const UNIQUE: &str = "UNIQUE";
-pub const WITH_SYNTAX: &str = "WITH SYNTAX";
+pub const SYNTAX: &str = "SYNTAX";
 pub const AT: char = '@';
 pub const DOT: char = '.';
 
 // Subtyping tokens
 pub const SIZE: &str = "SIZE";
-pub const CONSTRAINED_BY: &str = "CONSTRAINED BY";
+pub const CONSTRAINED: &str = "CONSTRAINED";
 pub const PATTERN: &str = "PATTERN";
 pub const DEFAULT: &str = "DEFAULT";
 pub const CONTAINING: &str = "CONTAINING";
-pub const ENCODED_BY: &str = "ENCODED BY";
+pub const ENCODED: &str = "ENCODED";
 pub const OPTIONAL: &str = "OPTIONAL";
-pub const WITH_COMPONENTS: &str = "WITH COMPONENTS";
-pub const WITH_COMPONENT: &str = "WITH COMPONENT";
+pub const COMPONENT: &str = "COMPONENT";
 pub const UNION: &str = "UNION";
 pub const EXCEPT: &str = "EXCEPT";
 pub const INTERSECTION: &str = "INTERSECTION";
@@ -163,9 +161,10 @@ pub const CHARACTER: &str = "CHARACTER";
 pub const DATE: &str = "DATE";
 pub const DATE_TIME: &str = "DATE-TIME";
 pub const DURATION: &str = "DURATION";
-pub const EMBEDDED_PDV: &str = "EMBEDDED PDV";
+pub const EMBEDDED: &str = "EMBEDDED";
+pub const PDV: &str = "PDV";
 pub const EXTERNAL: &str = "EXTERNAL";
-pub const INSTANCE_OF: &str = "INSTANCE OF";
+pub const INSTANCE: &str = "INSTANCE";
 pub const MINUS_INFINITY: &str = "MINUS-INFINITY";
 pub const NOT_A_NUMBER: &str = "NOT-A-NUMBER";
 pub const OBJECT: &str = "OBJECT";
@@ -179,7 +178,7 @@ pub const TIME_OF_DAY: &str = "TIME-OF-DAY";
 pub const TYPE_IDENTIFIER: &str = "TYPE-IDENTIFIER";
 pub const ENCODING_CONTROL: &str = "ENCODING-CONTROL";
 
-pub const ASN1_KEYWORDS: [&str; 67] = [
+pub const ASN1_KEYWORDS: [&str; 76] = [
     ABSTRACT_SYNTAX,
     BIT,
     CHARACTER,
@@ -187,9 +186,10 @@ pub const ASN1_KEYWORDS: [&str; 67] = [
     DATE,
     DATE_TIME,
     DURATION,
-    EMBEDDED_PDV,
+    EMBEDDED,
+    PDV,
     EXTERNAL,
-    INSTANCE_OF,
+    INSTANCE,
     MINUS_INFINITY,
     NOT_A_NUMBER,
     OBJECT,
@@ -202,10 +202,13 @@ pub const ASN1_KEYWORDS: [&str; 67] = [
     TIME_OF_DAY,
     TYPE_IDENTIFIER,
     SIZE,
+    CONSTRAINED,
+    PATTERN,
     DEFAULT,
     OPTIONAL,
-    WITH_COMPONENTS,
-    WITH_COMPONENT,
+    COMPONENTS,
+    COMPONENT,
+    WITH,
     UNION,
     EXCEPT,
     INTERSECTION,
@@ -216,18 +219,19 @@ pub const ASN1_KEYWORDS: [&str; 67] = [
     MAX,
     CLASS,
     UNIQUE,
-    WITH_SYNTAX,
+    SYNTAX,
     NULL,
     BOOLEAN,
     INTEGER,
     REAL,
+    STRING,
     ENUMERATED,
     CHOICE,
     SEQUENCE,
     OF,
     ALL,
     SET,
-    OBJECT_IDENTIFIER,
+    IDENTIFIER,
     UNIVERSAL,
     PRIVATE,
     APPLICATION,
@@ -243,6 +247,10 @@ pub const ASN1_KEYWORDS: [&str; 67] = [
     FROM,
     INSTRUCTIONS,
     TAGS,
+    EXTENSIBILITY,
+    IMPLIED,
+    SUCCESSORS,
+    DESCENDANTS,
     MACRO,
     ANY,
     BY,
@@ -356,18 +364,12 @@ pub struct Import {
     pub with: Option<With>,
 }
 
-impl From<(Vec<&str>, (GlobalModuleReference, Option<&str>))> for Import {
-    fn from(value: (Vec<&str>, (GlobalModuleReference, Option<&str>))) -> Self {
+impl From<(Vec<&str>, (GlobalModuleReference, Option<With>))> for Import {
+    fn from(value: (Vec<&str>, (GlobalModuleReference, Option<With>))) -> Self {
         Self {
             types: value.0.into_iter().map(String::from).collect(),
             global_module_reference: value.1 .0,
-            with: value.1 .1.map(|with| {
-                if with == WITH_SUCCESSORS {
-                    With::Successors
-                } else {
-                    With::Descendants
-                }
-            }),
+            with: value.1 .1,
         }
     }
 }
@@ -839,8 +841,8 @@ impl ASN1Type {
             ASN1Type::Boolean(_) => Cow::Borrowed(BOOLEAN),
             ASN1Type::Integer(_) => Cow::Borrowed(INTEGER),
             ASN1Type::Real(_) => Cow::Borrowed(REAL),
-            ASN1Type::BitString(_) => Cow::Borrowed(BIT_STRING),
-            ASN1Type::OctetString(_) => Cow::Borrowed(OCTET_STRING),
+            ASN1Type::BitString(_) => Cow::Borrowed("BIT STRING"),
+            ASN1Type::OctetString(_) => Cow::Borrowed("OCTET STRING"),
             ASN1Type::CharacterString(CharacterString {
                 ty: CharacterStringType::BMPString,
                 ..
@@ -888,9 +890,9 @@ impl ASN1Type {
             ASN1Type::Enumerated(_) => Cow::Borrowed(ENUMERATED),
             ASN1Type::Choice(_) => Cow::Borrowed(CHOICE),
             ASN1Type::Sequence(_) => Cow::Borrowed(SEQUENCE),
-            ASN1Type::SequenceOf(_) => Cow::Borrowed(SEQUENCE_OF),
+            ASN1Type::SequenceOf(_) => Cow::Borrowed("SEQUENCE OF"),
             ASN1Type::Set(_) => Cow::Borrowed(SET),
-            ASN1Type::SetOf(_) => Cow::Borrowed(SET_OF),
+            ASN1Type::SetOf(_) => Cow::Borrowed("SET OF"),
             ASN1Type::Time(_) => Cow::Borrowed(TIME),
             ASN1Type::GeneralizedTime(_) => Cow::Borrowed(GENERALIZED_TIME),
             ASN1Type::UTCTime(_) => Cow::Borrowed(UTC_TIME),
@@ -899,13 +901,13 @@ impl ASN1Type {
                 Cow::Borrowed(identifier)
             }
             ASN1Type::ChoiceSelectionType(_) => todo!(),
-            ASN1Type::ObjectIdentifier(_) => Cow::Borrowed(OBJECT_IDENTIFIER),
+            ASN1Type::ObjectIdentifier(_) => Cow::Borrowed("OBJECT IDENTIFIER"),
             ASN1Type::ObjectClassField(ifr) => Cow::Owned(format!(
                 "{INTERNAL_IO_FIELD_REF_TYPE_NAME_PREFIX}{}${}",
                 ifr.class,
                 ifr.field_path_as_str()
             )),
-            ASN1Type::EmbeddedPdv => Cow::Borrowed(EMBEDDED_PDV),
+            ASN1Type::EmbeddedPdv => Cow::Borrowed("EMBEDDED PDV"),
             ASN1Type::External => Cow::Borrowed(EXTERNAL),
         }
     }

--- a/rasn-compiler/src/lexer/bit_string.rs
+++ b/rasn-compiler/src/lexer/bit_string.rs
@@ -61,7 +61,10 @@ pub fn bit_string_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
 pub fn bit_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         preceded(
-            skip_ws_and_comments(tag(BIT_STRING)),
+            (
+                skip_ws_and_comments(tag(BIT)),
+                skip_ws_and_comments(tag(STRING)),
+            ),
             pair(opt(distinguished_values), opt(constraints)),
         ),
         |m| ASN1Type::BitString(m.into()),

--- a/rasn-compiler/src/lexer/constraint.rs
+++ b/rasn-compiler/src/lexer/constraint.rs
@@ -388,14 +388,17 @@ fn user_defined_constraint(input: Input<'_>) -> ParserResult<'_, SubtypeElements
 ///     DefinedObjectClass
 /// ```
 fn user_defined_constraint_real(input: Input<'_>) -> ParserResult<'_, UserDefinedConstraint> {
-    skip_ws_and_comments(into(preceded(
-        tag(CONSTRAINED_BY),
+    into(preceded(
+        (
+            skip_ws_and_comments(tag(CONSTRAINED)),
+            skip_ws_and_comments(tag(BY)),
+        ),
         skip_ws_and_comments(delimited(
             char(LEFT_BRACE),
             take_until_unbalanced("{", "}"),
             char(RIGHT_BRACE),
         )),
-    )))
+    ))
     .parse(input)
 }
 
@@ -426,10 +429,13 @@ fn permitted_alphabet_constraint(input: Input<'_>) -> ParserResult<'_, SubtypeEl
 fn single_type_constraint(input: Input<'_>) -> ParserResult<'_, SubtypeElements> {
     opt_delimited(
         skip_ws_and_comments(char(LEFT_PARENTHESIS)),
-        skip_ws_and_comments(into(preceded(
-            tag(WITH_COMPONENT),
+        into(preceded(
+            (
+                skip_ws_and_comments(tag(WITH)),
+                skip_ws_and_comments(tag(COMPONENT)),
+            ),
             skip_ws_and_comments(map(constraints, SubtypeElements::SingleTypeConstraint)),
-        ))),
+        )),
         skip_ws_and_comments(char(RIGHT_PARENTHESIS)),
     )
     .parse(input)
@@ -457,8 +463,11 @@ fn single_type_constraint(input: Input<'_>) -> ParserResult<'_, SubtypeElements>
 fn multiple_type_constraints(input: Input<'_>) -> ParserResult<'_, SubtypeElements> {
     opt_delimited(
         skip_ws_and_comments(char(LEFT_PARENTHESIS)),
-        skip_ws_and_comments(into(preceded(
-            tag(WITH_COMPONENTS),
+        into(preceded(
+            (
+                skip_ws_and_comments(tag(WITH)),
+                skip_ws_and_comments(tag(COMPONENTS)),
+            ),
             in_braces(pair(
                 opt(skip_ws_and_comments(terminated(
                     value(ExtensionMarker(), tag(ELLIPSIS)),
@@ -469,7 +478,7 @@ fn multiple_type_constraints(input: Input<'_>) -> ParserResult<'_, SubtypeElemen
                     opt(skip_ws_and_comments(char(COMMA))),
                 )),
             )),
-        ))),
+        )),
         skip_ws_and_comments(char(RIGHT_PARENTHESIS)),
     )
     .parse(input)
@@ -522,7 +531,13 @@ fn content_constraint(input: Input<'_>) -> ParserResult<'_, ContentConstraint> {
             map(
                 pair(
                     preceded(skip_ws_and_comments(tag(CONTAINING)), skip_ws(asn1_type)),
-                    preceded(skip_ws_and_comments(tag(ENCODED_BY)), skip_ws(asn1_value)),
+                    preceded(
+                        (
+                            skip_ws_and_comments(tag(ENCODED)),
+                            skip_ws_and_comments(tag(BY)),
+                        ),
+                        skip_ws(asn1_value),
+                    ),
                 ),
                 |v| ContentConstraint::ContainingEncodedBy {
                     containing: v.0,
@@ -534,7 +549,13 @@ fn content_constraint(input: Input<'_>) -> ParserResult<'_, ContentConstraint> {
                 ContentConstraint::Containing,
             ),
             map(
-                preceded(skip_ws_and_comments(tag(ENCODED_BY)), skip_ws(asn1_value)),
+                preceded(
+                    (
+                        skip_ws_and_comments(tag(ENCODED)),
+                        skip_ws_and_comments(tag(BY)),
+                    ),
+                    skip_ws(asn1_value),
+                ),
                 ContentConstraint::EncodedBy,
             ),
         ))),

--- a/rasn-compiler/src/lexer/embedded_pdv.rs
+++ b/rasn-compiler/src/lexer/embedded_pdv.rs
@@ -23,7 +23,10 @@ use super::{common::skip_ws_and_comments, error::ParserResult};
 pub fn embedded_pdv(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     value(
         ASN1Type::EmbeddedPdv,
-        skip_ws_and_comments(tag(EMBEDDED_PDV)),
+        (
+            skip_ws_and_comments(tag(EMBEDDED)),
+            skip_ws_and_comments(tag(PDV)),
+        ),
     )
     .parse(input)
 }

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -13,8 +13,8 @@ use crate::{
     intermediate::{
         information_object::*,
         types::{ObjectIdentifier, Optionality},
-        ASN1Type, DeclarationElsewhere, AMPERSAND, CLASS, COMMA, DOT, INSTANCE_OF, TYPE_IDENTIFIER,
-        UNIQUE, WITH_SYNTAX,
+        ASN1Type, DeclarationElsewhere, AMPERSAND, CLASS, COMMA, DOT, INSTANCE, OF, SYNTAX,
+        TYPE_IDENTIFIER, UNIQUE, WITH,
     },
     lexer::{
         common::{assignment, comment, optionality, skip_ws},
@@ -112,7 +112,10 @@ pub fn type_identifier(input: Input<'_>) -> ParserResult<'_, ObjectClassDefn> {
 pub fn instance_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         preceded(
-            tag(INSTANCE_OF),
+            (
+                skip_ws_and_comments(tag(INSTANCE)),
+                skip_ws_and_comments(tag(OF)),
+            ),
             pair(
                 skip_ws_and_comments(uppercase_identifier),
                 skip_ws_and_comments(opt(constraints)),
@@ -150,7 +153,13 @@ pub fn object_class_defn(input: Input<'_>) -> ParserResult<'_, ObjectClassDefn> 
                 skip_ws_and_comments(information_object_field),
                 optional_comma,
             ))),
-            opt(preceded(skip_ws_and_comments(tag(WITH_SYNTAX)), syntax)),
+            opt(preceded(
+                (
+                    skip_ws_and_comments(tag(WITH)),
+                    skip_ws_and_comments(tag(SYNTAX)),
+                ),
+                syntax,
+            )),
         ),
     ))
     .parse(input)

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -4,14 +4,14 @@
 //! identify a so-called _information object_.
 use crate::{
     input::Input,
-    intermediate::{ASN1Type, ObjectIdentifierArc, ObjectIdentifierValue, OBJECT_IDENTIFIER},
+    intermediate::{ASN1Type, ObjectIdentifierArc, ObjectIdentifierValue, IDENTIFIER, OBJECT},
 };
 
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::u128,
-    combinator::{into, map, opt},
+    combinator::{into, map, opt, recognize},
     multi::many1,
     sequence::{pair, preceded},
     Parser,
@@ -66,7 +66,10 @@ pub fn object_identifier(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         into(preceded(
             // TODO: store info whether the object id is relative
-            skip_ws_and_comments(alt((tag(OBJECT_IDENTIFIER), tag(RELATIVE_OID)))),
+            skip_ws_and_comments(alt((
+                recognize((tag(OBJECT), skip_ws_and_comments(tag(IDENTIFIER)))),
+                tag(RELATIVE_OID),
+            ))),
             opt(skip_ws_and_comments(constraints)),
         )),
         ASN1Type::ObjectIdentifier,

--- a/rasn-compiler/src/lexer/octet_string.rs
+++ b/rasn-compiler/src/lexer/octet_string.rs
@@ -19,7 +19,13 @@ use super::{common::*, constraint::constraints, error::ParserResult};
 /// If the match fails, the lexer will not consume the input and will return an error.
 pub fn octet_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
-        preceded(skip_ws_and_comments(tag(OCTET_STRING)), opt(constraints)),
+        preceded(
+            (
+                skip_ws_and_comments(tag(OCTET)),
+                skip_ws_and_comments(tag(STRING)),
+            ),
+            opt(constraints),
+        ),
         |m| ASN1Type::OctetString(m.into()),
     )
     .parse(input)

--- a/rasn-compiler/src/lexer/sequence.rs
+++ b/rasn-compiler/src/lexer/sequence.rs
@@ -109,10 +109,13 @@ fn extension_group(input: Input<'_>) -> ParserResult<'_, SequenceComponent> {
 }
 
 pub fn sequence_component(input: Input<'_>) -> ParserResult<'_, SequenceComponent> {
-    skip_ws_and_comments(alt((
+    alt((
         map(
             preceded(
-                tag(COMPONENTS_OF),
+                (
+                    skip_ws_and_comments(tag(COMPONENTS)),
+                    skip_ws_and_comments(tag(OF)),
+                ),
                 skip_ws_and_comments(alt((
                     into_inner(recognize(separated_list1(tag(".&"), identifier))),
                     type_reference,
@@ -121,7 +124,7 @@ pub fn sequence_component(input: Input<'_>) -> ParserResult<'_, SequenceComponen
             |id| SequenceComponent::ComponentsOf(id.into()),
         ),
         map(sequence_or_set_member, SequenceComponent::Member),
-    )))
+    ))
     .parse(input)
 }
 


### PR DESCRIPTION
### feat(parser): Split up combined reserved words

For example, split "SEQUENCE OF" into it's two reserved character sequences "SEQUENCE" and "OF". This is to better follow the reserved words, and also allows arbitrary white space between words.