### PR TITLE
refactor: Parse `CharacterStringType` directly

### DIFF
--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -1081,25 +1081,6 @@ impl CharacterStringType {
     }
 }
 
-impl From<&str> for CharacterStringType {
-    fn from(value: &str) -> Self {
-        match value {
-            IA5_STRING => Self::IA5String,
-            NUMERIC_STRING => Self::NumericString,
-            VISIBLE_STRING => Self::VisibleString,
-            TELETEX_STRING => Self::TeletexString,
-            T61_STRING => Self::TeletexString,
-            VIDEOTEX_STRING => Self::VideotexString,
-            GRAPHIC_STRING => Self::GraphicString,
-            GENERAL_STRING => Self::GeneralString,
-            UNIVERSAL_STRING => Self::UniversalString,
-            BMP_STRING => Self::BMPString,
-            PRINTABLE_STRING => Self::PrintableString,
-            _ => Self::UTF8String,
-        }
-    }
-}
-
 /// Representation of common integer types
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum IntegerType {

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -290,15 +290,6 @@ pub struct CharacterString {
     pub ty: CharacterStringType,
 }
 
-impl From<(&str, Option<Vec<Constraint>>)> for CharacterString {
-    fn from(value: (&str, Option<Vec<Constraint>>)) -> Self {
-        CharacterString {
-            constraints: value.1.unwrap_or_default(),
-            ty: value.0.into(),
-        }
-    }
-}
-
 /// Representation of an ASN1 SEQUENCE OF and SET OF data element
 /// with corresponding constraints and element type info
 /// Whether the struct describes a SEQUENCE OF or a SET OF

--- a/rasn-compiler/src/lexer/character_string.rs
+++ b/rasn-compiler/src/lexer/character_string.rs
@@ -2,12 +2,15 @@ use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::{char, u8},
-    combinator::{map, map_res, opt},
+    combinator::{map, map_res, opt, value},
     sequence::{delimited, pair, terminated},
     Parser,
 };
 
-use crate::{input::Input, intermediate::*};
+use crate::{
+    input::Input,
+    intermediate::{types::CharacterString, *},
+};
 
 use super::{
     common::*,
@@ -113,23 +116,28 @@ fn quadruple(input: Input<'_>) -> ParserResult<'_, char> {
 pub fn character_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         pair(
-            into_inner(skip_ws_and_comments(alt((
-                tag(IA5_STRING),
-                tag(UTF8_STRING),
-                tag(NUMERIC_STRING),
-                tag(VISIBLE_STRING),
-                tag(TELETEX_STRING),
-                tag(T61_STRING),
-                tag(VIDEOTEX_STRING),
-                tag(GRAPHIC_STRING),
-                tag(GENERAL_STRING),
-                tag(UNIVERSAL_STRING),
-                tag(BMP_STRING),
-                tag(PRINTABLE_STRING),
-            )))),
+            skip_ws_and_comments(alt((
+                value(CharacterStringType::IA5String, tag(IA5_STRING)),
+                value(CharacterStringType::UTF8String, tag(UTF8_STRING)),
+                value(CharacterStringType::NumericString, tag(NUMERIC_STRING)),
+                value(CharacterStringType::VisibleString, tag(VISIBLE_STRING)),
+                value(CharacterStringType::TeletexString, tag(TELETEX_STRING)),
+                value(CharacterStringType::TeletexString, tag(T61_STRING)),
+                value(CharacterStringType::VideotexString, tag(VIDEOTEX_STRING)),
+                value(CharacterStringType::GraphicString, tag(GRAPHIC_STRING)),
+                value(CharacterStringType::GeneralString, tag(GENERAL_STRING)),
+                value(CharacterStringType::UniversalString, tag(UNIVERSAL_STRING)),
+                value(CharacterStringType::BMPString, tag(BMP_STRING)),
+                value(CharacterStringType::PrintableString, tag(PRINTABLE_STRING)),
+            ))),
             opt(constraints),
         ),
-        |m| ASN1Type::CharacterString(m.into()),
+        |(ty, constraints)| {
+            ASN1Type::CharacterString(CharacterString {
+                constraints: constraints.unwrap_or_default(),
+                ty,
+            })
+        },
     )
     .parse(input)
 }


### PR DESCRIPTION
Let the parser directly match the `CharacterStringType` variant instead of matching it again in `impl From<..> for CharacterStringType`.