### PR TITLE
feat(parser): More rigorous parsing of `realnumber` literal

### DIFF
--- a/rasn-compiler/src/lexer/mod.rs
+++ b/rasn-compiler/src/lexer/mod.rs
@@ -188,12 +188,12 @@ pub fn asn1_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
         null_value,
         map(object_identifier_value, ASN1Value::ObjectIdentifier),
         choice_value,
-        real_value,
         sequence_value,
         time_value,
         bit_string_value,
         boolean_value,
         integer_value,
+        real_value,
         character_string_value,
         elsewhere_declared_value,
     ))


### PR DESCRIPTION
feat(parser): Parse integer only: Ex "111", "222.".

feat(parser): Parse with exponent: Ex "111.222e-333", "44e5".

fix(parser): Fixes an error where leading zeroes in fractional part was lost. Ex "0.00777" was parsed as 0.777.

Since `number` is also a valid `realnumber`, parsing of real literals is moved to after numbers in `asn1_value` so that number is preferred (like previous behavior).

Note: No test snapshots is changed due to this.