### PR TITLE
fix(lexer): Allow white space and comments before `STRING`

### DIFF
--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -59,8 +59,7 @@ pub const NULL: &str = "NULL";
 pub const BOOLEAN: &str = "BOOLEAN";
 pub const INTEGER: &str = "INTEGER";
 pub const REAL: &str = "REAL";
-pub const BIT_STRING: &str = "BIT STRING";
-pub const OCTET_STRING: &str = "OCTET STRING";
+pub const STRING: &str = "STRING";
 pub const IA5_STRING: &str = "IA5String";
 pub const UTF8_STRING: &str = "UTF8String";
 pub const NUMERIC_STRING: &str = "NumericString";
@@ -839,8 +838,8 @@ impl ASN1Type {
             ASN1Type::Boolean(_) => Cow::Borrowed(BOOLEAN),
             ASN1Type::Integer(_) => Cow::Borrowed(INTEGER),
             ASN1Type::Real(_) => Cow::Borrowed(REAL),
-            ASN1Type::BitString(_) => Cow::Borrowed(BIT_STRING),
-            ASN1Type::OctetString(_) => Cow::Borrowed(OCTET_STRING),
+            ASN1Type::BitString(_) => Cow::Borrowed("BIT STRING"),
+            ASN1Type::OctetString(_) => Cow::Borrowed("OCTET STRING"),
             ASN1Type::CharacterString(CharacterString {
                 ty: CharacterStringType::BMPString,
                 ..

--- a/rasn-compiler/src/lexer/bit_string.rs
+++ b/rasn-compiler/src/lexer/bit_string.rs
@@ -61,7 +61,10 @@ pub fn bit_string_value(input: Input<'_>) -> ParserResult<'_, ASN1Value> {
 pub fn bit_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
         preceded(
-            skip_ws_and_comments(tag(BIT_STRING)),
+            (
+                skip_ws_and_comments(tag(BIT)),
+                skip_ws_and_comments(tag(STRING)),
+            ),
             pair(opt(distinguished_values), opt(constraints)),
         ),
         |m| ASN1Type::BitString(m.into()),

--- a/rasn-compiler/src/lexer/octet_string.rs
+++ b/rasn-compiler/src/lexer/octet_string.rs
@@ -19,7 +19,13 @@ use super::{common::*, constraint::constraints, error::ParserResult};
 /// If the match fails, the lexer will not consume the input and will return an error.
 pub fn octet_string(input: Input<'_>) -> ParserResult<'_, ASN1Type> {
     map(
-        preceded(skip_ws_and_comments(tag(OCTET_STRING)), opt(constraints)),
+        preceded(
+            (
+                skip_ws_and_comments(tag(OCTET)),
+                skip_ws_and_comments(tag(STRING)),
+            ),
+            opt(constraints),
+        ),
         |m| ASN1Type::OctetString(m.into()),
     )
     .parse(input)


### PR DESCRIPTION
Allow white space and comments before `"STRING"` in `"OCTET STRING"` and `"BIT STRING"`.