### PR TITLE
fix: Avoid panics for choice type

### DIFF
--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -628,7 +628,13 @@ impl Rasn {
             | ASN1Type::ObjectClassField(_)
             | ASN1Type::EmbeddedPdv
             | ASN1Type::External => (vec![], quote!(Any)),
-            ASN1Type::ChoiceSelectionType(_) => unreachable!(),
+            ASN1Type::ChoiceSelectionType(_) => {
+                return Err(GeneratorError {
+                    kind: GeneratorErrorType::NotYetInplemented,
+                    details: "Choice selection types should be resolved by now.".into(),
+                    top_level_declaration: None,
+                })
+            }
         })
     }
 

--- a/rasn-compiler/src/intermediate/mod.rs
+++ b/rasn-compiler/src/intermediate/mod.rs
@@ -898,7 +898,10 @@ impl ASN1Type {
             ASN1Type::ElsewhereDeclaredType(DeclarationElsewhere { identifier, .. }) => {
                 Cow::Borrowed(identifier)
             }
-            ASN1Type::ChoiceSelectionType(_) => todo!(),
+            ASN1Type::ChoiceSelectionType(ChoiceSelectionType {
+                choice_name,
+                selected_option,
+            }) => Cow::Owned(format!("{selected_option} < {choice_name}")),
             ASN1Type::ObjectIdentifier(_) => Cow::Borrowed(OBJECT_IDENTIFIER),
             ASN1Type::ObjectClassField(ifr) => Cow::Owned(format!(
                 "{INTERNAL_IO_FIELD_REF_TYPE_NAME_PREFIX}{}${}",


### PR DESCRIPTION
Don't panic in `ASN1Type::to_str` for choice type.

Don't panic on unresolved choice type in rasn generator.