### PR TITLE
Fix syntax errors in RFC 3281

### DIFF
--- a/rasn-compiler-tests/tests/modules/ietf_rfc_rfc3281_PKIXAttributeCertificate.asn1
+++ b/rasn-compiler-tests/tests/modules/ietf_rfc_rfc3281_PKIXAttributeCertificate.asn1
@@ -48,10 +48,10 @@ AttributeCertificate ::= SEQUENCE {
  }
 
 AttributeCertificateInfo ::= SEQUENCE {
-    version  AttCertVersion  -- version is v2,
+    version  AttCertVersion,  -- version is v2
     holder   Holder,
     issuer   AttCertIssuer,
-    signatureAlgorithmIdentifier,
+    signature   AlgorithmIdentifier,
     serialNumber   CertificateSerialNumber,
     attrCertValidityPeriod   AttCertValidityPeriod,
     attributes     SEQUENCE OF Attribute,
@@ -91,7 +91,7 @@ AttCertIssuer ::= CHOICE {
  }
 
 V2Form ::= SEQUENCE {
- issuerNameGeneralNames  OPTIONAL,
+ issuerName            GeneralNames  OPTIONAL,
  baseCertificateID     [0] IssuerSerial  OPTIONAL,
  objectDigestInfo[1] ObjectDigestInfo  OPTIONAL
     -- issuerName MUST be present in this profile
@@ -102,7 +102,7 @@ V2Form ::= SEQUENCE {
 IssuerSerial  ::=  SEQUENCE {
  issuer   GeneralNames,
  serial   CertificateSerialNumber,
- issuerUIDUniqueIdentifier OPTIONAL
+ issuerUID UniqueIdentifier OPTIONAL
  }
 
 AttCertValidityPeriod  ::= SEQUENCE {


### PR DESCRIPTION
Fix the syntax errors in [RFC 3281](https://datatracker.ietf.org/doc/html/rfc3281) file `ietf_rfc_rfc3281_PKIXAttributeCertificate.asn1` so that it now parses.

The errors are not in the RFC except for one, which is fixed in the newer [RFC 5755](https://datatracker.ietf.org/doc/html/rfc5755).