### PR TITLE
feat: Impl Constrainable for more ASN1Type's

### DIFF
--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -1,4 +1,4 @@
-use std::{ops::Not, str::FromStr};
+use std::str::FromStr;
 
 use proc_macro2::{Ident, Literal, Punct, Spacing, Span, TokenStream};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
@@ -224,7 +224,7 @@ impl Rasn {
     pub(crate) fn format_alphabet_annotations(
         &self,
         string_type: CharacterStringType,
-        constraints: &Vec<Constraint>,
+        constraints: &[Constraint],
     ) -> Result<TokenStream, GeneratorError> {
         if constraints.is_empty() {
             return Ok(TokenStream::new());
@@ -614,7 +614,7 @@ impl Rasn {
                     parent_name,
                     s.is_recursive,
                 )?;
-                (s.constraints().clone(), quote!(SequenceOf<#inner_type>))
+                (s.constraints().to_owned(), quote!(SequenceOf<#inner_type>))
             }
             ASN1Type::SetOf(s) => {
                 let (_, inner_type) = self.constraints_and_type_name(
@@ -623,7 +623,7 @@ impl Rasn {
                     parent_name,
                     s.is_recursive,
                 )?;
-                (s.constraints().clone(), quote!(SetOf<#inner_type>))
+                (s.constraints().to_owned(), quote!(SetOf<#inner_type>))
             }
             ASN1Type::ElsewhereDeclaredType(e) => {
                 let mut tokenized = self.to_rust_qualified_type(e.module.as_deref(), &e.identifier);
@@ -962,9 +962,7 @@ impl Rasn {
                 ..
             }) => {
                 Self::needs_unnesting(element_type)
-                    || element_type
-                        .constraints()
-                        .is_some_and(|c| c.is_empty().not())
+                    || !element_type.constraints().is_empty()
                     || element_tag.is_some()
             }
             _ => false,

--- a/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
+++ b/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
@@ -419,7 +419,7 @@ impl TryFrom<Option<&SubtypeElements>> for PerVisibleRangeConstraints {
                 extensible: _,
             }) => per_visible_range_constraints(
                 matches!(subtype, ASN1Type::Integer(_)),
-                subtype.constraints().unwrap_or(&vec![]),
+                subtype.constraints(),
             ),
             x => {
                 println!("{x:?}");
@@ -459,9 +459,7 @@ impl PerVisible for SubtypeElements {
             SubtypeElements::ContainedSubtype {
                 subtype: s,
                 extensible: _,
-            } => s
-                .constraints()
-                .is_some_and(|c| c.iter().any(|c| c.per_visible())),
+            } => s.constraints().iter().any(Constraint::per_visible),
             SubtypeElements::ValueRange {
                 min: _,
                 max: _,

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -913,29 +913,29 @@ impl ASN1Type {
         )
     }
 
-    pub fn constraints(&self) -> Option<&Vec<Constraint>> {
+    pub fn constraints(&self) -> &[Constraint] {
         match self {
-            ASN1Type::Boolean(b) => Some(b.constraints()),
-            ASN1Type::Real(r) => Some(r.constraints()),
-            ASN1Type::Integer(i) => Some(i.constraints()),
-            ASN1Type::BitString(b) => Some(b.constraints()),
-            ASN1Type::OctetString(o) => Some(o.constraints()),
-            ASN1Type::CharacterString(c) => Some(c.constraints()),
-            ASN1Type::Enumerated(e) => Some(e.constraints()),
-            ASN1Type::Time(t) => Some(t.constraints()),
-            ASN1Type::Choice(c) => Some(c.constraints()),
-            ASN1Type::Set(s) | ASN1Type::Sequence(s) => Some(s.constraints()),
-            ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => Some(s.constraints()),
-            ASN1Type::ElsewhereDeclaredType(e) => Some(e.constraints()),
-            ASN1Type::ObjectClassField(f) => Some(f.constraints()),
-            ASN1Type::GeneralizedTime(g) => Some(g.constraints()),
-            ASN1Type::UTCTime(u) => Some(u.constraints()),
-            ASN1Type::ObjectIdentifier(o) => Some(o.constraints()),
+            ASN1Type::Boolean(b) => b.constraints(),
+            ASN1Type::Real(r) => r.constraints(),
+            ASN1Type::Integer(i) => i.constraints(),
+            ASN1Type::BitString(b) => b.constraints(),
+            ASN1Type::OctetString(o) => o.constraints(),
+            ASN1Type::CharacterString(c) => c.constraints(),
+            ASN1Type::Enumerated(e) => e.constraints(),
+            ASN1Type::Time(t) => t.constraints(),
+            ASN1Type::Choice(c) => c.constraints(),
+            ASN1Type::Set(s) | ASN1Type::Sequence(s) => s.constraints(),
+            ASN1Type::SetOf(s) | ASN1Type::SequenceOf(s) => s.constraints(),
+            ASN1Type::ElsewhereDeclaredType(e) => e.constraints(),
+            ASN1Type::ObjectClassField(f) => f.constraints(),
+            ASN1Type::GeneralizedTime(g) => g.constraints(),
+            ASN1Type::UTCTime(u) => u.constraints(),
+            ASN1Type::ObjectIdentifier(o) => o.constraints(),
             ASN1Type::ChoiceSelectionType(_)
             | ASN1Type::Null
             | ASN1Type::Any
             | ASN1Type::EmbeddedPdv
-            | ASN1Type::External => None,
+            | ASN1Type::External => &[],
         }
     }
 

--- a/rasn-compiler/src/intermediate/types.rs
+++ b/rasn-compiler/src/intermediate/types.rs
@@ -58,7 +58,7 @@ pub trait MemberOrOption {
 /// *See also Rec. ITU-T X.680 (02/2021) §49 - §51*
 pub trait Constrainable {
     /// returns a reference to the type's constraints
-    fn constraints(&self) -> &Vec<Constraint>;
+    fn constraints(&self) -> &[Constraint];
     /// returns a mutable reference to the type's constraints
     fn constraints_mut(&mut self) -> &mut Vec<Constraint>;
 }
@@ -66,7 +66,7 @@ pub trait Constrainable {
 macro_rules! constrainable {
     ($typ:ty) => {
         impl Constrainable for $typ {
-            fn constraints(&self) -> &Vec<Constraint> {
+            fn constraints(&self) -> &[Constraint] {
                 &self.constraints
             }
 

--- a/rasn-compiler/src/validator/linking/mod.rs
+++ b/rasn-compiler/src/validator/linking/mod.rs
@@ -68,11 +68,11 @@ impl ToplevelDefinition {
             | ToplevelDefinition::Type(ToplevelTypeDefinition {
                 ty: ASN1Type::SetOf(s),
                 ..
-            }) => s.element_type.constraints().is_some_and(|constraints| {
-                constraints
-                    .iter()
-                    .any(|c| matches!(c, Constraint::Parameter(_)))
-            }),
+            }) => s
+                .element_type
+                .constraints()
+                .iter()
+                .any(|c| matches!(c, Constraint::Parameter(_))),
             _ => false,
         }
     }


### PR DESCRIPTION
`UTCTime`, `GeneralizedTime` and `ObjectIdentifier` is also constrainable, so impl `Constrainable` for them too.

Also refactors `Constrainable::constraints` to return a slice instead, which simplifies some code paths and avoids some clones.