### PR TITLE
perf(rasn-generator): Better handling of `Config::type_annotations`

### DIFF
--- a/rasn-compiler-tests/tests/system_tests.rs
+++ b/rasn-compiler-tests/tests/system_tests.rs
@@ -100,7 +100,7 @@ fn custom_derives_without_any_required() {
         .generated;
     assert!(bindings.contains(
         r#"#[serde(rename = "camelCase")]
-    #[derive(Serialize, Debug, AsnType, Encode, Decode, PartialEq, Clone)]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Serialize)]
     #[rasn(delegate, value("4..=8"))]
     pub struct Hello(pub u8);"#
     ))
@@ -130,7 +130,7 @@ fn custom_derives_without_some_required() {
         .generated;
     assert!(bindings.contains(
         r#"#[serde(rename = "camelCase")]
-    #[derive(Serialize, AsnType, Encode, Debug, Decode, PartialEq, Clone)]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Serialize)]
     #[rasn(delegate, value("4..=8"))]
     pub struct Hello(pub u8);"#
     ))

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -1187,8 +1187,6 @@ impl Rasn {
         }
     }
 
-    const REQUIRED_DERIVES: [&'static str; 6] =
-        ["Debug", "AsnType", "Encode", "Decode", "PartialEq", "Clone"];
     const COPY_DERIVE: &str = "Copy";
     const RUST_KEYWORDS: [&'static str; 53] = [
         "as",
@@ -1335,13 +1333,9 @@ impl Rasn {
     }
 
     fn required_annotations(&self, needs_copy: bool) -> Result<Vec<TokenStream>, GeneratorError> {
-        let mut required_derives = Vec::new();
-        for derive in Self::REQUIRED_DERIVES {
-            if !self.derive_is_present(derive)? {
-                required_derives.push(derive)
-            }
-        }
-        if needs_copy && !self.derive_is_present(Self::COPY_DERIVE)? {
+        let mut required_derives: Vec<_> =
+            self.required_derives.iter().map(String::as_str).collect();
+        if needs_copy && !required_derives.contains(&Self::COPY_DERIVE) {
             required_derives.push(Self::COPY_DERIVE);
         }
         let mut custom_annotations = self
@@ -1366,21 +1360,6 @@ impl Rasn {
             custom_annotations.push(quote!(#[derive(#(#derives),*)]));
         };
         Ok(custom_annotations)
-    }
-
-    fn derive_is_present(&self, annotation: &str) -> Result<bool, GeneratorError> {
-        let regex = regex::Regex::from_str(&format!(
-            r#"#\[derive\([0-z \t,]*{annotation}[0-z \t,]*\)\]"#
-        ))
-        .map_err(|e| GeneratorError {
-            details: e.to_string(),
-            ..Default::default()
-        })?;
-        Ok(self
-            .config
-            .type_annotations
-            .iter()
-            .any(|s| regex.is_match(s)))
     }
 
     pub(super) fn type_mismatch_error<T>(
@@ -1482,8 +1461,8 @@ mod tests {
             TaggingEnvironment::Automatic,
             ExtensibilityEnvironment::Explicit,
         );
-        assert!(!rasn.derive_is_present("NotPresent").unwrap());
-        assert!(rasn.derive_is_present("AsnType").unwrap());
+        assert!(!rasn.required_derives.contains(&String::from("NotPresent")));
+        assert!(rasn.required_derives.contains(&String::from("AsnType")));
     }
 
     #[test]


### PR DESCRIPTION
The generator spent a lot of time parsing `Config::type_annotations` in `Rasn::derive_is_present`. Partly because it recompiled the regex on all invocations.

Fix this by only parsing it once on `Rasn` instantiation.

Running test `parse_test::parses_modules` is reduced from 42 s to 34 s on my system.

This replaces the usage of the regex crate with a nom parser. If pull request #195 is also accepted, the dependency on regex can be dropped.