### PR TITLE
fix(lexer): Allow white space and comments in more places.

### DIFF
--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q1551_1997_UPT-DataModel.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q1551_1997_UPT-DataModel.asn1.snap
@@ -2,13 +2,300 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_q_q1551_1997_UPT-DataModel.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 462, column 2]
-     │
-     │ 
- 461 │  -- object-identifiers assignment
- 462 │  id-oc OBJECT IDENTIFIER ::= ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 463 │    {itu-t recommendation q 1551 --upt-- module(0) uptUsefulDefinitions(0)
- 464 │     objectClasses(0) version1(0)}
-     │
-─────╯
+Warnings:
+Not yet implemented error while generating bindings: Real types are currently unsupported!
+
+
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod upt_data_model {
+    extern crate alloc;
+    use super::authentication_framework::USER_PASSWORD;
+    use super::information_framework::*;
+    use super::selected_attribute_types::{
+        COMMON_NAME, DESCRIPTION, INTEGER_MATCH, INTEGER_ORDERING_MATCH, NAME,
+        NUMERIC_STRING_MATCH, OCTET_STRING_MATCH, ORGANIZATIONAL_UNIT_NAME, SEE_ALSO,
+        STORED_PREFIX_MATCH, SURNAME,
+    };
+    use super::selected_object_classes::{COUNTRY_NAME_FORM, ORGANIZATION, ORGANIZATIONAL_UNIT};
+    use super::upper_bounds::UB_INTERNATIONAL_ISDN_NUMBER;
+    use super::useful_definitions::{INFORMATION_FRAMEWORK, UPPER_BOUNDS};
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct CFServices(pub SetOf<Service>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct CallInfoRecord {
+        #[rasn(tag(context, 0), identifier = "authenticationTime")]
+        pub authentication_time: UtcTime,
+        #[rasn(tag(context, 1), identifier = "callStopTimeValue")]
+        pub call_stop_time_value: UtcTime,
+        #[rasn(tag(context, 2), identifier = "callStartTimeValue")]
+        pub call_start_time_value: UtcTime,
+        #[rasn(tag(context, 3), identifier = "callingAddressValue")]
+        pub calling_address_value: IsdnAddress,
+        #[rasn(tag(context, 4), identifier = "calledNumber")]
+        pub called_number: IsdnAddress,
+        #[rasn(value("0..=2147483647"), tag(context, 5))]
+        pub duration: Option<u32>,
+        #[rasn(tag(context, 6), identifier = "routingAddress")]
+        pub routing_address: Option<IsdnAddress>,
+        #[rasn(tag(context, 7), identifier = "forwardedToAddress")]
+        pub forwarded_to_address: Option<IsdnAddress>,
+        #[rasn(tag(context, 8), identifier = "invokedSupplementaryServices")]
+        pub invoked_supplementary_services: Option<CFServices>,
+        #[rasn(tag(context, 9), identifier = "visitedNetwork")]
+        pub visited_network: Option<NetworkCode>,
+        #[rasn(tag(context, 10), identifier = "callCost")]
+        pub call_cost: Option<Cost>,
+        #[rasn(tag(context, 11))]
+        pub surcharges: Option<Cost>,
+        #[rasn(tag(context, 12), identifier = "releaseCause")]
+        pub release_cause: Option<Cause>,
+    }
+    impl CallInfoRecord {
+        pub fn new(
+            authentication_time: UtcTime,
+            call_stop_time_value: UtcTime,
+            call_start_time_value: UtcTime,
+            calling_address_value: IsdnAddress,
+            called_number: IsdnAddress,
+            duration: Option<u32>,
+            routing_address: Option<IsdnAddress>,
+            forwarded_to_address: Option<IsdnAddress>,
+            invoked_supplementary_services: Option<CFServices>,
+            visited_network: Option<NetworkCode>,
+            call_cost: Option<Cost>,
+            surcharges: Option<Cost>,
+            release_cause: Option<Cause>,
+        ) -> Self {
+            Self {
+                authentication_time,
+                call_stop_time_value,
+                call_start_time_value,
+                calling_address_value,
+                called_number,
+                duration,
+                routing_address,
+                forwarded_to_address,
+                invoked_supplementary_services,
+                visited_network,
+                call_cost,
+                surcharges,
+                release_cause,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("2..=20"))]
+    pub struct Cause(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum Cost {
+        #[rasn(value("1..=10000"), tag(context, 0))]
+        pulse(u16),
+        #[rasn(tag(context, 1))]
+        cost(CurrencyValue),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum CurrencyValue {
+        #[rasn(tag(context, 0))]
+        usDollar(Currency),
+        #[rasn(tag(context, 1))]
+        frenchFranc(Currency),
+        #[rasn(tag(context, 2))]
+        germanMark(Currency),
+        #[rasn(tag(context, 3))]
+        dutchGuilder(Currency),
+        #[rasn(tag(context, 4))]
+        italianLira(Currency),
+        #[rasn(tag(context, 5))]
+        englishPound(Currency),
+        #[rasn(tag(context, 6))]
+        spanishPeseta(Currency),
+        #[rasn(tag(context, 7))]
+        swedishKrone(Currency),
+        #[rasn(tag(context, 8))]
+        norwegianKrone(Currency),
+        #[rasn(tag(context, 9))]
+        japaneseYen(Currency),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct IsdnAddress(pub NumericString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=3"))]
+    pub struct NetworkCode(pub NumericString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "SS-Code")]
+    pub struct SSCode(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct Service(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct SupplServiceStatus(pub BitString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct TypesOfNotification(pub BitString);
+    pub static ID_AO: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&[0u32, 0u32], &***Q, &[1551u32, 0u32, 0u32, 1u32, 0u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AO_SUPPLEMENTARY_SERVICE: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AO, &[1u32]].concat()).unwrap().to_owned());
+    pub static ID_AT: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&[0u32, 0u32], &***Q, &[1551u32, 0u32, 0u32, 2u32, 0u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_ACTIVE_CHARGING_SERVICE: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[10u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_ALLOWED_DESTINATIONS: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[21u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_ALLOWED_REGISTRATION_ADDRESS: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| {
+            Oid::new(&[&***ID_AT, &[15u32]].concat())
+                .unwrap()
+                .to_owned()
+        });
+    pub static ID_AT_ALLOWED_SERVICE_FEATURES: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[11u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_CALL_INFO_RECORDS: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[9u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_DEFAULT_CHARGING_REFERENCE: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[13u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_FORWARDED_TO_NUMBER: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[18u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_IC_REGISTRATION_ADDRESS: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[14u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_NB_OF_FAILED_AUTHENTICATIONS: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[7u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_NO_REPLY_CONDITION_TIMER: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[20u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_PROVIDED_LOCATIONS: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[3u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_PROVIDED_SERVICE_ID: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[2u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_PROVIDER_ID: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[1u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_PUI: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[4u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_SPECIAL_PASSWORD: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[5u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_SUPPL_SERV_ID: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[16u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_SUPPL_SERVICE_STATUS: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[17u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_TYPES_OF_NOTIFICATION: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[19u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_UPT_NUMBER: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_AT, &[12u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AT_USER_CREDIT: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[8u32]].concat()).unwrap().to_owned());
+    pub static ID_AT_VARIABLE_PASSWORD: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AT, &[6u32]].concat()).unwrap().to_owned());
+    pub static ID_NF: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&[0u32, 0u32], &***Q, &[1551u32, 0u32, 0u32, 3u32, 0u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_NF_ADMIN_UNIT_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[3u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_AGREED_SERVICE_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[4u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_CALL_FORWARDING_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[9u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_CALLED_UPT_USER_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[7u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_CALLING_UPT_USER_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[8u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_PARTNER_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[2u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_UPT_PROVIDER_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[1u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_USER_PROFILE_ALIAS_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[6u32]].concat()).unwrap().to_owned());
+    pub static ID_NF_USER_PROFILE_NAME_FORM: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_NF, &[5u32]].concat()).unwrap().to_owned());
+    #[doc = " object-identifiers assignment"]
+    pub static ID_OC: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&[0u32, 0u32], &***Q, &[1551u32, 0u32, 0u32, 0u32, 0u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_OC_ADMINISTRATIVE_UNIT: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[4u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_AGREEMENT: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[3u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_CALL_FORWARDING: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[9u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_CALLED_UPT_USER: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[7u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_CALLING_UPT_USER: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[8u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_PARTNER: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[2u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_UPT_PROVIDER: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[1u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_USER_PROFILE: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[5u32]].concat()).unwrap().to_owned());
+    pub static ID_OC_USER_PROFILE_ALIAS: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_OC, &[6u32]].concat()).unwrap().to_owned());
+    pub static MAX_CAUSE_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(20i128));
+    pub static MIN_CAUSE_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(2i128));
+    pub static UB_MAX_NB_OF_FAILED_AUTHENTICATIONS: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(6i128));
+    pub static UB_MAX_USER_CREDIT: LazyLock<Integer> = LazyLock::new(|| Integer::from(10000i128));
+    pub static UB_NETWORK_CODE: LazyLock<Integer> = LazyLock::new(|| Integer::from(3i128));
+    pub static UB_NO_REPLY_CONDITION_TIMER: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(10000i128));
+    pub static UB_PROVIDER_ID: LazyLock<Integer> = LazyLock::new(|| Integer::from(3i128));
+    pub static UB_PUI: LazyLock<Integer> = LazyLock::new(|| Integer::from(15i128));
+    pub static UB_PULSE: LazyLock<Integer> = LazyLock::new(|| Integer::from(10000i128));
+    pub static UB_SPECIAL_PASSWORD: LazyLock<Integer> = LazyLock::new(|| Integer::from(8i128));
+    pub static UB_VARIABLE_PASSWORD: LazyLock<Integer> = LazyLock::new(|| Integer::from(15i128));
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q825_1998_ASN1DefinedTypesModuleNew.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_q_q825_1998_ASN1DefinedTypesModuleNew.asn1.snap
@@ -2,12 +2,51 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_q_q825_1998_ASN1DefinedTypesModuleNew.asn1
 ---
-Error matching ASN syntax at while parsing:
-    ╭─[line 26, column 13]
-    │
-    │ 
- 26 │   OF MANAGEMENT-EXTENSION({AllowedAdditionalRecordTypes}) ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 28 │  -- The AllowedAdditionalRecordTypes is the constraint that allows only certain types to be set as
- 29 │  -- AdditionalRecordType.
-    │
-────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod asn1_defined_types_module_new {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct AdditionalRecordType(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " The AdditionalRecordTypes type is to be used in the RecordContent type of"]
+    #[doc = " ASN1DefinedTypesModule module."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct BlockExtension(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " The BlockExtensions type is to be used in the BlockHeaderRecord type of"]
+    #[doc = " ASN1DefinedTypesModule"]
+    #[doc = " module"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RecordExtension(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " The RecordExtensions type is to be used in the CallRecord type of"]
+    #[doc = " ASN1DefinedTypesModule module"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ServiceSpecificINInformation(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " TheServiceSpecificINInformations type is to be used in the CallRecord type of"]
+    #[doc = " ASN1DefinedTypesModule module."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct StandardAdditionalRecordType(pub MANAGEMENTEXTENSION);
+    #[doc = " dynamically extensible information object set"]
+    #[doc = " TheStandardAdditionalRecordTypes type is to be used in the RecordContent type of"]
+    #[doc = " ASN1DefinedTypesModule module."]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct StandardExtension(pub MANAGEMENTEXTENSION);
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x1085_2016_XBHSM.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x1085_2016_XBHSM.asn1.snap
@@ -2,11 +2,95 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_x_x1085_2016_XBHSM.asn1
 ---
-Error matching ASN syntax at while parsing:
-    ╭─[line 39, column 35]
-    │
-    │ 
- 39 │   OF BHSM-PSID({SupportedBHSM-PSID}) ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 40 │  	SupportedBHSM-PSID BHSM-PSID ::= {bioRef,...}
-    │
-────╯
+Warnings:
+LinkerError in ASN grammar: No syntax definition for information object class found!
+LinkerError in ASN grammar: No syntax definition for information object class found!
+LinkerError in ASN grammar: Failed to resolve supertype AlgorithmIdentifier of parameterized implementation.
+LinkerError in ASN grammar: Failed to resolve supertype AlgorithmIdentifier of parameterized implementation.
+
+
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod xbhsm {
+    extern crate alloc;
+    use super::authentication_framework::*;
+    use super::useful_definitions::AUTHENTICATION_FRAMEWORK;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct DataSetForEncryptedPSID {
+        #[rasn(default = "data_set_for_encrypted_psid_version_default")]
+        pub version: Integer,
+        #[rasn(identifier = "psidEncAlg")]
+        pub psid_enc_alg: PSIDEncryptionAlgorithm,
+        #[rasn(identifier = "encryptedPsid")]
+        pub encrypted_psid: EncryptedPsid,
+    }
+    impl DataSetForEncryptedPSID {
+        pub fn new(
+            version: Integer,
+            psid_enc_alg: PSIDEncryptionAlgorithm,
+            encrypted_psid: EncryptedPsid,
+        ) -> Self {
+            Self {
+                version,
+                psid_enc_alg,
+                encrypted_psid,
+            }
+        }
+    }
+    fn data_set_for_encrypted_psid_version_default() -> Integer {
+        Integer::from(0i128)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncryptedPsid(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct HashAlgorithm(pub AlgorithmIdentifier);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct HashContent {
+        #[rasn(identifier = "bR")]
+        pub b_r: PrintableString,
+        #[rasn(identifier = "randomNum")]
+        pub random_num: BitString,
+    }
+    impl HashContent {
+        pub fn new(b_r: PrintableString, random_num: BitString) -> Self {
+            Self { b_r, random_num }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "InstanceOfBHSM-PID")]
+    pub struct InstanceOfBHSMPID(pub BHSMPSID);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PSID {
+        #[rasn(identifier = "hashAlg")]
+        pub hash_alg: HashAlgorithm,
+        #[rasn(identifier = "hashContent")]
+        pub hash_content: HashContent,
+    }
+    impl PSID {
+        pub fn new(hash_alg: HashAlgorithm, hash_content: HashContent) -> Self {
+            Self {
+                hash_alg,
+                hash_content,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PSIDEncryptionAlgorithm(pub AlgorithmIdentifier);
+    pub static BHSMPSID: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::const_new(&[1u32, 0u32, 17922u32, 2u32, 1u32]).to_owned());
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x413_1999_MSAbstractService.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x413_1999_MSAbstractService.asn1.snap
@@ -3,9 +3,31 @@ source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/itu-t_x_x413_1999_MSAbstractService.asn1
 ---
 Error matching ASN syntax at while parsing:
-     ╭─[line 237, column 31]
+     ╭─[line 391, column 2]
      │
      │ 
- 237 │   OF MS-EXTENSION ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
+ 391 │  FilterItem ::= CHOICE { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
+ 392 │    equality           [0]  AttributeValueAssertion,
+ 393 │    substrings
+ 394 │      [1]  SEQUENCE {type     X413ATTRIBUTE.&id({AttributeTable}),
+ 395 │                     strings
+ 396 │                       SEQUENCE OF
+ 397 │                         CHOICE {initial
+ 398 │                                   [0]  X413ATTRIBUTE.&Type
+ 399 │                                          ({AttributeTable}{@substrings.type}),
+ 400 │                                 any
+ 401 │                                   [1]  X413ATTRIBUTE.&Type
+ 402 │                                          ({AttributeTable}{@substrings.type}),
+ 403 │                                 final
+ 404 │                                   [2]  X413ATTRIBUTE.&Type
+ 405 │                                          ({AttributeTable}{@substrings.type})
+ 406 │                         }},
+ 407 │    greater-or-equal   [2]  AttributeValueAssertion,
+ 408 │    less-or-equal      [3]  AttributeValueAssertion,
+ 409 │    present            [4]  X413ATTRIBUTE.&id({AttributeTable}),
+ 410 │    approximate-match  [5]  AttributeValueAssertion,
+ 411 │    -- 1994 extension
+ 412 │    other-match        [6]  MatchingRuleAssertion
+ 413 │  }
      │
 ─────╯

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@oasis_X9.84-CMS_2003_X9-84-Biometrics.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@oasis_X9.84-CMS_2003_X9-84-Biometrics.asn1.snap
@@ -2,20 +2,374 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/oasis_X9.84-CMS_2003_X9-84-Biometrics.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 289, column 2]
-     │
-     │ 
- 281 │  --
- 282 │  -- A domainBiometricTemplates information object can be used to
- 283 │  -- extend the information bound to a public key in an value of
- 284 │  -- ASN.1 type DomainCertificate as defined in the X9.68 Domain
- 285 │  -- Certificate Syntax standard, to include biometric identity
- 286 │  -- information.
- 287 │  --
- 289 │  domainBiometricTemplates PRIVATE-X ::= { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 290 │     NAME  oid : x968-biometricTemplates
- 291 │     TYPE  EncodedBiometricObjects  -- DER or cXER --
- 292 │  }
-     │
-─────╯
+Warnings:
+LinkerError in ASN grammar: Failed to resolve reference in object set.
+
+
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod x9_84_biometrics {
+    extern crate alloc;
+    use super::x9_84_cms::{
+        AuthenticatedData, EncryptedData, EnvelopedData, MACAlgorithmIdentifier,
+        SignatureAlgorithmIdentifier, SignedData,
+    };
+    use super::x9_84_identifiers::{
+        BiometricTypes, CBEFFFormats, IBIAFormats, MatchingAIDs, ProcessingAIDs, X9Formats,
+        X509_BIOMETRIC_TEMPLATES, X968_BIOMETRIC_TEMPLATES,
+    };
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags, identifier = "BIOMETRIC-IDENTIFIER")]
+    pub enum BIOMETRICIDENTIFIER {
+        oid(ObjectIdentifier),
+        id(ObjectIdentifier),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct BiometricData(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct BiometricHeader {
+        #[rasn(default = "biometric_header_version_default")]
+        pub version: BiometricVersion,
+        #[rasn(identifier = "recordType")]
+        pub record_type: Option<RecordType>,
+        #[rasn(identifier = "dataType")]
+        pub data_type: Option<DataType>,
+        pub purpose: Option<Purpose>,
+        pub quality: Option<Quality>,
+        #[rasn(identifier = "validityPeriod")]
+        pub validity_period: Option<ValidityPeriod>,
+        pub format: Option<Format>,
+    }
+    impl BiometricHeader {
+        pub fn new(
+            version: BiometricVersion,
+            record_type: Option<RecordType>,
+            data_type: Option<DataType>,
+            purpose: Option<Purpose>,
+            quality: Option<Quality>,
+            validity_period: Option<ValidityPeriod>,
+            format: Option<Format>,
+        ) -> Self {
+            Self {
+                version,
+                record_type,
+                data_type,
+                purpose,
+                quality,
+                validity_period,
+                format,
+            }
+        }
+    }
+    fn biometric_header_version_default() -> BiometricVersion {
+        BiometricVersion(Integer::from(0i128))
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct BiometricHeaders(pub SequenceOf<BiometricHeader>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct BiometricInformation {
+        #[rasn(identifier = "processingAlgorithms")]
+        pub processing_algorithms: Option<ProcessingAlgorithms>,
+        #[rasn(identifier = "matchingMethods")]
+        pub matching_methods: Option<MatchingMethods>,
+    }
+    impl BiometricInformation {
+        pub fn new(
+            processing_algorithms: Option<ProcessingAlgorithms>,
+            matching_methods: Option<MatchingMethods>,
+        ) -> Self {
+            Self {
+                processing_algorithms,
+                matching_methods,
+            }
+        }
+    }
+    #[doc = " Authentication Information (AI) "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct BiometricInformationSets(pub SequenceOf<BiometricInformation>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct BiometricObject {
+        #[rasn(identifier = "biometricHeader")]
+        pub biometric_header: BiometricHeader,
+        #[rasn(identifier = "biometricData")]
+        pub biometric_data: BiometricData,
+    }
+    impl BiometricObject {
+        pub fn new(biometric_header: BiometricHeader, biometric_data: BiometricData) -> Self {
+            Self {
+                biometric_header,
+                biometric_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct BiometricObjects(pub SequenceOf<BiometricObject>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum BiometricSyntax {
+        biometricObjects(BiometricObjects),
+        integrityObjects(IntegrityObjects),
+        privacyObjects(PrivacyObjects),
+        privacyAndIntegrityObjects(PrivacyAndIntegrityObjects),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct BiometricSyntaxSets(pub SequenceOf<BiometricSyntax>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0.."))]
+    pub struct BiometricVersion(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    pub enum DataType {
+        raw = 0,
+        intermediate = 1,
+        processed = 2,
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct DateTime(pub ObjectIdentifier);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct DigitalSignature {
+        #[rasn(identifier = "algorithmID")]
+        pub algorithm_id: SignatureAlgorithmIdentifier,
+        #[rasn(value("0.."))]
+        pub signature: OctetString,
+    }
+    impl DigitalSignature {
+        pub fn new(algorithm_id: SignatureAlgorithmIdentifier, signature: OctetString) -> Self {
+            Self {
+                algorithm_id,
+                signature,
+            }
+        }
+    }
+    #[doc = ""]
+    #[doc = " All of the cryptographic processing in this standard is performed"]
+    #[doc = " on a value of type EncodedBiometricObjects. This is a sequence of"]
+    #[doc = " one or more values of type BiometricObject in its encoded form."]
+    #[doc = ""]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct EncodedBiometricObjects(pub Any);
+    #[doc = " { yyyy mm dd hh mm ss z } "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct Format {
+        #[rasn(identifier = "formatOwner")]
+        pub format_owner: BIOMETRICIDENTIFIER,
+        #[rasn(identifier = "formatType")]
+        pub format_type: Option<Any>,
+    }
+    impl Format {
+        pub fn new(format_owner: BIOMETRICIDENTIFIER, format_type: Option<Any>) -> Self {
+            Self {
+                format_owner,
+                format_type,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum Identifier {
+        oid(ObjectIdentifier),
+        id(ObjectIdentifier),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum IntegrityBlock {
+        digitalSignature(DigitalSignature),
+        messageAuthenticationCode(MessageAuthenticationCode),
+        signedData(SignedData),
+        authenticatedData(AuthenticatedData),
+    }
+    #[doc = " Integrity "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct IntegrityObjects {
+        #[rasn(identifier = "biometricObjects")]
+        pub biometric_objects: EncodedBiometricObjects,
+        #[rasn(identifier = "integrityBlock")]
+        pub integrity_block: IntegrityBlock,
+    }
+    impl IntegrityObjects {
+        pub fn new(
+            biometric_objects: EncodedBiometricObjects,
+            integrity_block: IntegrityBlock,
+        ) -> Self {
+            Self {
+                biometric_objects,
+                integrity_block,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct MatchingInformation {
+        pub id: BIOMETRICIDENTIFIER,
+        pub parms: Option<Any>,
+    }
+    impl MatchingInformation {
+        pub fn new(id: BIOMETRICIDENTIFIER, parms: Option<Any>) -> Self {
+            Self { id, parms }
+        }
+    }
+    #[doc = " Biometric matching methods "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct MatchingMethods(pub SequenceOf<MatchingInformation>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct MessageAuthenticationCode {
+        #[rasn(identifier = "keyName")]
+        pub key_name: Option<OctetString>,
+        #[rasn(identifier = "algorithmID")]
+        pub algorithm_id: MACAlgorithmIdentifier,
+        #[rasn(value("0.."))]
+        pub mac: OctetString,
+    }
+    impl MessageAuthenticationCode {
+        pub fn new(
+            key_name: Option<OctetString>,
+            algorithm_id: MACAlgorithmIdentifier,
+            mac: OctetString,
+        ) -> Self {
+            Self {
+                key_name,
+                algorithm_id,
+                mac,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct NamedKeyEncryptedData {
+        #[rasn(size("1.."), identifier = "keyName")]
+        pub key_name: OctetString,
+        #[rasn(identifier = "encryptedData")]
+        pub encrypted_data: EncryptedData,
+    }
+    impl NamedKeyEncryptedData {
+        pub fn new(key_name: OctetString, encrypted_data: EncryptedData) -> Self {
+            Self {
+                key_name,
+                encrypted_data,
+            }
+        }
+    }
+    #[doc = " Privacy and integrity "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PrivacyAndIntegrityObjects {
+        #[rasn(identifier = "biometricHeaders")]
+        pub biometric_headers: Option<BiometricHeaders>,
+        #[rasn(identifier = "privacyBlock")]
+        pub privacy_block: PrivacyBlock,
+        #[rasn(identifier = "integrityBlock")]
+        pub integrity_block: IntegrityBlock,
+    }
+    impl PrivacyAndIntegrityObjects {
+        pub fn new(
+            biometric_headers: Option<BiometricHeaders>,
+            privacy_block: PrivacyBlock,
+            integrity_block: IntegrityBlock,
+        ) -> Self {
+            Self {
+                biometric_headers,
+                privacy_block,
+                integrity_block,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    pub enum PrivacyBlock {
+        fixedKey(EncryptedData),
+        namedKey(NamedKeyEncryptedData),
+        establishedKey(EnvelopedData),
+    }
+    #[doc = " Privacy "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct PrivacyObjects {
+        #[rasn(identifier = "biometricHeaders")]
+        pub biometric_headers: Option<BiometricHeaders>,
+        #[rasn(identifier = "privacyBlock")]
+        pub privacy_block: PrivacyBlock,
+    }
+    impl PrivacyObjects {
+        pub fn new(
+            biometric_headers: Option<BiometricHeaders>,
+            privacy_block: PrivacyBlock,
+        ) -> Self {
+            Self {
+                biometric_headers,
+                privacy_block,
+            }
+        }
+    }
+    #[doc = " Biometric processing algorithms "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct ProcessingAlgorithms(pub SequenceOf<ProcessingInformation>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ProcessingInformation {
+        pub id: BIOMETRICIDENTIFIER,
+        pub parms: Option<Any>,
+    }
+    impl ProcessingInformation {
+        pub fn new(id: BIOMETRICIDENTIFIER, parms: Option<Any>) -> Self {
+            Self { id, parms }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(enumerated)]
+    #[non_exhaustive]
+    pub enum Purpose {
+        verify = 1,
+        identify = 2,
+        enroll = 3,
+        enrollVerify = 4,
+        enrollIdentity = 5,
+        audit = 6,
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("-2..=100", extensible))]
+    pub struct Quality(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RecordType(pub BIOMETRICIDENTIFIER);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct ValidityPeriod {
+        #[rasn(identifier = "notBefore")]
+        pub not_before: Option<DateTime>,
+        #[rasn(identifier = "notAfter")]
+        pub not_after: Option<DateTime>,
+    }
+    impl ValidityPeriod {
+        pub fn new(not_before: Option<DateTime>, not_after: Option<DateTime>) -> Self {
+            Self {
+                not_before,
+                not_after,
+            }
+        }
+    }
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@oasis_X9.84-CMS_2003_X9-84-Identifiers.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@oasis_X9.84-CMS_2003_X9-84-Identifiers.asn1.snap
@@ -2,33 +2,378 @@
 source: rasn-compiler-tests/tests/parse_test.rs
 input_file: rasn-compiler-tests/tests/modules/oasis_X9.84-CMS_2003_X9-84-Identifiers.asn1
 ---
-Error matching ASN syntax at while parsing:
-     ╭─[line 150, column 2]
-     │
-     │ 
- 150 │  BiometricTypes BIOMETRIC ::= { ◀▪▪▪▪▪▪▪▪▪▪ FAILED AT THIS LINE
- 151 │     { BIOMETRIC id : unknown-Type       } |
- 152 │     { BIOMETRIC id : body-Odor          } |
- 153 │     { BIOMETRIC id : dna                } |
- 154 │     { BIOMETRIC id : ear-Shape          } |
- 155 │     { BIOMETRIC id : facial-Features    } |
- 156 │     { BIOMETRIC id : finger-Image       } |
- 157 │     { BIOMETRIC id : finger-Geometry    } |
- 158 │     { BIOMETRIC id : hand-Geometry      } |
- 159 │     { BIOMETRIC id : iris-Features      } |
- 160 │     { BIOMETRIC id : keystroke-Dynamics } |
- 161 │     { BIOMETRIC id : palm               } |
- 162 │     { BIOMETRIC id : retina             } |
- 163 │     { BIOMETRIC id : signature          } |
- 164 │     { BIOMETRIC id : speech-Pattern     } |
- 165 │     { BIOMETRIC id : thermal-Image      } |
- 166 │     { BIOMETRIC id : vein-Pattern       } |
- 167 │     { BIOMETRIC id : thermal-Face-Image } |
- 168 │     { BIOMETRIC id : thermal-Hand-Image } |
- 169 │     { BIOMETRIC id : lip-Movement       } |
- 170 │     { BIOMETRIC id : gait               },
- 172 │     ...  -- expect additional biometric types --
- 173 │  }
- 176 │  -- X9.84 biometric processing algorithms --
-     │
-─────╯
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod x9_84_identifiers {
+    extern crate alloc;
+    use super::x9_84_biometrics::*;
+    use super::x9_84_cms::*;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct Any(pub Any);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct BirInt16(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
+    #[rasn(delegate)]
+    pub struct NoIV(pub ());
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct OID(pub ObjectIdentifier);
+    #[doc = " Alias"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RelOID(pub ObjectIdentifier);
+    #[doc = " X9.84 biometric technologies "]
+    pub static BIOMETRIC: LazyLock<OID> =
+        LazyLock::new(|| OID(Oid::new(&[&***X9_84, &[1u32]].concat()).unwrap().to_owned()));
+    pub static BODY_ODOR: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[1u32]).to_owned()));
+    pub static CBEFF_OWNER: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***FORMAT_OWNER, &[0u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static CERTIFICATE_EXTENSIONS: LazyLock<OID> =
+        LazyLock::new(|| OID(Oid::new(&[&***X9_84, &[5u32]].concat()).unwrap().to_owned()));
+    #[doc = " ANS X9.52 Triple DES Modes of Operation "]
+    pub static DES_EDE3_CBC: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::const_new(&[1u32, 2u32, 840u32, 113549u32, 3u32, 7u32]).to_owned());
+    pub static DNA: LazyLock<RelOID> = LazyLock::new(|| RelOID(Oid::const_new(&[2u32]).to_owned()));
+    #[doc = " No initialization vector"]
+    #[doc = " X9.57 DSA signature generated with SHA-1 hash (DSA X9.30)"]
+    pub static DSA_WITH_SHA1: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::const_new(&[1u32, 2u32, 840u32, 10040u32, 4u32, 3u32]).to_owned())
+    });
+    pub static EAR_SHAPE: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[3u32]).to_owned()));
+    #[doc = " X9.62 ECDSA signature with SHA-1"]
+    pub static ECDSA_WITH_SHA1: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::const_new(&[1u32, 2u32, 840u32, 10045u32, 4u32, 1u32]).to_owned())
+    });
+    pub static FACIAL_FEATURES: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[4u32]).to_owned()));
+    pub static FINGER_GEOMETRY: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[6u32]).to_owned()));
+    pub static FINGER_IMAGE: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[5u32]).to_owned()));
+    #[doc = " X9.84 vendor specific formats "]
+    pub static FORMAT_OWNER: LazyLock<OID> =
+        LazyLock::new(|| OID(Oid::new(&[&***X9_84, &[4u32]].concat()).unwrap().to_owned()));
+    pub static GAIT: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[19u32]).to_owned()));
+    pub static HAND_GEOMETRY: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[7u32]).to_owned()));
+    #[doc = "  X9.71 HMAC with SHA-1 algorithm"]
+    pub static HMAC_WITH_SHA1: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::const_new(&[1u32, 3u32, 6u32, 1u32, 5u32, 5u32, 8u32, 1u32, 2u32]).to_owned())
+    });
+    pub static IBIA_A3_VISION: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[16u32]).to_owned()));
+    pub static IBIA_BIOSCRYPT: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[2u32]).to_owned()));
+    pub static IBIA_CYBER_SIGN: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[7u32]).to_owned()));
+    pub static IBIA_DERMALOG: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[13u32]).to_owned()));
+    pub static IBIA_FINGERPRINT_CARDS_AB: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[9u32]).to_owned()));
+    pub static IBIA_IDENTIX: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[12u32]).to_owned()));
+    pub static IBIA_INFINEON_TECHNOLOGIES_AG: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[4u32]).to_owned()));
+    pub static IBIA_IRIDIAN_TECHNOLOGIES: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[5u32]).to_owned()));
+    pub static IBIA_LOGICO: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[14u32]).to_owned()));
+    pub static IBIA_NEC: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[17u32]).to_owned()));
+    pub static IBIA_NIST: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[15u32]).to_owned()));
+    pub static IBIA_OWNER: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***FORMAT_OWNER, &[1u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static IBIA_PRECISE_BIOMETRIC: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[11u32]).to_owned()));
+    #[doc = " Application constrained"]
+    #[doc = " Relative object identifier representations of the identical"]
+    #[doc = " IBIA vendor specific formats defined as OBJECT IDENTIFIER"]
+    #[doc = " values above are used to identify these formats when they must"]
+    #[doc = " comply with the fixed format requirements of the BioAPI 1.1"]
+    #[doc = " specification and are associated with a two byte integer value."]
+    pub static IBIA_SAFLINK: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[1u32]).to_owned()));
+    pub static IBIA_STMICROELECTRONICS: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[18u32]).to_owned()));
+    pub static IBIA_SECU_GEN: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[10u32]).to_owned()));
+    pub static IBIA_VERIDICOM: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[6u32]).to_owned()));
+    pub static IBIA_VISIONICS: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[3u32]).to_owned()));
+    pub static IBIA_E_CRYP: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[8u32]).to_owned()));
+    pub static ID_BODY_ODOR: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[1u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    #[doc = " RSA PKCS #7 Content type"]
+    pub static ID_DATA: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::const_new(&[1u32, 2u32, 840u32, 113549u32, 1u32, 7u32, 1u32]).to_owned())
+    });
+    pub static ID_DNA: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[2u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_EAR_SHAPE: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[3u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_FACIAL_FEATURES: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[4u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_FINGER_GEOMETRY: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[6u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_FINGER_IMAGE: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[5u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_GAIT: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[19u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_HAND_GEOMETRY: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[7u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_IRIS_FEATURES: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[8u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_KEYSTROKE_DYNAMICS: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[9u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_LIP_MOVEMENT: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[18u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_PALM: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[10u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_RETINA: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[11u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    #[doc = " Security object identifiers"]
+    #[doc = " FIPS 180-1 and FIPS 180-2 Secure Hash Algorithm "]
+    pub static ID_SHA1: LazyLock<OID> =
+        LazyLock::new(|| OID(Oid::const_new(&[1u32, 3u32, 14u32, 3u32, 2u32, 26u32]).to_owned()));
+    pub static ID_SHA256: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***SHA2_ALGORITHM, &[1u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_SHA384: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***SHA2_ALGORITHM, &[2u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_SHA512: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***SHA2_ALGORITHM, &[3u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_SIGNATURE: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[12u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_SPEECH_PATTERN: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[13u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_THERMAL_FACE_IMAGE: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[16u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_THERMAL_HAND_IMAGE: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[17u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_THERMAL_IMAGE: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[14u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_UNKNOWN_TYPE: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[0u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_VEIN_PATTERN: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***BIOMETRIC, &[15u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static ID_X984_BIO_INFO: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***CBEFF_OWNER, &[0u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static IRIS_FEATURES: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[8u32]).to_owned()));
+    pub static KEYSTROKE_DYNAMICS: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[9u32]).to_owned()));
+    pub static LIP_MOVEMENT: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[18u32]).to_owned()));
+    #[doc = " X9.84 biometric matching methods "]
+    pub static MATCHING_METHOD: LazyLock<OID> =
+        LazyLock::new(|| OID(Oid::new(&[&***X9_84, &[3u32]].concat()).unwrap().to_owned()));
+    pub static PALM: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[10u32]).to_owned()));
+    #[doc = " X9.84 biometric processing algorithms "]
+    pub static PROCESSING_ALGORITHM: LazyLock<OID> =
+        LazyLock::new(|| OID(Oid::new(&[&***X9_84, &[2u32]].concat()).unwrap().to_owned()));
+    pub static RETINA: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[11u32]).to_owned()));
+    pub static RSA_ENCRYPTION: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::const_new(&[1u32, 2u32, 840u32, 113549u32, 1u32, 1u32, 1u32]).to_owned()
+    });
+    #[doc = " RSA PKCS #1 signature generated with SHA-1 hash & encryption scheme"]
+    pub static SHA1_WITH_RSAENCRYPTION: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::const_new(&[1u32, 2u32, 840u32, 113549u32, 1u32, 1u32, 5u32]).to_owned())
+    });
+    pub static SHA2_ALGORITHM: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::const_new(&[2u32, 16u32, 840u32, 1u32, 101u32, 3u32, 4u32, 2u32]).to_owned())
+    });
+    pub static SIGNATURE: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[12u32]).to_owned()));
+    pub static SPEECH_PATTERN: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[13u32]).to_owned()));
+    pub static THERMAL_FACE_IMAGE: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[16u32]).to_owned()));
+    pub static THERMAL_HAND_IMAGE: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[17u32]).to_owned()));
+    pub static THERMAL_IMAGE: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[14u32]).to_owned()));
+    #[doc = " X9.84 biometric technology object identifier fragments "]
+    pub static UNKNOWN_TYPE: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[0u32]).to_owned()));
+    pub static VEIN_PATTERN: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[15u32]).to_owned()));
+    #[doc = " Alias"]
+    #[doc = " x9-84                          { 1 3 133 16 840 9 84         }"]
+    #[doc = " x9-84-Module                   { 1 3 133 16 840 9 84 0       }"]
+    #[doc = " x9-84-Biometrics               { 1 3 133 16 840 9 84 0  1    }"]
+    #[doc = " x9-84-CMS                      { 1 3 133 16 840 9 84 0  2    }"]
+    #[doc = " x9-84-Identifiers              { 1 3 133 16 840 9 84 0  3    }"]
+    #[doc = " biometric                      { 1 3 133 16 840 9 84 1       }"]
+    #[doc = " id-unknown-Type                { 1 3 133 16 840 9 84 1  0    }"]
+    #[doc = " id-body-Odor                   { 1 3 133 16 840 9 84 1  1    }"]
+    #[doc = " id-dna                         { 1 3 133 16 840 9 84 1  2    }"]
+    #[doc = " id-ear-Shape                   { 1 3 133 16 840 9 84 1  3    }"]
+    #[doc = " id-facial-Features             { 1 3 133 16 840 9 84 1  4    }"]
+    #[doc = " id-finger-Image                { 1 3 133 16 840 9 84 1  5    }"]
+    #[doc = " id-finger-Geometry             { 1 3 133 16 840 9 84 1  6    }"]
+    #[doc = " id-hand-Geometry               { 1 3 133 16 840 9 84 1  7    }"]
+    #[doc = " id-iris-Features               { 1 3 133 16 840 9 84 1  8    }"]
+    #[doc = " id-keystroke-Dynamics          { 1 3 133 16 840 9 84 1  9    }"]
+    #[doc = " id-palm                        { 1 3 133 16 840 9 84 1 10    }"]
+    #[doc = " id-retina                      { 1 3 133 16 840 9 84 1 11    }"]
+    #[doc = " id-signature                   { 1 3 133 16 840 9 84 1 12    }"]
+    #[doc = " id-speech-Pattern              { 1 3 133 16 840 9 84 1 13    }"]
+    #[doc = " id-thermal-Image               { 1 3 133 16 840 9 84 1 14    }"]
+    #[doc = " id-vein-Pattern                { 1 3 133 16 840 9 84 1 15    }"]
+    #[doc = " id-thermal-Face-Image          { 1 3 133 16 840 9 84 1 16    }"]
+    #[doc = " id-thermal-Hand-Image          { 1 3 133 16 840 9 84 1 17    }"]
+    #[doc = " id-lip-Movement                { 1 3 133 16 840 9 84 1 18    }"]
+    #[doc = " id-gait                        { 1 3 133 16 840 9 84 1 19    }"]
+    #[doc = " processing-algorithm           { 1 3 133 16 840 9 84 2       }"]
+    #[doc = " matching-method                { 1 3 133 16 840 9 84 3       }"]
+    #[doc = " format-Owner                   { 1 3 133 16 840 9 84 4       }"]
+    #[doc = " cbeff-Owner                    { 1 3 133 16 840 9 84 4  0    }"]
+    #[doc = " ibia-Owner                     { 1 3 133 16 840 9 84 4  1    }"]
+    #[doc = " id-ibia-SAFLINK                { 1 3 133 16 840 9 84 4  1  1 }"]
+    #[doc = " id-ibia-Bioscrypt              { 1 3 133 16 840 9 84 4  1  2 }"]
+    #[doc = " id-ibia-Visionics              { 1 3 133 16 840 9 84 4  1  3 }"]
+    #[doc = " id-ibia-InfineonTechnologiesAG { 1 3 133 16 840 9 84 4  1  4 }"]
+    #[doc = " id-ibia-IridianTechnologies    { 1 3 133 16 840 9 84 4  1  5 }"]
+    #[doc = " id-ibia-Veridicom              { 1 3 133 16 840 9 84 4  1  6 }"]
+    #[doc = " id-ibia-CyberSIGN              { 1 3 133 16 840 9 84 4  1  7 }"]
+    #[doc = " id-ibia-eCryp                  { 1 3 133 16 840 9 84 4  1  8 }"]
+    #[doc = " id-ibia-FingerprintCardsAB     { 1 3 133 16 840 9 84 4  1  9 }"]
+    #[doc = " id-ibia-SecuGen                { 1 3 133 16 840 9 84 4  1 10 }"]
+    #[doc = " id-ibia-PreciseBiometric       { 1 3 133 16 840 9 84 4  1 11 }"]
+    #[doc = " id-ibia-Identix                { 1 3 133 16 840 9 84 4  1 12 }"]
+    #[doc = " id-ibia-DERMALOG               { 1 3 133 16 840 9 84 4  1 13 }"]
+    #[doc = " id-ibia-LOGICO                 { 1 3 133 16 840 9 84 4  1 14 }"]
+    #[doc = " id-ibia-NIST                   { 1 3 133 16 840 9 84 4  1 15 }"]
+    #[doc = " id-ibia-A3Vision               { 1 3 133 16 840 9 84 4  1 16 }"]
+    #[doc = " id-ibia-NEC                    { 1 3 133 16 840 9 84 4  1 17 }"]
+    #[doc = " id-ibia-STMicroelectronics     { 1 3 133 16 840 9 84 4  1 18 }"]
+    #[doc = " x9-Owner                       { 1 3 133 16 840 9 84 4  2    }"]
+    #[doc = " certificate-Extensions         { 1 3 133 16 840 9 84 5       }"]
+    #[doc = " x968-biometricTemplates        { 1 3 133 16 840 9 84 5  0    }"]
+    #[doc = " x509-biometricTemplates        { 1 3 133 16 840 9 84 5  1    }"]
+    #[doc = " X9.84 arc; base object identifier "]
+    pub static X9_84: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::const_new(&[1u32, 3u32, 133u32, 16u32, 840u32, 9u32, 84u32]).to_owned())
+    });
+    pub static X9_84_BIOMETRICS: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***X9_84_MODULE, &[1u32, 1u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static X9_84_CMS: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***X9_84_MODULE, &[2u32, 1u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static X9_84_IDENTIFIERS: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***X9_84_MODULE, &[3u32, 1u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    #[doc = " X9.84 ASN.1 modules "]
+    pub static X9_84_MODULE: LazyLock<OID> =
+        LazyLock::new(|| OID(Oid::new(&[&***X9_84, &[0u32]].concat()).unwrap().to_owned()));
+    pub static X9_OWNER: LazyLock<OID> = LazyLock::new(|| {
+        OID(Oid::new(&[&***FORMAT_OWNER, &[2u32]].concat())
+            .unwrap()
+            .to_owned())
+    });
+    pub static X984_BIO_INFO: LazyLock<RelOID> =
+        LazyLock::new(|| RelOID(Oid::const_new(&[0u32]).to_owned()));
+}

--- a/rasn-compiler/src/lexer/choice.rs
+++ b/rasn-compiler/src/lexer/choice.rs
@@ -16,7 +16,11 @@ use super::{constraint::constraints, error::ParserResult, *};
 
 pub fn choice_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
     map(
-        skip_ws_and_comments(separated_pair(identifier, char(':'), asn1_value)),
+        skip_ws_and_comments(separated_pair(
+            identifier,
+            skip_ws_and_comments(char(':')),
+            asn1_value,
+        )),
         |(id, val)| ASN1Value::Choice {
             type_name: None,
             variant_name: id.to_owned(),

--- a/rasn-compiler/src/lexer/information_object_class.rs
+++ b/rasn-compiler/src/lexer/information_object_class.rs
@@ -112,7 +112,7 @@ pub fn type_identifier(input: Input<'_>) -> ParserResult<'_, ObjectClassDefn> {
 pub fn instance_of(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         preceded(
-            tag(INSTANCE_OF),
+            skip_ws_and_comments(tag(INSTANCE_OF)),
             pair(
                 skip_ws_and_comments(uppercase_identifier),
                 skip_ws_and_comments(opt(constraints)),

--- a/rasn-compiler/src/lexer/object_identifier.rs
+++ b/rasn-compiler/src/lexer/object_identifier.rs
@@ -45,9 +45,9 @@ use super::{
 ///     RelativeOIDComponents RelativeOIDComponentsList
 /// ```
 pub fn object_identifier_value(input: Input<'_>) -> ParserResult<'_, ObjectIdentifierValue> {
-    into(skip_ws_and_comments(in_braces(many1(skip_ws(
-        object_identifier_arc,
-    )))))
+    into(skip_ws_and_comments(in_braces(many1(
+        skip_ws_and_comments(object_identifier_arc),
+    ))))
     .parse(input)
 }
 


### PR DESCRIPTION
- Allow white space and comments before ':' in CHOICE value.
- Allow white space and comments before INSTANCE OF.
- Allow white space and comments between object identifier arcs.

Fixes parsing of 6 modules.