### PR TITLE
fix(lexer): Fix panic on empty unterminated block comment

### DIFF
--- a/rasn-compiler/src/lexer/common.rs
+++ b/rasn-compiler/src/lexer/common.rs
@@ -366,6 +366,14 @@ and one */"#
     }
 
     #[test]
+    fn unterminated_block_comment_is_err() {
+        assert!(block_comment("/*".into()).is_err());
+        assert!(block_comment("/* Unnested".into()).is_err());
+        assert!(block_comment("/* Outer /* Nested".into()).is_err());
+        assert!(block_comment("/* Outer /* Nested */ outer".into()).is_err());
+    }
+
+    #[test]
     fn parses_multiline_block_comment() {
         assert_eq!(comment(r#"/**
       * This DE indicates a change of acceleration.

--- a/rasn-compiler/src/lexer/util.rs
+++ b/rasn-compiler/src/lexer/util.rs
@@ -157,7 +157,7 @@ pub fn take_until_unbalanced<'a>(
     move |i: Input<'a>| {
         let mut index = 0;
         let mut bracket_counter = 0;
-        'consume: loop {
+        while index < i.len() {
             let input = i.slice(index..);
 
             if input.inner().starts_with(opening_tag) {
@@ -166,8 +166,6 @@ pub fn take_until_unbalanced<'a>(
             } else if input.inner().starts_with(closing_tag) {
                 bracket_counter -= 1;
                 index += closing_tag.len();
-            } else if index == i.len() - 1 {
-                break 'consume;
             } else {
                 let c = i.slice(index..).inner().chars().next().unwrap_or_default();
                 index += c.len_utf8();

--- a/rasn-compiler/src/lexer/util.rs
+++ b/rasn-compiler/src/lexer/util.rs
@@ -1,8 +1,7 @@
 use std::{cmp::min, fmt::Debug};
 
 use nom::{
-    bytes::complete::tag,
-    error::{Error, ErrorKind, ParseError},
+    error::{ErrorKind, ParseError},
     Err, FindSubstring, IResult, Input as _, Offset, Parser,
 };
 
@@ -161,10 +160,10 @@ pub fn take_until_unbalanced<'a>(
         'consume: loop {
             let input = i.slice(index..);
 
-            if tag::<&str, Input<'_>, Error<Input<'_>>>(opening_tag)(input.clone()).is_ok() {
+            if input.inner().starts_with(opening_tag) {
                 bracket_counter += 1;
                 index += opening_tag.len();
-            } else if tag::<&str, Input<'_>, Error<Input<'_>>>(closing_tag)(input).is_ok() {
+            } else if input.inner().starts_with(closing_tag) {
                 bracket_counter -= 1;
                 index += closing_tag.len();
             } else if index == i.len() - 1 {


### PR DESCRIPTION
Parser was panicking on `/*` input.