### PR TITLE
feat: Generate bindings for `UniversalString`

### DIFF
--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -655,11 +655,7 @@ impl Rasn {
             }),
             CharacterStringType::GraphicString => Ok(quote!(GraphicString)),
             CharacterStringType::GeneralString => Ok(quote!(GeneralString)),
-            CharacterStringType::UniversalString => Err(GeneratorError {
-                kind: GeneratorErrorType::NotYetInplemented,
-                details: "UniversalString is currently unsupported!".into(),
-                top_level_declaration: None,
-            }),
+            CharacterStringType::UniversalString => Ok(quote!(UniversalString)),
             CharacterStringType::UTF8String => Ok(quote!(Utf8String)),
             CharacterStringType::BMPString => Ok(quote!(BmpString)),
             CharacterStringType::PrintableString => Ok(quote!(PrintableString)),


### PR DESCRIPTION
Generate bindings for `UniversalString` type.

Fixes `warning: NotYetInplemented generating bindings for : UniversalString is currently unsupported!`.

Partial fix for issue #167.