### PR TITLE
refactor: Infallible `Rasn::format_comments`

### DIFF
--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@IVIM.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@IVIM.asn1.snap
@@ -1200,7 +1200,6 @@ pub mod ivim_pdu_descriptions {
     #[doc = "*"]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct IVIM {

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h225-0_1999_ANNEXG-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h225-0_1999_ANNEXG-MESSAGES.asn1.snap
@@ -93,7 +93,6 @@ pub mod annexg_messages {
     }
     #[doc = ""]
     #[doc = " structures common to multiple messages"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -822,7 +821,6 @@ pub mod annexg_messages {
     }
     #[doc = ""]
     #[doc = " Annex G messages"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235.0_2014_H235-SECURITY-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h235.0_2014_H235-SECURITY-MESSAGES.asn1.snap
@@ -958,7 +958,6 @@ pub mod h235_security_messages {
     #[doc = "\tobject identifier { 0 0 } to indicate that the tokenOID value is not"]
     #[doc = "\tpresent."]
     #[doc = "\tStart all the cryptographic parameterized types here..."]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h282_1999_RDC-PROTOCOL.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h282_1999_RDC-PROTOCOL.asn1.snap
@@ -574,7 +574,6 @@ pub mod rdc_protocol {
     }
     #[doc = ""]
     #[doc = " Attribute parameter types"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("1..=31"))]
     pub struct Day(pub u8);

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h460.9_2002_QOS-MONITORING-REPORT.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h460.9_2002_QOS-MONITORING-REPORT.asn1.snap
@@ -265,7 +265,6 @@ pub mod qos_monitoring_report {
         LazyLock::new(|| GenericIdentifier(GenericIdentifier(GenericIdentifier::standard(1))));
     #[doc = ""]
     #[doc = " H.460.9 Identifiers:"]
-    #[doc = ""]
     pub static QOS_MONITORING_REPORT_ID: LazyLock<GenericIdentifier> =
         LazyLock::new(|| GenericIdentifier(GenericIdentifier(GenericIdentifier::standard(9))));
 }

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h501_2002_H501-MESSAGES.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_h_h501_2002_H501-MESSAGES.asn1.snap
@@ -143,7 +143,6 @@ pub mod h501_messages {
     }
     #[doc = ""]
     #[doc = " structures common to multiple messages"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -1042,7 +1041,6 @@ pub mod h501_messages {
     }
     #[doc = ""]
     #[doc = " H.501 messages"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -1506,6 +1504,5 @@ pub mod h501_messages {
     #[doc = " REPOSITORY FOR APPLICATION SPECIFIC DATA"]
     #[doc = ""]
     #[doc = " H.225.0 Annex-G profile data"]
-    #[doc = ""]
     pub static ID_ANNEX_GPROFILES: LazyLock<Integer> = LazyLock::new(|| Integer::from(0i128));
 }

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_t_t123_1999_CNP-PROTOCOL.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_t_t123_1999_CNP-PROTOCOL.asn1.snap
@@ -65,7 +65,6 @@ pub mod cnp_protocol {
     }
     #[doc = ""]
     #[doc = "  CNP Control PDU Types"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]
@@ -271,7 +270,6 @@ pub mod cnp_protocol {
     #[doc = " {itu-t (0) recommendation (0) t (20) 123 annexb (2) 1}"]
     #[doc = ""]
     #[doc = "  Service Negotiation Types"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate, value("128..=65535"))]
     pub struct TPDUSize(pub u16);

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_t_t134_1998_CHAT-PROTOCOL.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_t_t134_1998_CHAT-PROTOCOL.asn1.snap
@@ -42,7 +42,6 @@ pub mod chat_protocol {
     #[doc = " Chat Protocol String"]
     #[doc = ""]
     #[doc = "                          Begin CHATPDU Definitions"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     #[non_exhaustive]

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x282_1999_DLM.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x282_1999_DLM.asn1.snap
@@ -107,7 +107,6 @@ pub mod dlm {
     #[doc = ""]
     #[doc = "  value assignments for Data Link layer specific errorIds for activate action processingFailure"]
     #[doc = "  errors."]
-    #[doc = ""]
     pub static ACTIVATE_FAILURE: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
         Oid::new(&[&***SSEOI, &[9u32, 1u32, 1u32, 1u32]].concat())
             .unwrap()
@@ -151,7 +150,6 @@ pub mod dlm {
         LazyLock::new(|| Oid::const_new(&[2u32, 15u32]).to_owned());
     #[doc = ""]
     #[doc = "  other definitions"]
-    #[doc = ""]
     pub static DATALINK_SUBSYSTEM_ID_VALUE: LazyLock<GraphicString> =
         LazyLock::new(|| GraphicString::try_from(String::from("datalinkSubsystem")).unwrap());
     pub static DLOI: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
@@ -193,7 +191,6 @@ pub mod dlm {
     });
     #[doc = ""]
     #[doc = "  value assignments for Data Link layer specificProblems"]
-    #[doc = ""]
     pub static F_RMRRECEIVED: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
         Oid::new(&[&***SSEOI, &[11u32, 5u32]].concat())
             .unwrap()

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x501_2019_UsefulDefinitions.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x501_2019_UsefulDefinitions.asn1.snap
@@ -22,7 +22,6 @@ pub mod useful_definitions {
     #[doc = "applications which will use them to access Directory services. Other applications"]
     #[doc = "may use them for their own purposes, but this will not constrain extensions and"]
     #[doc = "modifications needed to maintain or improve the Directory service."]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
     pub struct ID(pub ObjectIdentifier);

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x520_2019_UpperBounds.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x520_2019_UpperBounds.asn1.snap
@@ -22,7 +22,6 @@ pub mod upper_bounds {
     #[doc = "applications which will use them to access Directory services. Other applications"]
     #[doc = "may use them for their own purposes, but this will not constrain extensions and"]
     #[doc = "modifications needed to maintain or improve the Directory service."]
-    #[doc = ""]
     pub static UB_ANSWERBACK: LazyLock<Integer> = LazyLock::new(|| Integer::from(8i128));
     pub static UB_BUSINESS_CATEGORY: LazyLock<Integer> = LazyLock::new(|| Integer::from(128i128));
     pub static UB_COMMON_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(64i128));

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x749_1997_MDMPMF.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x749_1997_MDMPMF.asn1.snap
@@ -26,7 +26,6 @@ pub mod mdmpmf {
         LazyLock::new(|| Oid::const_new(&[2u32, 9u32, 2u32, 19u32, 13u32, 4u32]).to_owned());
     #[doc = ""]
     #[doc = "\t\tThe following arcs support the defined policy classes."]
-    #[doc = ""]
     pub static ASSERTED_VALUE_IDENTIFIER: LazyLock<ObjectIdentifier> =
         LazyLock::new(|| Oid::const_new(&[2u32, 9u32, 2u32, 19u32, 13u32]).to_owned());
     pub static ERROR_TYPE: LazyLock<ObjectIdentifier> =

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@v2x_cam.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@v2x_cam.asn1.snap
@@ -2393,7 +2393,6 @@ pub mod ivim_pdu_descriptions {
     #[doc = "*"]
     #[doc = "* @category: Basic Information"]
     #[doc = "* @revision: V1.3.1"]
-    #[doc = ""]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags)]
     pub struct IVIM {

--- a/rasn-compiler/src/generator/rasn/builder.rs
+++ b/rasn-compiler/src/generator/rasn/builder.rs
@@ -24,7 +24,7 @@ pub(crate) const INNER_ARRAY_LIKE_PREFIX: &str = "Anonymous_";
 macro_rules! call_template {
     ($this:ident, $fn:ident, $tld:ident, $($args:expr),*) => {
         Ok($fn(
-            $this.format_comments(&$tld.comments)?,
+            $this.format_comments(&$tld.comments),
             $this.to_rust_const_case(&$tld.name),
             $($args),*
         ))
@@ -107,7 +107,7 @@ impl Rasn {
             annotations.push(self.format_range_annotations(true, &dec.constraints)?);
             let alias = self.to_rust_qualified_type(dec.module.as_deref(), &dec.identifier);
             Ok(typealias_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 alias,
                 self.join_annotations(annotations, false, true)?,
@@ -131,7 +131,7 @@ impl Rasn {
             };
             if integer_type.is_unbounded() {
                 Ok(lazy_static_value_template(
-                    self.format_comments(&tld.comments)?,
+                    self.format_comments(&tld.comments),
                     self.to_rust_const_case(&tld.name),
                     ty,
                     val,
@@ -139,7 +139,7 @@ impl Rasn {
                 ))
             } else {
                 Ok(integer_value_template(
-                    self.format_comments(&tld.comments)?,
+                    self.format_comments(&tld.comments),
                     self.to_rust_const_case(&tld.name),
                     ty,
                     val,
@@ -162,7 +162,7 @@ impl Rasn {
             let (name, mut annotations) = self.format_name_and_common_annotations(&tld)?;
             annotations.push(self.format_range_annotations(true, &int.constraints)?);
             Ok(integer_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 self.join_annotations(annotations, false, true)?,
                 int.int_type().to_token_stream(),
@@ -183,14 +183,14 @@ impl Rasn {
             }
             if let Some(size) = bitstr.fixed_size() {
                 Ok(fixed_bit_string_template(
-                    self.format_comments(&tld.comments)?,
+                    self.format_comments(&tld.comments),
                     name,
                     self.join_annotations(annotations, false, true)?,
                     size.to_token_stream(),
                 ))
             } else {
                 Ok(bit_string_template(
-                    self.format_comments(&tld.comments)?,
+                    self.format_comments(&tld.comments),
                     name,
                     self.join_annotations(annotations, false, true)?,
                 ))
@@ -211,14 +211,14 @@ impl Rasn {
             }
             if let Some(size) = oct_str.fixed_size() {
                 Ok(fixed_octet_string_template(
-                    self.format_comments(&tld.comments)?,
+                    self.format_comments(&tld.comments),
                     name,
                     self.join_annotations(annotations, false, true)?,
                     size.to_token_stream(),
                 ))
             } else {
                 Ok(octet_string_template(
-                    self.format_comments(&tld.comments)?,
+                    self.format_comments(&tld.comments),
                     name,
                     self.join_annotations(annotations, false, true)?,
                 ))
@@ -239,7 +239,7 @@ impl Rasn {
                 self.format_alphabet_annotations(char_str.ty, &char_str.constraints)?,
             ]);
             Ok(char_string_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 self.string_type(&char_str.ty)?,
                 self.join_annotations(annotations, false, true)?,
@@ -257,7 +257,7 @@ impl Rasn {
         let (name, annotations) = self.format_name_and_common_annotations(&tld)?;
         if let ASN1Type::Boolean(_) = tld.ty {
             Ok(boolean_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 self.join_annotations(annotations, true, true)?,
             ))
@@ -508,7 +508,7 @@ impl Rasn {
             annotations.push(self.format_identifier_annotation(&tld.name, &tld.comments, &tld.ty));
         }
         Ok(any_template(
-            self.format_comments(&tld.comments)?,
+            self.format_comments(&tld.comments),
             name,
             self.join_annotations(annotations, false, true)?,
         ))
@@ -521,7 +521,7 @@ impl Rasn {
         if let ASN1Type::GeneralizedTime(_) = &tld.ty {
             let (name, annotations) = self.format_name_and_common_annotations(&tld)?;
             Ok(generalized_time_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 self.join_annotations(annotations, false, true)?,
             ))
@@ -537,7 +537,7 @@ impl Rasn {
         if let ASN1Type::UTCTime(_) = &tld.ty {
             let (name, annotations) = self.format_name_and_common_annotations(&tld)?;
             Ok(utc_time_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 self.join_annotations(annotations, false, true)?,
             ))
@@ -554,7 +554,7 @@ impl Rasn {
             let (name, mut annotations) = self.format_name_and_common_annotations(&tld)?;
             annotations.push(self.format_range_annotations(false, &oid.constraints)?);
             Ok(oid_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 self.join_annotations(annotations, false, true)?,
             ))
@@ -570,7 +570,7 @@ impl Rasn {
         if let ASN1Type::Null = tld.ty {
             let (name, annotations) = self.format_name_and_common_annotations(&tld)?;
             Ok(null_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 self.join_annotations(annotations, true, true)?,
             ))
@@ -606,7 +606,7 @@ impl Rasn {
                 ));
             }
             Ok(enumerated_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 name,
                 extensible,
                 self.format_enum_members(enumerated)?,
@@ -651,7 +651,7 @@ impl Rasn {
             }
             let formatted_options = self.format_choice_options(choice, &name.to_string())?;
             let choice_str = choice_template(
-                self.format_comments(&tld.comments)?,
+                self.format_comments(&tld.comments),
                 &name,
                 extensible,
                 formatted_options.enum_body,
@@ -783,7 +783,7 @@ impl Rasn {
                     ));
                 }
                 Ok(sequence_or_set_template(
-                    self.format_comments(&tld.comments)?,
+                    self.format_comments(&tld.comments),
                     name.clone(),
                     extensible,
                     formatted_members.struct_body,
@@ -848,7 +848,7 @@ impl Rasn {
         }
         Ok(sequence_or_set_of_template(
             is_set_of,
-            self.format_comments(&tld.comments)?,
+            self.format_comments(&tld.comments),
             name,
             anonymous_item,
             member_type,

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -130,12 +130,12 @@ impl Rasn {
         }
     }
 
-    pub(crate) fn format_comments(&self, comments: &str) -> Result<TokenStream, GeneratorError> {
+    pub(crate) fn format_comments(&self, comments: &str) -> TokenStream {
         if comments.is_empty() {
-            Ok(TokenStream::new())
+            TokenStream::new()
         } else {
-            let joined = String::from("///") + &comments.replace('\n', "\n ///") + "\n";
-            Ok(TokenStream::from_str(&joined)?)
+            let comments = comments.lines().map(|c| c.trim_end_matches('\r'));
+            quote!(#(#[doc = #comments])*)
         }
     }
 


### PR DESCRIPTION
`Rasn::format_comments` can be made infallible if it generates a doc comment directly, instead of parsing a normal comment ("/// ...") into a doc comment.

This also removes the last empty line from some comments.