### PR TITLE
perf(rasn-generator): Cache charset generation

### DIFF
--- a/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
+++ b/rasn-compiler/src/intermediate/encoding_rules/per_visible.rs
@@ -84,7 +84,7 @@ impl PerVisibleAlphabetConstraints {
             Constraint::Subtype(c) => match &c.set {
                 ElementOrSetOperation::Element(e) => Self::from_subtype_elem(Some(e), string_type),
                 ElementOrSetOperation::SetOperation(s) => Self::from_subtype_elem(
-                    fold_constraint_set(s, Some(&string_type.character_set()), false)?.as_ref(),
+                    fold_constraint_set(s, Some(string_type.character_set()), false)?.as_ref(),
                     string_type,
                 ),
             },
@@ -133,7 +133,7 @@ impl PerVisibleAlphabetConstraints {
                     let mut char_subset = s
                         .clone()
                         .chars()
-                        .map(|c| find_char_index(&string_type.character_set(), c).map(|i| (i, c)))
+                        .map(|c| find_char_index(string_type.character_set(), c).map(|i| (i, c)))
                         .collect::<Result<Vec<(usize, char)>, _>>()?;
                     char_subset.sort_by(|(a, _), (b, _)| a.cmp(b));
                     Ok(Some(PerVisibleAlphabetConstraints {
@@ -160,12 +160,12 @@ impl PerVisibleAlphabetConstraints {
                 }
                 let (lower, upper) = match (min, max) {
                     (Some(ASN1Value::String(min)), Some(ASN1Value::String(max))) => (
-                        find_string_index(min, &char_set)?,
-                        find_string_index(max, &char_set)?,
+                        find_string_index(min, char_set)?,
+                        find_string_index(max, char_set)?,
                     ),
-                    (None, Some(ASN1Value::String(max))) => (0, find_string_index(max, &char_set)?),
+                    (None, Some(ASN1Value::String(max))) => (0, find_string_index(max, char_set)?),
                     (Some(ASN1Value::String(min)), None) => {
-                        (find_string_index(min, &char_set)?, char_set.len() - 1)
+                        (find_string_index(min, char_set)?, char_set.len() - 1)
                     }
                     _ => (0, char_set.len() - 1),
                 };
@@ -1155,7 +1155,7 @@ mod tests {
                         }
                     ))
                 },
-                Some(&CharacterStringType::IA5String.character_set()),
+                Some(CharacterStringType::IA5String.character_set()),
                 false
             )
             .unwrap()
@@ -1180,7 +1180,7 @@ mod tests {
                         }
                     ))
                 },
-                Some(&CharacterStringType::IA5String.character_set()),
+                Some(CharacterStringType::IA5String.character_set()),
                 false
             )
             .unwrap()
@@ -1210,7 +1210,7 @@ mod tests {
                         }
                     ))
                 },
-                Some(&CharacterStringType::PrintableString.character_set()),
+                Some(CharacterStringType::PrintableString.character_set()),
                 false,
             )
             .unwrap()
@@ -1237,7 +1237,7 @@ mod tests {
                         }
                     ))
                 },
-                Some(&CharacterStringType::PrintableString.character_set()),
+                Some(CharacterStringType::PrintableString.character_set()),
                 false
             )
             .unwrap()
@@ -1269,7 +1269,7 @@ mod tests {
                         }
                     ))
                 },
-                Some(&CharacterStringType::VisibleString.character_set()),
+                Some(CharacterStringType::VisibleString.character_set()),
                 false,
             )
             .unwrap()
@@ -1297,7 +1297,7 @@ mod tests {
                         }
                     ))
                 },
-                Some(&CharacterStringType::PrintableString.character_set()),
+                Some(CharacterStringType::PrintableString.character_set()),
                 false
             )
             .unwrap()
@@ -1483,7 +1483,7 @@ mod tests {
         assert_eq!(
             fold_constraint_set(
                 &set_op(SetOperator::Intersection),
-                Some(&CharacterStringType::IA5String.character_set()),
+                Some(CharacterStringType::IA5String.character_set()),
                 false
             )
             .unwrap()
@@ -1500,7 +1500,7 @@ mod tests {
         assert_eq!(
             fold_constraint_set(
                 &set_op(SetOperator::Union),
-                Some(&CharacterStringType::IA5String.character_set()),
+                Some(CharacterStringType::IA5String.character_set()),
                 false
             )
             .unwrap(),
@@ -1527,7 +1527,7 @@ mod tests {
         assert_eq!(
             fold_constraint_set(
                 &set_op(SetOperator::Intersection),
-                Some(&CharacterStringType::PrintableString.character_set()),
+                Some(CharacterStringType::PrintableString.character_set()),
                 false
             )
             .unwrap()
@@ -1540,7 +1540,7 @@ mod tests {
         assert_eq!(
             fold_constraint_set(
                 &set_op(SetOperator::Union),
-                Some(&CharacterStringType::PrintableString.character_set()),
+                Some(CharacterStringType::PrintableString.character_set()),
                 false
             )
             .unwrap(),
@@ -1582,7 +1582,7 @@ mod tests {
         assert_eq!(
             fold_constraint_set(
                 &set_op(SetOperator::Intersection),
-                Some(&CharacterStringType::PrintableString.character_set()),
+                Some(CharacterStringType::PrintableString.character_set()),
                 true
             )
             .unwrap()
@@ -1606,7 +1606,7 @@ mod tests {
         assert_eq!(
             fold_constraint_set(
                 &set_op(SetOperator::Union),
-                Some(&CharacterStringType::PrintableString.character_set()),
+                Some(CharacterStringType::PrintableString.character_set()),
                 true
             )
             .unwrap(),

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -15,7 +15,14 @@ pub mod parameterization;
 pub mod types;
 pub mod utils;
 
-use std::{borrow::Cow, cell::RefCell, collections::BTreeMap, ops::Add, rc::Rc};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::BTreeMap,
+    ops::{Add, Deref},
+    rc::Rc,
+    sync::LazyLock,
+};
 
 use crate::common::INTERNAL_IO_FIELD_REF_TYPE_NAME_PREFIX;
 use constraints::Constraint;
@@ -952,15 +959,6 @@ impl ASN1Type {
     }
 }
 
-pub const NUMERIC_STRING_CHARSET: [char; 11] =
-    [' ', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-pub const PRINTABLE_STRING_CHARSET: [char; 74] = [
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
-    'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
-    'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
-    '5', '6', '7', '8', '9', ' ', '\'', '(', ')', '+', ',', '-', '.', '/', ':', '=', '?',
-];
-
 /// The types of an ASN1 character strings.
 #[cfg_attr(test, derive(EnumDebug))]
 #[cfg_attr(not(test), derive(Debug))]
@@ -980,22 +978,45 @@ pub enum CharacterStringType {
 }
 
 impl CharacterStringType {
-    pub fn character_set(&self) -> BTreeMap<usize, char> {
-        match self {
-            CharacterStringType::NumericString => {
-                NUMERIC_STRING_CHARSET.into_iter().enumerate().collect()
-            }
-            CharacterStringType::VisibleString | CharacterStringType::PrintableString => {
-                PRINTABLE_STRING_CHARSET.into_iter().enumerate().collect()
-            }
-            CharacterStringType::IA5String => (0..128u32)
+    pub fn character_set(&self) -> &'static BTreeMap<usize, char> {
+        static NUMERIC_CHARSET: LazyLock<BTreeMap<usize, char>> = LazyLock::new(|| {
+            [' ', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+                .into_iter()
+                .enumerate()
+                .collect()
+        });
+        static PRINTABLE_CHARSET: LazyLock<BTreeMap<usize, char>> = LazyLock::new(|| {
+            [
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ' ', '\'',
+                '(', ')', '+', ',', '-', '.', '/', ':', '=', '?',
+            ]
+            .into_iter()
+            .enumerate()
+            .collect()
+        });
+        static IA5_CHARSET: LazyLock<BTreeMap<usize, char>> = LazyLock::new(|| {
+            (0..128u32)
                 .map(|i| char::from_u32(i).unwrap())
                 .enumerate()
-                .collect(),
-            _ => (0..u16::MAX as u32)
+                .collect()
+        });
+        static ANY_CHARSET: LazyLock<BTreeMap<usize, char>> = LazyLock::new(|| {
+            (0..u16::MAX as u32)
                 .filter_map(char::from_u32)
                 .enumerate()
-                .collect(),
+                .collect()
+        });
+
+        match self {
+            CharacterStringType::NumericString => &NUMERIC_CHARSET,
+            CharacterStringType::VisibleString | CharacterStringType::PrintableString => {
+                &PRINTABLE_CHARSET
+            }
+            CharacterStringType::IA5String => IA5_CHARSET.deref(),
+            _ => &ANY_CHARSET,
         }
     }
 }


### PR DESCRIPTION
Do not recreate the character set on every invocation of `CharacterStringType::character_set`. Instead store them in a static `LazyLock`.

This improves the performance by about 1.32 times.