### PR TITLE
fix(derive): Add a newline before `END`

### DIFF
--- a/rasn-compiler-derive/src/lib.rs
+++ b/rasn-compiler-derive/src/lib.rs
@@ -8,7 +8,7 @@ const DUMMY_HEADER: &str = r#"asn1 { dummy(999) header(999) }
 
 DEFINITIONS AUTOMATIC TAGS::= BEGIN
 "#;
-const DUMMY_FOOTER: &str = r#"END"#;
+const DUMMY_FOOTER: &str = "\nEND";
 
 struct MacroInput {
     asn: LitStr,


### PR DESCRIPTION
Add a newline before the final `END` in the derive macro. This avoids generating an ASN.1 module ending with for example `my1 ::= myThing1END`.