### PR TITLE
fix: wrap DEFAULT values for newtype aliases and SequenceOf types (#167)

### DIFF
--- a/rasn-compiler-tests/Cargo.toml
+++ b/rasn-compiler-tests/Cargo.toml
@@ -17,6 +17,9 @@ rasn-compiler-derive = { path = "../rasn-compiler-derive" }
 rasn-compiler = { path = "../rasn-compiler" }
 rasn = { version = "0.27" }
 
+[build-dependencies]
+rasn-compiler = { path = "../rasn-compiler" }
+
 [dev-dependencies]
 bitvec = { version = "1" }
 bitvec-nom = { version = "0.2" }

--- a/rasn-compiler-tests/build.rs
+++ b/rasn-compiler-tests/build.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use rasn_compiler::{prelude::RasnBackend, Compiler};
+
+fn main() {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let modules = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("tests/modules");
+
+    // TCA v2.3.1 — standalone, no external imports.
+    let result = Compiler::<RasnBackend, _>::new()
+        .add_asn_by_path(modules.join("tca_PEDefinitions_v2.3.1.asn1"))
+        .compile_to_string()
+        .expect("rasn-compiler failed on TCA v2.3.1");
+    std::fs::write(out_dir.join("tca_v2_3_1.rs"), &result.generated).unwrap();
+
+    // TCA v3.4.1 — imports Certificate from PKIX1Explicit88.
+    // Both modules are compiled together; the generated pedefinitions module
+    // references pkix1_explicit88 as a sibling module.
+    let result = Compiler::<RasnBackend, _>::new()
+        .add_asn_by_path(modules.join("ietf_rfc_rfc3280_PKIX1Explicit88.asn1"))
+        .add_asn_by_path(modules.join("tca_PEDefinitions_v3.4.1.asn1"))
+        .compile_to_string()
+        .expect("rasn-compiler failed on TCA v3.4.1 + PKIX1Explicit88");
+    std::fs::write(out_dir.join("tca_v3_4_1.rs"), &result.generated).unwrap();
+
+    println!("cargo:rerun-if-changed=tests/modules/tca_PEDefinitions_v2.3.1.asn1");
+    println!("cargo:rerun-if-changed=tests/modules/tca_PEDefinitions_v3.4.1.asn1");
+    println!(
+        "cargo:rerun-if-changed=tests/modules/ietf_rfc_rfc3280_PKIX1Explicit88.asn1"
+    );
+}

--- a/rasn-compiler-tests/tests/edge_cases.rs
+++ b/rasn-compiler-tests/tests/edge_cases.rs
@@ -126,3 +126,14 @@ e2e_pdu!(
         LDAPString ::= [UNIVERSAL 4] IMPLICIT UTF8String
     "#
 );
+
+// Regression test for issue #167.2 (Bug B): a type alias used as a SEQUENCE field type
+// with a plain integer literal DEFAULT must generate a newtype-wrapped value, e.g.
+// `MyUInt8(1)` rather than bare `1`.
+e2e_pdu!(
+    integer_type_alias_with_literal_default,
+    r#"
+        MySeq ::= SEQUENCE { count MyUInt8 DEFAULT 1 }
+        MyUInt8 ::= INTEGER (0..255)
+    "#
+);

--- a/rasn-compiler-tests/tests/modules/tca_PEDefinitions_v2.3.1.asn1
+++ b/rasn-compiler-tests/tests/modules/tca_PEDefinitions_v2.3.1.asn1
@@ -1,0 +1,936 @@
+PEDefinitions {joint-iso-itu-t(2) international-organizations(23) simalliance(143) euicc-profile(1) spec-version(1) version-two(2)}
+DEFINITIONS
+AUTOMATIC TAGS
+EXTENSIBILITY IMPLIED ::=
+BEGIN
+
+-- Basic integer types, for size constraints
+maxUInt8 INTEGER ::= 255
+UInt8 ::= INTEGER (0..maxUInt8)
+maxUInt15 INTEGER ::= 32767
+UInt15 ::= INTEGER (0..maxUInt15)
+maxUInt16 INTEGER ::= 65535
+UInt16 ::= INTEGER (0..maxUInt16)
+maxUInt31 INTEGER ::= 2147483647
+UInt31 ::= INTEGER (0..maxUInt31)
+
+ApplicationIdentifier ::= OCTET STRING (SIZE(5..16))
+
+PEHeader ::= SEQUENCE {
+mandated NULL OPTIONAL,
+-- if set, indicate that the support of this PE is mandatory
+identification UInt15 -- Identification number of this PE
+}
+
+ProfileElement ::= CHOICE {
+	header ProfileHeader,
+
+/* PEs */
+	genericFileManagement PE-GenericFileManagement,
+	pinCodes PE-PINCodes,
+	pukCodes PE-PUKCodes,
+	akaParameter PE-AKAParameter,
+	cdmaParameter PE-CDMAParameter,
+	securityDomain PE-SecurityDomain,
+	rfm PE-RFM,
+	application PE-Application,
+	nonStandard PE-NonStandard,
+	end PE-End,
+	rfu1 PE-Dummy, -- this avoids renumbering of tag values
+	rfu2 PE-Dummy, -- in case other non-file-system PEs are
+	rfu3 PE-Dummy, -- added here in future versions
+	rfu4 PE-Dummy,
+	rfu5 PE-Dummy,
+
+/* PEs related to file system creation using templates defined in this specification */	
+	mf PE-MF,
+	cd PE-CD,
+	telecom PE-TELECOM,
+	usim PE-USIM,
+	opt-usim PE-OPT-USIM,
+	isim PE-ISIM,
+	opt-isim PE-OPT-ISIM,
+	phonebook PE-PHONEBOOK,
+	gsm-access PE-GSM-ACCESS,
+	csim PE-CSIM,
+	opt-csim PE-OPT-CSIM,
+	eap PE-EAP,
+	df-5gs PE-DF-5GS,
+	df-saip PE-DF-SAIP,
+...
+}
+
+PE-Dummy ::= SEQUENCE {
+}
+
+ProfileHeader ::= SEQUENCE {
+major-version UInt8, -- set to 2 for this version of the specification
+minor-version UInt8, -- set to 3 for this version of the specification
+profileType UTF8String (SIZE (1..100)) OPTIONAL, -- Profile type
+iccid OCTET STRING (SIZE (10)), -- ICCID of the Profile 
+pol OCTET STRING OPTIONAL,
+eUICC-Mandatory-services ServicesList,
+eUICC-Mandatory-GFSTEList SEQUENCE OF OBJECT IDENTIFIER,
+connectivityParameters OCTET STRING OPTIONAL,
+eUICC-Mandatory-AIDs SEQUENCE OF SEQUENCE {
+	aid ApplicationIdentifier,
+	version OCTET STRING (SIZE(2))
+} OPTIONAL
+}
+
+ServicesList ::= SEQUENCE {
+/* Contactless */
+contactless NULL OPTIONAL,
+
+/* NAAs */
+usim NULL OPTIONAL,
+isim NULL OPTIONAL,
+csim NULL OPTIONAL,
+
+/* NAA algorithms */
+milenage NULL OPTIONAL,
+tuak128 NULL OPTIONAL,
+cave NULL OPTIONAL,
+
+/* USIM/ISIM services */
+gba-usim NULL OPTIONAL,
+gba-isim NULL OPTIONAL,
+mbms NULL OPTIONAL,
+
+/* EAP service */
+eap NULL OPTIONAL,
+
+/* Application Runtime environment */
+	javacard NULL OPTIONAL,
+	multos NULL OPTIONAL,
+
+/* NAAs */
+multiple-usim NULL OPTIONAL,
+multiple-isim NULL OPTIONAL,
+multiple-csim NULL OPTIONAL,
+
+/* Additional algorithms */
+tuak256 NULL OPTIONAL,
+usim-test-algorithm NULL OPTIONAL,
+
+/* File type */
+ber-tlv NULL OPTIONAL,
+
+/* Linked files */
+dfLink NULL OPTIONAL,
+
+/* Support of CAT_TP */
+cat-tp NULL OPTIONAL,
+
+/* Support of 5G */
+get-identity NULL OPTIONAL,
+profile-a-x25519 NULL OPTIONAL,
+profile-b-p256 NULL OPTIONAL
+
+}
+
+ProprietaryInfo ::= SEQUENCE {
+	specialFileInformation [PRIVATE 0] OCTET STRING (SIZE (1)) DEFAULT '00'H,
+
+	/* fillPattern, repeatPattern
+	only one of the parameters may be present. Coding and rules defined within ETSI TS 102 222 [102 222] apply
+	*/
+
+	fillPattern [PRIVATE 1] OCTET STRING (SIZE(1..200)) OPTIONAL,
+	repeatPattern [PRIVATE 2] OCTET STRING (SIZE(1..200)) OPTIONAL
+}
+
+Fcp ::= SEQUENCE {
+		/* The fileDescriptor shall be encoded as defined in
+		 ETSI TS 102 222 [102 222] */
+	   fileDescriptor [2] OCTET STRING (SIZE(2..4)) OPTIONAL,
+
+		/* fileID	
+			For ADFs, the fileID is a temporary value (named temporary file ID in this document) used only during the profile creation. It has to be unique within a profile and is used for referencing files within this ADF using the file path.
+		*/
+	   fileID [3] OCTET STRING (SIZE(2)) OPTIONAL,
+
+		/* dfName	
+			Only applies for ADFs
+		*/
+	   dfName [4] ApplicationIdentifier OPTIONAL,
+
+		/* lcsi	
+			Coding according to ETSI TS 102 222 [102 222]
+		*/
+	   lcsi [10] OCTET STRING (SIZE (1)) DEFAULT '05'H,
+
+		/* securityAttributesReferenced
+		Either containing EF ARR ID[2] + record number[1] or
+		record number[1] only and EF ARR ID implicitly known from the
+		context: File ID 2F06 is automatically applied for ADFs,
+		the MF and all files directly located under the MF
+		'6F06' for any other files
+		*/
+		securityAttributesReferenced [11] OCTET STRING (SIZE (1..3)) OPTIONAL,
+
+		/* efFileSize
+			Mandatory for EF file types
+			Not allowed for DF files and EF link files
+			Shall be encoded on the minimum number of octets possible
+			 (i.e. no leading bytes set to '00' are allowed)*/
+		efFileSize [0] OCTET STRING OPTIONAL,
+
+		/* pinStatusTemplateDO
+			Not allowed for EF files
+			Mandatory for DF/ADF files
+		*/
+	   pinStatusTemplateDO [PRIVATE 6] OCTET STRING OPTIONAL,
+
+		/* shortEFID
+			Not allowed for DF files
+			Optional for EF file types / equivalent to ETSI TS 102 222
+			shortEFID not provided: in case of a template file, SFI
+			is set according to Annex A. For files created
+			by using GenericFileManagement, SFI is calculated from FID
+			shortEFID provided with no value: no SFI is supported
+			for this EF
+			shortEFID available with a length of 1 byte:
+			The Short File Identifier is coded from bits b8 to b4.
+			Bits b3,b2,b1 = 000.
+		*/
+	   shortEFID [8] OCTET STRING (SIZE (0..1)) OPTIONAL,
+
+		/* proprietaryEFInfo
+			Optional for EF file types
+			Not allowed for DF files
+		*/
+	   proprietaryEFInfo [5] ProprietaryInfo OPTIONAL,
+
+		/* linkPath
+			Specifies the path to the file to which shall be linked,
+			also valid for DFs. Files within ADFs are addressed
+			by the temporary file ID of the respective ADF. For the coding
+			see filePath.
+		*/
+		linkPath [PRIVATE 7] OCTET STRING OPTIONAL
+}
+
+File ::= SEQUENCE OF CHOICE {
+	doNotCreate	NULL,	/* Indicates that this file shall not be created by the eUICC even if present in a PE referencing a "Created by Default" template.
+This flag has no effect for the creation of files in the MF and shall not be used for all the files listed in a "Not Created by Default" template*/
+	fileDescriptor Fcp,
+fillFileOffset UInt16,
+fillFileContent OCTET STRING
+}
+
+PE-MF ::= SEQUENCE {
+mf-header PEHeader,
+templateID OBJECT IDENTIFIER,
+mf File,
+ef-pl File OPTIONAL,
+ef-iccid File,
+ef-dir File,
+ef-arr File,
+ef-umpc File OPTIONAL
+}
+
+PE-CD ::= SEQUENCE {
+cd-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-cd File, 
+ef-launchpad File OPTIONAL,
+ef-icon File OPTIONAL
+}
+
+PE-TELECOM ::= SEQUENCE {
+telecom-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-telecom File,
+ef-arr File OPTIONAL,
+ef-rma File OPTIONAL,
+ef-sume File OPTIONAL,
+ef-ice-dn File OPTIONAL,
+ef-ice-ff File OPTIONAL,
+ef-psismsc File OPTIONAL,
+df-graphics File OPTIONAL,
+  ef-img File OPTIONAL,
+  ef-iidf File OPTIONAL,
+  ef-ice-graphics File OPTIONAL,
+  ef-launch-scws File OPTIONAL,
+  ef-icon File OPTIONAL,
+df-phonebook File OPTIONAL,
+  ef-pbr File OPTIONAL,
+  ef-ext1 File OPTIONAL,
+  ef-aas File OPTIONAL,
+  ef-gas File OPTIONAL,
+  ef-psc File OPTIONAL,
+  ef-cc File OPTIONAL,
+  ef-puid File OPTIONAL,
+  ef-iap File OPTIONAL,
+  ef-adn File OPTIONAL,
+  ef-pbc File OPTIONAL,
+  ef-anr File OPTIONAL,
+  ef-puri File OPTIONAL,
+  ef-email File OPTIONAL,
+  ef-sne File OPTIONAL,
+  ef-uid File OPTIONAL,
+  ef-grp File OPTIONAL,
+  ef-ccp1 File OPTIONAL,
+df-multimedia File OPTIONAL,
+  ef-mml File OPTIONAL,
+  ef-mmdf File OPTIONAL,
+df-mmss File OPTIONAL,
+  ef-mlpl File OPTIONAL,
+  ef-mspl File OPTIONAL,
+  ef-mmssmode File OPTIONAL
+}
+
+PE-USIM ::= SEQUENCE {
+usim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+adf-usim File,
+ef-imsi File,
+ef-arr File,
+ef-keys File OPTIONAL,
+ef-keysPS File OPTIONAL,
+ef-hpplmn File OPTIONAL,
+ef-ust File, /* The content of UST file shall be modified by the eUICC during profile installation according to the functionality supported by the eUICC platform  i.e. in the case where a service is not supported (and not indicated as required) the related bit(s) will be set to zero */
+ef-fdn File OPTIONAL,
+ef-sms File OPTIONAL,
+ef-smsp File OPTIONAL,
+ef-smss File OPTIONAL,
+ef-spn File,
+ef-est File,
+ef-start-hfn File OPTIONAL,
+ef-threshold File OPTIONAL,
+ef-psloci File OPTIONAL,
+ef-acc File,
+ef-fplmn File OPTIONAL,
+ef-loci File OPTIONAL,
+ef-ad File OPTIONAL,
+ef-ecc File,
+ef-netpar File OPTIONAL,
+ef-epsloci File OPTIONAL,
+ef-epsnsc File OPTIONAL
+}
+
+PE-OPT-USIM ::= SEQUENCE {
+optusim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+ef-li File OPTIONAL,
+ef-acmax File OPTIONAL,
+ef-acm File OPTIONAL,
+ef-gid1 File OPTIONAL,
+ef-gid2 File OPTIONAL,
+ef-msisdn File OPTIONAL,
+ef-puct File OPTIONAL,
+ef-cbmi File OPTIONAL,
+ef-cbmid File OPTIONAL,
+ef-sdn File OPTIONAL,
+ef-ext2 File OPTIONAL,
+ef-ext3 File OPTIONAL,
+ef-cbmir File OPTIONAL,
+ef-plmnwact File OPTIONAL,
+ef-oplmnwact File OPTIONAL,
+ef-hplmnwact File OPTIONAL,
+ef-dck File OPTIONAL,
+ef-cnl File OPTIONAL,
+ef-smsr File OPTIONAL,
+ef-bdn File OPTIONAL,
+ef-ext5 File OPTIONAL,
+ef-ccp2 File OPTIONAL,
+ef-ext4 File OPTIONAL,
+ef-acl File OPTIONAL,
+ef-cmi File OPTIONAL,
+ef-ici File OPTIONAL,
+ef-oci File OPTIONAL,
+ef-ict File OPTIONAL,
+ef-oct File OPTIONAL,
+ef-vgcs File OPTIONAL,
+ef-vgcss File OPTIONAL,
+ef-vbs File OPTIONAL,
+ef-vbss File OPTIONAL,
+ef-emlpp File OPTIONAL,
+ef-aaem File OPTIONAL,
+ef-hiddenkey File OPTIONAL,
+ef-pnn File OPTIONAL,
+ef-opl File OPTIONAL,
+ef-mbdn File OPTIONAL,
+ef-ext6 File OPTIONAL,
+ef-mbi File OPTIONAL,
+ef-mwis File OPTIONAL,
+ef-cfis File OPTIONAL,
+ef-ext7 File OPTIONAL,
+ef-spdi File OPTIONAL,
+ef-mmsn File OPTIONAL,
+ef-ext8 File OPTIONAL,
+ef-mmsicp File OPTIONAL,
+ef-mmsup File OPTIONAL,
+ef-mmsucp File OPTIONAL,
+ef-nia File OPTIONAL,
+ef-vgcsca File OPTIONAL,
+ef-vbsca File OPTIONAL,
+ef-gbabp File OPTIONAL,
+ef-msk File OPTIONAL,
+ef-muk File OPTIONAL,
+ef-ehplmn File OPTIONAL,
+ef-gbanl File OPTIONAL,
+ef-ehplmnpi File OPTIONAL,
+ef-lrplmnsi File OPTIONAL,
+ef-nafkca File OPTIONAL,
+ef-spni File OPTIONAL,
+ef-pnni File OPTIONAL,
+ef-ncp-ip File OPTIONAL,
+ef-ufc File OPTIONAL,
+ef-nasconfig File OPTIONAL,
+ef-uicciari File OPTIONAL,
+ef-pws File OPTIONAL,
+ef-fdnuri File OPTIONAL,
+ef-bdnuri File OPTIONAL,
+ef-sdnuri File OPTIONAL,
+ef-iwl File OPTIONAL,
+ef-ips File OPTIONAL,
+ef-ipd File OPTIONAL
+}
+
+PE-PHONEBOOK ::= SEQUENCE {
+phonebook-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-phonebook File,
+ef-pbr File OPTIONAL,
+ef-ext1 File OPTIONAL,
+ef-aas File OPTIONAL,
+ef-gas File OPTIONAL,
+ef-psc File OPTIONAL,
+ef-cc File OPTIONAL,
+ef-puid File OPTIONAL,
+ef-iap File OPTIONAL,
+ef-adn File OPTIONAL,
+ef-pbc File OPTIONAL,
+ef-anr File OPTIONAL,
+ef-puri File OPTIONAL,
+ef-email File OPTIONAL,
+ef-sne File OPTIONAL,
+ef-uid File OPTIONAL,
+ef-grp File OPTIONAL,
+ef-ccp1 File OPTIONAL
+}
+
+PE-GSM-ACCESS ::= SEQUENCE {
+gsm-access-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-gsm-access File,
+ef-kc File OPTIONAL,
+ef-kcgprs File OPTIONAL,
+ef-cpbcch File OPTIONAL,
+ef-invscan File OPTIONAL
+}
+
+PE-DF-5GS ::= SEQUENCE {
+df-5gs-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-df-5gs File,
+ef-5gs3gpploci File OPTIONAL,
+ef-5gsn3gpploci File OPTIONAL,
+ef-5gs3gppnsc File OPTIONAL,
+ef-5gsn3gppnsc File OPTIONAL,
+ef-5gauthkeys File OPTIONAL,
+ef-uac-aic File OPTIONAL,
+ef-suci-calc-info File OPTIONAL,
+ef-opl5g File OPTIONAL,
+ef-nsi File OPTIONAL,
+ef-routing-indicator File OPTIONAL
+}
+
+PE-DF-SAIP ::= SEQUENCE {
+df-saip-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-df-saip File,
+ef-suci-calc-info-usim File OPTIONAL
+}
+
+PE-ISIM ::= SEQUENCE {
+isim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+adf-isim File,
+ef-impi File,
+ef-impu File,
+ef-domain File,
+ef-ist File, /* The content of IST file shall be modified by the eUICC during profile installation according to the functionality supported by the eUICC platform i.e. in the case where a service is not supported (and not indicated as required) the related bit(s) will be set to zero */
+ef-ad File OPTIONAL,
+ef-arr File
+}
+
+PE-OPT-ISIM ::= SEQUENCE {
+optisim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+ef-pcscf File OPTIONAL,
+ef-sms File OPTIONAL,
+ef-smsp File OPTIONAL,
+ef-smss File OPTIONAL,
+ef-smsr File OPTIONAL,
+ef-gbabp File OPTIONAL,
+ef-gbanl File OPTIONAL,
+ef-nafkca File OPTIONAL,
+ef-uicciari File OPTIONAL
+}
+
+PE-CSIM ::= SEQUENCE {
+csim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+adf-csim File,
+ef-arr File,
+ef-call-count File,
+ef-imsi-m File,
+ef-imsi-t File,
+ef-tmsi File,
+ef-ah File,
+ef-aop File,
+ef-aloc File,
+ef-cdmahome File,
+ef-znregi File,
+ef-snregi File,
+ef-distregi File,
+ef-accolc File,
+ef-term File,
+ef-acp File,
+ef-prl File,
+ef-ruimid File,
+ef-csim-st File,
+ef-spc File,
+ef-otapaspc File,
+ef-namlock File,
+ef-ota File,
+ef-sp File,
+ef-esn-meid-me File,
+ef-li File,
+ef-usgind File,
+ef-ad File,
+ef-max-prl File,
+ef-spcs File,
+ef-mecrp File,
+ef-home-tag File,
+ef-group-tag File,
+ef-specific-tag File,
+ef-call-prompt File
+}
+
+PE-OPT-CSIM ::= SEQUENCE {
+optcsim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+ef-ssci File OPTIONAL,
+ef-fdn File OPTIONAL,
+ef-sms File OPTIONAL,
+ef-smsp File OPTIONAL,
+ef-smss File OPTIONAL,
+ef-ssfc File OPTIONAL,
+ef-spn File OPTIONAL,
+ef-mdn File OPTIONAL,
+ef-ecc File OPTIONAL,
+ef-me3gpdopc File OPTIONAL,
+ef-3gpdopm File OPTIONAL,
+ef-sipcap File OPTIONAL,
+ef-mipcap File OPTIONAL,
+ef-sipupp File OPTIONAL,
+ef-mipupp File OPTIONAL,
+ef-sipsp File OPTIONAL,
+ef-mipsp File OPTIONAL,
+ef-sippapss File OPTIONAL,
+ef-puzl File OPTIONAL,
+ef-maxpuzl File OPTIONAL,
+ef-hrpdcap File OPTIONAL,
+ef-hrpdupp File OPTIONAL,
+ef-csspr File OPTIONAL,
+ef-atc File OPTIONAL,
+ef-eprl File OPTIONAL,
+ef-bcsmscfg File OPTIONAL,
+ef-bcsmspref File OPTIONAL,
+ef-bcsmstable File OPTIONAL,
+ef-bcsmsp File OPTIONAL,
+ef-bakpara File OPTIONAL,
+ef-upbakpara File OPTIONAL,
+ef-mmsn File OPTIONAL,
+ef-ext8 File OPTIONAL,
+ef-mmsicp File OPTIONAL,
+ef-mmsup File OPTIONAL,
+ef-mmsucp File OPTIONAL,
+ef-auth-capability File OPTIONAL,
+ef-3gcik File OPTIONAL,
+ef-dck File OPTIONAL,
+ef-gid1 File OPTIONAL,
+ef-gid2 File OPTIONAL,
+ef-cdmacnl File OPTIONAL,
+ef-sf-euimid File OPTIONAL,
+ef-est File OPTIONAL,
+ef-hidden-key File OPTIONAL,
+ef-lcsver File OPTIONAL,
+ef-lcscp File OPTIONAL,
+ef-sdn File OPTIONAL,
+ef-ext2 File OPTIONAL,
+ef-ext3 File OPTIONAL,
+ef-ici File OPTIONAL,
+ef-oci File OPTIONAL,
+ef-ext5 File OPTIONAL,
+ef-ccp2 File OPTIONAL,
+ef-applabels File OPTIONAL,
+ef-model File OPTIONAL,
+ef-rc File OPTIONAL,
+ef-smscap File OPTIONAL,
+ef-mipflags File OPTIONAL,
+ef-3gpduppext File OPTIONAL,
+ef-ipv6cap File OPTIONAL,
+ef-tcpconfig File OPTIONAL,
+ef-dgc File OPTIONAL,
+ef-wapbrowsercp File OPTIONAL,
+ef-wapbrowserbm File OPTIONAL,
+ef-mmsconfig File OPTIONAL,
+ef-jdl File OPTIONAL
+}
+
+PE-EAP ::= SEQUENCE {
+eap-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-eap File,
+ef-eapkeys File OPTIONAL,
+ef-eapstatus File,
+ef-puid File OPTIONAL,
+ef-ps File OPTIONAL,
+ef-curid File OPTIONAL,
+ef-reid File OPTIONAL,
+ef-realm File OPTIONAL
+}
+
+/* Create GenericFileManagement
+*/
+PE-GenericFileManagement ::= SEQUENCE {
+		gfm-header PEHeader,
+	fileManagementCMD SEQUENCE (SIZE (1..MAX)) OF FileManagement
+}
+
+FileManagement ::= SEQUENCE (SIZE (1..MAX)) OF CHOICE {
+filePath [0] OCTET STRING (SIZE (0..8)), -- Use Temporary File ID for ADF
+createFCP [APPLICATION 2] Fcp,
+fillFileOffset UInt16,
+fillFileContent [1] OCTET STRING
+}
+
+MappingParameter ::= SEQUENCE {
+mappingOptions	OCTET STRING (SIZE(1)),
+	mappingSource	ApplicationIdentifier
+}
+
+AlgoParameter ::= SEQUENCE {
+algorithmID INTEGER {
+   milenage(1),
+   tuak(2),
+   usim-test-algorithm(3)
+},
+algorithmOptions	OCTET STRING (SIZE(1)),
+key OCTET STRING,
+opc OCTET STRING, /* OPc for Milenage; TOPc for TUAK; ignored in case of usim-test-algorithm */
+
+/* rotationConstants only apply for Milenage; ignored in case of TUAK and usim-test-algorithm */
+	rotationConstants	OCTET STRING (SIZE (5)) DEFAULT '4000204060'H,
+
+/* xoringConstants only apply for Milenage; ignored in case of TUAK and usim-test-algorithm */
+xoringConstants	OCTET STRING (SIZE (80)) DEFAULT '0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000020000000000000000000000000000000400000000000000000000000000000008'H,
+authCounterMax	OCTET STRING (SIZE(3)) OPTIONAL, /* ignored in case of usim-test-algorithm */
+
+/* Number of iterations of Keccak-f[1600] (noted:  ) permutation as recommended by 3GPP TS 35.231 [TUAK] in section 7.2.
+This parameter only applies for TUAK; ignored otherwise.*/
+numberOfKeccak	UInt8 DEFAULT 1
+}
+
+PE-AKAParameter ::= SEQUENCE {
+	aka-header PEHeader,
+algoConfiguration CHOICE {
+		mappingParameter	MappingParameter,
+		algoParameter	AlgoParameter
+},
+
+sqnOptions		OCTET STRING (SIZE(1)) DEFAULT '02'H, /* ignored in case of usim-test-algorithm */
+-- maximum value for sqnDelta and sqnAgeLimit is '07FFFFFFFFFF'H
+sqnDelta		OCTET STRING (SIZE(6)) DEFAULT '000010000000'H, /* ignored in case of usim-test-algorithm */
+sqnAgeLimit 	OCTET STRING (SIZE(6)) DEFAULT '000010000000'H, /* ignored in case of usim-test-algorithm */
+
+-- Sequence numbers do not include the index (IND)
+-- maximum for any values within sqnInit is '07FFFFFFFFFF'H
+sqnInit SEQUENCE (SIZE (32)) OF OCTET STRING (SIZE (6)) DEFAULT {
+/* Index 0 */'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H,
+/* Index 31 */'000000000000'H } /* ignored in case of usim-test-algorithm */
+}
+
+PE-CDMAParameter ::= SEQUENCE {
+	cdma-header PEHeader,
+
+/* A-Key for CAVE Authentication */ 
+authenticationKey OCTET STRING (SIZE(8)),
+
+/* 
+Optional value for ssd
+Bytes 1..8: value if shared secret data A
+Bytes 9..16: value if shared secret data B
+*/ 
+ssd OCTET STRING (SIZE (16)) OPTIONAL,
+
+/* 
+   Shared Secrets for HRPD access authentication 
+   Includes the shared secret data. This field is coded as defined in section 4.5.7.10 HRPD Access Authentication CHAP SS Parameters of [S0016].
+*/ 
+hrpdAccessAuthenticationData OCTET STRING (SIZE (2..32)) OPTIONAL,
+
+/* 
+   Parameters for simple IP authentication are coded as defined in section 4.5.7.7 SimpleIP CHAP SS Parameters of [S0016].
+*/ 
+simpleIPAuthenticationData OCTET STRING (SIZE (3..483)) OPTIONAL,
+
+/* 
+   Parameters for mobile IP authentication are coded as defined in section 4.5.7.8 MobileIP SS Parameters of [S0016].
+*/ 
+mobileIPAuthenticationData OCTET STRING (SIZE (5..957)) OPTIONAL
+}
+
+PINKeyReferenceValue ::= INTEGER {
+pinAppl1(1),		-- PIN global of App 1
+pinAppl2(2), 		-- PIN global of App 2
+pinAppl3(3), 		-- PIN global of App 3
+pinAppl4(4), 		-- PIN global of App 4
+pinAppl5(5), 		-- PIN global of App 5
+pinAppl6(6), 		-- PIN global of App 6
+pinAppl7(7), 		-- PIN global of App 7
+pinAppl8(8), 		-- PIN global of App 8
+adm1(10),			-- Administrative Key 1
+adm2(11), 			-- Administrative Key 2
+adm3(12), 			-- Administrative Key 3
+adm4(13), 			-- Administrative Key 4
+adm5(14), 			-- Administrative Key 5
+secondPINAppl1(129),	-- PIN local of App 1
+secondPINAppl2(130), 	-- PIN local of App 2
+secondPINAppl3(131), 	-- PIN local of App 3
+secondPINAppl4(132), 	-- PIN local of App 4
+secondPINAppl5(133), 	-- PIN local of App 5
+secondPINAppl6(134), 	-- PIN local of App 6
+secondPINAppl7(135), 	-- PIN local of App 7
+secondPINAppl8(136), 	-- PIN local of App 8
+adm6(138), 			-- Administrative Key 6
+adm7(139), 			-- Administrative Key 7
+adm8(140), 			-- Administrative Key 8
+adm9(141), 			-- Administrative Key 9
+adm10(142) 			-- Administrative Key 10
+}
+
+PINConfiguration ::= SEQUENCE {
+/*
+For every value defined in PINKeyReferenceValue only one entry may be included per PE-PINCodes.
+Within the PE-PINCodes sent in the context of the MF only global PIN key references shall be used. For PINs in any ADF/DF only local PINs shall be defined: secondPINAppl1  secondPINAppl8. It is allowed to define the same PINKeyReferenceValue in multiple directories (e.g. secondPINAppl1 may be defined in the ISIM NAA and within the USIM NAA). Provided they are not linked they shall be handled as two independent PIN values which also may reference different PUK references.
+*/
+	keyReference PINKeyReferenceValue,
+	pinValue OCTET STRING (SIZE (8)),
+/*
+In case no unblockingPINReference is set, no PUK applies for the corresponding PIN.
+In case a PUKKeyReferenceValue is defined the related PUKKeyReferenceValue shall exist within the PE-PUKCodes list.
+Any value defined in PUKKeyReferenceValue may be applied for any PINKeyReferenceValue.
+*/
+	unblockingPINReference PUKKeyReferenceValue OPTIONAL,
+	pinAttributes UInt8 DEFAULT 7,
+	maxNumOfAttemps-retryNumLeft UInt8 DEFAULT 51
+/* maxNumOfAttemps-retryNumLeft is encoded as follows: max Number of Attempts is encoded in the high nibble of this value (Bits b8 to b5) and the Number of retry left is encoded in the low nibble of this value (Bits b4 to b1)*/
+}
+
+PE-PINCodes ::= SEQUENCE {
+	pin-Header PEHeader,
+pinCodes CHOICE {
+	pinconfig SEQUENCE (SIZE (1..26))OF PINConfiguration,
+	filePath OCTET STRING (SIZE (0..8)) /* temporary File ID for ADF, coding according to section 8.3.5 */
+} 
+/* PIN can be either defined in the current context or shared
+ with another DF/ADF
+ Up to 26 PIN could be defined according to TS 102 221 [102 221] 
+*/
+}
+
+PUKKeyReferenceValue ::= INTEGER {
+pukAppl1(1),		-- PUK Reference 1
+pukAppl2(2), 		-- PUK Reference 2
+pukAppl3(3), 		-- PUK Reference 3
+pukAppl4(4), 		-- PUK Reference 4
+pukAppl5(5), 		-- PUK Reference 5
+pukAppl6(6), 		-- PUK Reference 6
+pukAppl7(7), 		-- PUK Reference 7
+pukAppl8(8), 		-- PUK Reference 8
+secondPUKAppl1(129),	-- PUK Reference 9
+secondPUKAppl2(130), 	-- PUK Reference 10
+secondPUKAppl3(131), 	-- PUK Reference 11
+secondPUKAppl4(132), 	-- PUK Reference 12
+secondPUKAppl5(133), 	-- PUK Reference 13
+secondPUKAppl6(134), 	-- PUK Reference 14
+secondPUKAppl7(135), 	-- PUK Reference 15
+secondPUKAppl8(136) 	-- PUK Reference 16
+}
+
+PUKConfiguration ::= SEQUENCE {
+/*
+Any PUKKeyReferenceValue shall only be defined once within PE-PUKCodes.
+*/
+	keyReference PUKKeyReferenceValue,
+	pukValue OCTET STRING (SIZE (8)),
+	maxNumOfAttemps-retryNumLeft UInt8 DEFAULT 170
+/* maxNumOfAttemps-retryNumLeft is encoded as follows: max Number of Attempts is encoded in the high nibble of this value (Bits b8 to b5) and the Number of retry left is encoded in the low nibble of this value (Bits b4 to b1)*/
+}
+
+PE-PUKCodes ::= SEQUENCE {
+	puk-Header PEHeader,
+pukCodes SEQUENCE (SIZE (1..16))OF PUKConfiguration
+}
+
+PE-SecurityDomain ::= SEQUENCE {
+	sd-Header PEHeader,
+instance ApplicationInstance, -- see section 8.7.3
+keyList SEQUENCE (SIZE (1..MAX)) OF KeyObject OPTIONAL, -- see section 8.6.3
+sdPersoData SEQUENCE (SIZE (1..MAX)) OF OCTET STRING OPTIONAL, /* see section 8.6.4 */
+openPersoData SEQUENCE {
+	restrictParameter [PRIVATE 25] OCTET STRING OPTIONAL,
+	contactlessProtocolParameters OCTET STRING OPTIONAL
+} OPTIONAL, /* see section 8.6.6 */
+catTpParameters SEQUENCE
+{	catTpMaxSduSize UInt16,
+	catTpMaxPduSize UInt16
+} OPTIONAL -- see section 8.6.7
+}
+
+KeyObject::= SEQUENCE {
+keyUsageQualifier [21] OCTET STRING (SIZE (1..2)), /* see [GPCS] section 11.1.9 */
+keyAccess [22] OCTET STRING (SIZE (1)) DEFAULT '00'H,
+keyIdentifier [2] OCTET STRING (SIZE (1)),
+keyVersionNumber [3] OCTET STRING (SIZE (1)),
+keyCounterValue [5] OCTET STRING OPTIONAL,
+keyCompontents SEQUENCE (SIZE (1..MAX)) OF SEQUENCE {
+		keyType [0] OCTET STRING,
+		keyData [6] OCTET STRING,
+		macLength[7] UInt8 DEFAULT 8
+	}
+}
+
+PE-Application ::= SEQUENCE {
+	app-Header PEHeader,
+loadBlock ApplicationLoadPackage OPTIONAL,
+instanceList SEQUENCE (SIZE (1..MAX)) OF ApplicationInstance OPTIONAL
+}
+
+ApplicationLoadPackage ::= SEQUENCE {
+loadPackageAID [APPLICATION 15] ApplicationIdentifier,
+securityDomainAID [APPLICATION 15] ApplicationIdentifier OPTIONAL,
+nonVolatileCodeLimitC6 [PRIVATE 6] OCTET STRING OPTIONAL,
+volatileDataLimitC7 [PRIVATE 7] OCTET STRING OPTIONAL,
+nonVolatileDataLimitC8 [PRIVATE 8] OCTET STRING OPTIONAL,
+hashValue [PRIVATE 1] OCTET STRING OPTIONAL,
+loadBlockObject [PRIVATE 4] OCTET STRING
+}
+
+ApplicationInstance ::= SEQUENCE {
+applicationLoadPackageAID [APPLICATION 15] ApplicationIdentifier,
+classAID [APPLICATION 15] ApplicationIdentifier,
+instanceAID [APPLICATION 15] ApplicationIdentifier,
+extraditeSecurityDomainAID [APPLICATION 15] ApplicationIdentifier OPTIONAL,
+applicationPrivileges [2] OCTET STRING,
+lifeCycleState [3] OCTET STRING (SIZE(1)) DEFAULT '07'H,
+/* Coding according to GP Life Cycle State.  */
+
+applicationSpecificParametersC9 [PRIVATE 9] OCTET STRING,
+systemSpecificParameters [PRIVATE 15] ApplicationSystemParameters OPTIONAL,
+applicationParameters [PRIVATE 10] UICCApplicationParameters OPTIONAL,
+processData SEQUENCE (SIZE (1..MAX)) OF OCTET STRING OPTIONAL
+}
+
+ApplicationSystemParameters ::= SEQUENCE{
+volatileMemoryQuotaC7 [PRIVATE 7] OCTET STRING (SIZE (2..4)) OPTIONAL,
+nonVolatileMemoryQuotaC8 [PRIVATE 8] OCTET STRING (SIZE (2..4)) OPTIONAL,
+globalServiceParameters [PRIVATE 11] OCTET STRING OPTIONAL,
+implicitSelectionParameter [PRIVATE 15] OCTET STRING OPTIONAL,
+volatileReservedMemory [PRIVATE 23] OCTET STRING (SIZE (2..4)) OPTIONAL,
+nonVolatileReservedMemory [PRIVATE 24] OCTET STRING (SIZE (2..4)) OPTIONAL,
+ts102226SIMFileAccessToolkitParameter [PRIVATE 10] OCTET STRING OPTIONAL,
+ts102226AdditionalContactlessParameters [0] TS102226AdditionalContactlessParameters OPTIONAL,
+contactlessProtocolParameters [PRIVATE 25] OCTET STRING OPTIONAL, /* Coded according to Contactless Protocol Parameters Structure as defined in GP Amd. C */
+userInteractionContactlessParameters [PRIVATE 26] OCTET STRING OPTIONAL,  /* Coded according to User Interaction Parameters Structure as defined in GP Amd. C */
+cumulativeGrantedVolatileMemory [2] OCTET STRING (SIZE (2..4)) OPTIONAL, /* 
+Coded according to Contactless Specific Parameters as defined in GP Amd. C */
+
+cumulativeGrantedNonVolatileMemory [3] OCTET STRING (SIZE (2..4)) OPTIONAL /* 
+Coded according to Contactless Specific Parameters as defined in GP Amd. C */
+}
+
+UICCApplicationParameters ::= SEQUENCE {
+uiccToolkitApplicationSpecificParametersField [0] OCTET STRING OPTIONAL,
+uiccAccessApplicationSpecificParametersField [1] OCTET STRING OPTIONAL,
+uiccAdministrativeAccessApplicationSpecificParametersField [2] OCTET STRING OPTIONAL
+}
+
+TS102226AdditionalContactlessParameters ::= SEQUENCE{
+protocolParameterData OCTET STRING /* Parameters for contactless applications encoded according to TS 102 226 */
+}
+
+PE-RFM ::= SEQUENCE {
+rfm-header [0] PEHeader,
+
+	/* instanceAID 
+	AID of the RFM instance
+	*/
+	instanceAID [APPLICATION 15] ApplicationIdentifier,
+
+	/* securityDomainAID to which the RFM instance is associated
+	*/
+	securityDomainAID [APPLICATION 15] ApplicationIdentifier OPTIONAL,
+
+	tarList [0] SEQUENCE (SIZE (1..MAX)) OF OCTET STRING (SIZE(3)) OPTIONAL,
+
+	minimumSecurityLevel [1] OCTET STRING (SIZE (1)),
+
+uiccAccessDomain OCTET STRING,
+      uiccAdminAccessDomain OCTET STRING,
+
+	/*
+       If the following parameter is available the respective ADF shall be the directory selected by default within an RFM script. In case it is not available the MF shall be the default selection.
+        */
+      adfRFMAccess ADFRFMAccess OPTIONAL
+}
+
+ADFRFMAccess ::= SEQUENCE {
+    	adfAID ApplicationIdentifier,
+      adfAccessDomain OCTET STRING,
+      adfAdminAccessDomain OCTET STRING
+}
+
+PE-NonStandard ::= SEQUENCE {
+nonStandard-header PEHeader,
+issuerID OBJECT IDENTIFIER,
+content OCTET STRING
+}
+
+PE-End ::= SEQUENCE {
+end-header PEHeader
+}
+
+PEStatus ::= SEQUENCE {
+status INTEGER {
+ok(0), pe-not-supported(1), memory-failure(2),bad-values(3),
+not-enough-memory(4),invalid-request-format(5), invalid-parameter(6),
+runtime-not-supported (7), lib-not-supported (8),
+template-not-supported (9), feature-not-supported (10),
+pin-code-missing (11),
+unsupported-profile-version(31)
+/* ISO 7816 standard status values apply in the range of [24576...28671]
+and [36864...40959] for reporting status values '6xxx'H and '9xxx'H
+proprietary values apply in the range [40960...65535]
+*/
+},
+identification UInt15 OPTIONAL,
+-- Identification number of the PE triggering the error
+additional-information UInt8 OPTIONAL,
+-- Additional information related to the status code
+offset UInt31 OPTIONAL
+-- Position of the part of the PE generating this status code
+}
+
+EUICCResponse ::= SEQUENCE {
+	peStatus SEQUENCE OF PEStatus,
+profileInstallationAborted NULL OPTIONAL,
+statusMessage UTF8String (SIZE (2..64)) OPTIONAL
+}
+END

--- a/rasn-compiler-tests/tests/modules/tca_PEDefinitions_v3.4.1.asn1
+++ b/rasn-compiler-tests/tests/modules/tca_PEDefinitions_v3.4.1.asn1
@@ -1,0 +1,1197 @@
+PEDefinitions {joint-iso-itu-t(2) international-organizations(23) tca(143) euicc-profile(1) spec-version(1) version-three(3)}
+DEFINITIONS
+AUTOMATIC TAGS
+EXTENSIBILITY IMPLIED ::=
+BEGIN
+EXPORTS UICCCapability; -- Definition to be used in remote provisioning specifications for eligibility check
+IMPORTS Certificate FROM PKIX1Explicit88 {iso(1) identified-organization(3) dod(6) internet(1) security(5) mechanisms(5) pkix(7) id-mod(0) id-pkix1-explicit(18)}; -- As defined in X.509 Public Key Infrastructure Certificate [RFC5280]
+
+-- Basic integer types, for size constraints
+maxUInt8 INTEGER ::= 255
+UInt8 ::= INTEGER (0..maxUInt8)
+maxUInt15 INTEGER ::= 32767
+UInt15 ::= INTEGER (0..maxUInt15)
+maxUInt16 INTEGER ::= 65535
+UInt16 ::= INTEGER (0..maxUInt16)
+maxUInt31 INTEGER ::= 2147483647
+UInt31 ::= INTEGER (0..maxUInt31)
+
+ApplicationIdentifier ::= OCTET STRING (SIZE(5..16))
+
+PEHeader ::= SEQUENCE {
+mandated NULL OPTIONAL,
+-- if set, indicate that the support of this PE is mandatory
+identification UInt15 -- Identification number of this PE
+}
+
+ProfileElement ::= CHOICE {
+	header ProfileHeader,
+
+/* PEs */
+	genericFileManagement PE-GenericFileManagement,
+	pinCodes PE-PINCodes,
+	pukCodes PE-PUKCodes,
+	akaParameter PE-AKAParameter,
+	cdmaParameter PE-CDMAParameter,
+	securityDomain PE-SecurityDomain,
+	rfm PE-RFM,
+	application PE-Application,
+	nonStandard PE-NonStandard,
+	end PE-End,
+	ssimEapTLSParameters PE-SSIM-EAPTLSParameters,
+	rfu2 PE-Dummy, -- this avoids renumbering of tag values
+	rfu3 PE-Dummy, -- in case other non-file-system PEs are
+	rfu4 PE-Dummy, -- added here in future versions
+	rfu5 PE-Dummy,
+
+/* PEs related to file system creation using templates defined in this specification */	
+	mf PE-MF,
+	cd PE-CD,
+	telecom PE-TELECOM,
+	usim PE-USIM,
+	opt-usim PE-OPT-USIM,
+	isim PE-ISIM,
+	opt-isim PE-OPT-ISIM,
+	phonebook PE-PHONEBOOK,
+	gsm-access PE-GSM-ACCESS,
+	csim PE-CSIM,
+	opt-csim PE-OPT-CSIM,
+	eap PE-EAP,
+	df-5gs PE-DF-5GS,
+	df-saip PE-DF-SAIP,
+	df-snpn PE-DF-SNPN,
+	df-5gprose PE-DF-5GPROSE,
+	iot PE-IoT,
+	opt-iot PE-OPT-IoT,
+	ssim PE-SSIM,
+...
+}
+
+PE-Dummy ::= SEQUENCE {
+}
+
+ProfileHeader ::= SEQUENCE {
+major-version UInt8, -- set to 3 for this version of the specification
+minor-version UInt8, -- set to 3 for this version of the specification
+profileType UTF8String (SIZE (1..100)) OPTIONAL, -- Profile type
+iccid OCTET STRING (SIZE (10)), -- ICCID of the Profile 
+pol OCTET STRING OPTIONAL,
+eUICC-Mandatory-services ServicesList,
+eUICC-Mandatory-GFSTEList SEQUENCE OF OBJECT IDENTIFIER,
+connectivityParameters OCTET STRING OPTIONAL,
+eUICC-Mandatory-AIDs SEQUENCE OF SEQUENCE {
+	aid ApplicationIdentifier,
+	version OCTET STRING (SIZE(2))
+} OPTIONAL,
+iotOptions IotOptions OPTIONAL -- details for IoT Minimal Profile, mandatory for IoT Minimal Profiles
+}
+
+IotOptions ::= SEQUENCE {
+pix OCTET STRING (SIZE (7..11)) -- PIX value to be used for IoT Minimal Profiles (Application code and Additional PIX coding)
+}
+
+ServicesList ::= SEQUENCE {
+/* Contactless */
+contactless NULL OPTIONAL,
+
+/* NAAs */
+usim NULL OPTIONAL,
+isim NULL OPTIONAL,
+csim NULL OPTIONAL,
+
+/* NAA algorithms */
+milenage NULL OPTIONAL,
+tuak128 NULL OPTIONAL,
+cave NULL OPTIONAL,
+
+/* USIM/ISIM services */
+gba-usim NULL OPTIONAL,
+gba-isim NULL OPTIONAL,
+mbms NULL OPTIONAL,
+
+/* EAP service */
+eap NULL OPTIONAL,
+
+/* Application Runtime environment */
+	javacard NULL OPTIONAL,
+	multos NULL OPTIONAL,
+
+/* NAAs */
+multiple-usim NULL OPTIONAL,
+multiple-isim NULL OPTIONAL,
+multiple-csim NULL OPTIONAL,
+
+/* Additional algorithms */
+tuak256 NULL OPTIONAL,
+usim-test-algorithm NULL OPTIONAL,
+
+/* File type */
+ber-tlv NULL OPTIONAL,
+
+/* Linked files */
+dfLink NULL OPTIONAL,
+
+/* Support of CAT_TP */
+cat-tp NULL OPTIONAL,
+
+/* Support of 5G */
+get-identity NULL OPTIONAL,
+profile-a-x25519 NULL OPTIONAL,
+profile-b-p256 NULL OPTIONAL,
+suciCalculatorApi NULL OPTIONAL,
+
+/* Support of DNS Resolution */
+dns-resolution NULL OPTIONAL,
+
+/* Support of GP Amd F SCP11 */
+scp11ac NULL OPTIONAL,
+scp11c-authorization-mechanism NULL OPTIONAL,
+
+/* Support of S16 mode as defined in GP Amd D and Amd F */
+s16mode NULL OPTIONAL,
+
+/* Support of enhanced AKA algorithm defined in 3GPP */
+eaka NULL OPTIONAL,
+
+/* Support of 5G additional options */
+suci-nswo NULL OPTIONAL,
+network-id NULL OPTIONAL,
+
+/* Support of GP Amd M remote management over CoAP */
+coap NULL OPTIONAL,
+
+/* Support of GBA_U API */
+gbauApi NULL OPTIONAL,
+
+/* Support of 5G ProSe usage information reporting*/
+uir5GProSe NULL OPTIONAL,
+
+/* Support of SSIM NAA*/
+ssim-Eap-Tls NULL OPTIONAL,
+ssim-Eap-Aka-prime NULL OPTIONAL,
+
+/* Support of USAT Application Pairing*/
+usatAppPairing NULL OPTIONAL
+}
+
+-- Definition of UICCCapability
+UICCCapability ::= BIT STRING {
+	contactlessSupport(0), 	-- Contactless (SWP, HCI and associated APIs)
+	usimSupport(1), 		-- USIM as defined by 3GPP
+	isimSupport(2), 		-- ISIM as defined by 3GPP
+	csimSupport(3), 		-- CSIM as defined by 3GPP2
+
+	akaMilenage(4), 		-- Milenage as AKA algorithm
+	akaCave(5),				-- CAVE as authentication algorithm
+	akaTuak128(6), 			-- TUAK as AKA algorithm with 128 bit key length
+	akaTuak256(7), 			-- TUAK as AKA algorithm with 256 bit key length
+	usimTestAlgorithm(8), 	-- USIM test algorithm
+	rfu2(9), 					-- reserved for further algorithms
+
+	gbaAuthenUsim(10),	-- GBA authentication in the context of USIM
+	gbaAuthenISim(11), 	-- GBA authentication in the context of ISIM
+	mbmsAuthenUsim(12), 	-- MBMS authentication in the context of USIM
+	eapClient(13), 			-- EAP client
+
+	javacard(14),				-- Java Card(TM) support
+	multos(15),				-- Multos support
+
+	multipleUsimSupport(16),	-- Multiple USIM applications are supported within the same Profile
+	multipleIsimSupport(17),	-- Multiple ISIM applications are supported within the same Profile
+	multipleCsimSupport(18),	-- Multiple CSIM applications are supported within the same Profile
+
+	berTlvFileSupport(19),	-- BER TLV files
+	dfLinkSupport(20),	-- Linked Directory Files
+	catTp(21),					-- Support of CAT TP
+	getIdentity(22),		-- Support of the GET IDENTITY command as defined in ETSI TS 102 221
+	profile-a-x25519(23),	-- Support of ECIES Profile A as defined in 3GPP TS 33.501 [87]
+	profile-b-p256(24),	-- Support of ECIES Profile B as defined in 3GPP TS 33.501 [87]
+	suciCalculatorApi(25),	-- Support of the associated API for SUCI derivation as defined in 3GPP 31.130 [31.130]
+	dns-resolution(26),	-- Support of DNS Resolution as defined by GP Amd B
+	scp11ac(27),			-- Support of GP Amd F SCP11 variants a and c
+	scp11c-authorization-mechanism(28),	-- Support of SCP11c authorization mechanism (Tag 'BF20')
+	s16mode(29),			-- Support of S16 mode as defined in GP Amd D and Amd F
+	eaka(30),					-- Support of enhanced AKA algorithm as defined in 3GPP TS [33.102]
+	iotminimal(31),		-- Support of IoT Minimal Profile as described in section 7.5
+	suci-nswo(32),			-- Support of the SUCI NSWO context for SUCI calculation as described in 3GPP [33.501]
+	network-id(33),		-- Support of the Network Identifier for SNPN for SUCI calculation, as described in 3GPP [23.003]
+	coap(34), 				-- Support of remote management over CoAP as defined by GP Amd M
+	gbauApi(35), 			-- Support of GBA_U API as defined in 3GPP 31.130 [31.130] if GBA authentication is supported for USIM or ISIM
+	uir5GProSe (36), 	-- Support of 5G ProSe usage information reporting as defined in 3GPP 31.111 [31.111]
+	ssim-Eap-Tls(37),	-- Support of one or more SSIM NAA as defined by 3GPP 31.105 [SSIM] with EAP-TLS 1.3 authentication as defined by IETF RFC 9190 [RFC9190]
+	ssim-Eap-Aka-prime(38), 	-- Support of one or more SSIM NAA as defined by 3GPP 31.105 [SSIM] with EAPAKA authentication as defined by IETF RFC 9048 [RFC9048]
+	usatAppPairing(39) 	-- Support of USAT Application Pairing procedure as defined in 3GPP TS 33.187 [33.187] and 3GPP TS 31.102 [31.102]
+}
+
+ProprietaryInfo ::= SEQUENCE {
+	specialFileInformation [PRIVATE 0] OCTET STRING (SIZE (1)) DEFAULT '00'H,
+
+	/* fillPattern, repeatPattern
+	only one of the parameters may be present. Coding and rules defined within ETSI TS 102 222 [102 222] apply
+	*/
+
+	fillPattern [PRIVATE 1] OCTET STRING (SIZE(1..200)) OPTIONAL,
+	repeatPattern [PRIVATE 2] OCTET STRING (SIZE(1..200)) OPTIONAL,
+	/* Specific parameters for BER-TLV files */
+	/* Shall be encoded on the minimum number of octets possible
+			(i.e. no leading bytes set to '00' are allowed)*/
+	maximumFileSize [6] OCTET STRING OPTIONAL,
+	fileDetails [4] OCTET STRING (SIZE(1)) DEFAULT '01'H
+}
+
+Fcp ::= SEQUENCE {
+		/* The fileDescriptor shall be encoded as defined in
+		 ETSI TS 102 222 [102 222]
+		*/
+	fileDescriptor [2] OCTET STRING (SIZE(2..4)) OPTIONAL,
+
+		/* fileID	
+		For ADFs, the fileID is a temporary value (named temporary file ID
+		in this document) used only during the profile creation. It has to
+		be unique within a profile and is used for referencing files within
+		this ADF using the file path.
+		*/
+	fileID [3] OCTET STRING (SIZE(2)) OPTIONAL,
+
+		/* dfName	
+		Only applies for ADFs
+		*/
+	dfName [4] ApplicationIdentifier OPTIONAL,
+
+		/* lcsi	
+		Coding according to ETSI TS 102 222 [102 222]
+		*/
+	lcsi [10] OCTET STRING (SIZE (1)) DEFAULT '05'H,
+
+		/* securityAttributesReferenced
+		Either containing EF ARR ID[2] + record number[1] or
+		record number[1] only and EF ARR ID implicitly known from the
+		context: File ID 2F06 is automatically applied for ADFs,
+		the MF and all files directly located under the MF
+		'6F06' for any other files
+		*/
+	securityAttributesReferenced [11] OCTET STRING (SIZE (1..3)) OPTIONAL,
+
+		/* efFileSize
+		Mandatory for EF file types
+		Not allowed for DF files and EF link files
+		Shall be encoded on the minimum number of octets possible
+		(i.e. no leading bytes set to '00' are allowed)
+		*/
+	efFileSize [0] OCTET STRING OPTIONAL,
+
+		/* pinStatusTemplateDO
+		Not allowed for EF files
+		Mandatory for DF/ADF files
+		*/
+	pinStatusTemplateDO [PRIVATE 6] OCTET STRING OPTIONAL,
+
+		/* shortEFID
+		Not allowed for DF files
+		Optional for EF file types / equivalent to ETSI TS 102 222
+		shortEFID not provided: in case of a template file, SFI
+		is set according to Annex A. For files created
+		by using GenericFileManagement, SFI is calculated from FID
+		shortEFID provided with no value: no SFI is supported
+		for this EF
+		shortEFID available with a length of 1 byte:
+		The Short File Identifier is coded from bits b8 to b4.
+		Bits b3,b2,b1 = 000.
+		*/
+	shortEFID [8] OCTET STRING (SIZE (0..1)) OPTIONAL,
+
+		/* proprietaryEFInfo
+		Optional for EF file types
+		Not allowed for DF files
+		*/
+	proprietaryEFInfo [5] ProprietaryInfo OPTIONAL,
+
+		/* linkPath
+		Specifies the path to the file to which shall be linked,
+		also valid for DFs. Files within ADFs are addressed
+		by the temporary file ID of the respective ADF. For the coding
+		see filePath. In case of a template link file, an empty linkPath indicates that the link file shall be turned into an independent file.
+		*/
+	linkPath [PRIVATE 7] OCTET STRING (SIZE (0..8)) OPTIONAL
+}
+
+File ::= SEQUENCE OF CHOICE {
+	doNotCreate	NULL,	/* Indicates that this file shall not be created by the eUICC even if present in a PE referencing a "Created by Default" template.
+This flag has no effect for the creation of files in the MF and shall not be used for all the files listed in a "Not Created by Default" template*/
+	fileDescriptor Fcp,
+	fillFileOffset UInt16,
+	fillFileContent OCTET STRING
+}
+
+PE-MF ::= SEQUENCE {
+mf-header PEHeader,
+templateID OBJECT IDENTIFIER,
+mf File,
+ef-pl File OPTIONAL,
+ef-iccid File,
+ef-dir File,
+ef-arr File,
+ef-umpc File OPTIONAL
+}
+
+PE-CD ::= SEQUENCE {
+cd-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-cd File, 
+ef-launchpad File OPTIONAL,
+ef-icon File OPTIONAL
+}
+
+PE-TELECOM ::= SEQUENCE {
+telecom-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-telecom File,
+ef-arr File OPTIONAL,
+ef-rma File OPTIONAL,
+ef-sume File OPTIONAL,
+ef-ice-dn File OPTIONAL,
+ef-ice-ff File OPTIONAL,
+ef-psismsc File OPTIONAL,
+df-graphics File OPTIONAL,
+  ef-img File OPTIONAL,
+  ef-iidf File OPTIONAL,
+  ef-ice-graphics File OPTIONAL,
+  ef-launch-scws File OPTIONAL,
+  ef-icon File OPTIONAL,
+df-phonebook File OPTIONAL,
+  ef-pbr File OPTIONAL,
+  ef-ext1 File OPTIONAL,
+  ef-aas File OPTIONAL,
+  ef-gas File OPTIONAL,
+  ef-psc File OPTIONAL,
+  ef-cc File OPTIONAL,
+  ef-puid File OPTIONAL,
+  ef-iap File OPTIONAL,
+  ef-adn File OPTIONAL,
+  ef-pbc File OPTIONAL,
+  ef-anr File OPTIONAL,
+  ef-puri File OPTIONAL,
+  ef-email File OPTIONAL,
+  ef-sne File OPTIONAL,
+  ef-uid File OPTIONAL,
+  ef-grp File OPTIONAL,
+  ef-ccp1 File OPTIONAL,
+df-multimedia File OPTIONAL,
+  ef-mml File OPTIONAL,
+  ef-mmdf File OPTIONAL,
+df-mmss File OPTIONAL,
+  ef-mlpl File OPTIONAL,
+  ef-mspl File OPTIONAL,
+  ef-mmssmode File OPTIONAL,
+df-mcs File OPTIONAL,
+  ef-mst File OPTIONAL,
+  ef-mcs-config File OPTIONAL,
+df-v2x File OPTIONAL,
+  ef-vst File OPTIONAL,
+  ef-v2x-config File OPTIONAL,
+  ef-v2xp-pc5 File OPTIONAL,
+  ef-v2xp-Uu File OPTIONAL,
+df-a2x File OPTIONAL,
+  ef-ast File OPTIONAL,
+  ef-a2x-config File OPTIONAL,
+  ef-a2xp-pc5 File OPTIONAL,
+  ef-a2x-ddaap-pc5 File OPTIONAL,
+  ef-a2x-dc2p-pc5 File OPTIONAL,
+  ef-a2xp-Uu File OPTIONAL
+}
+
+PE-USIM ::= SEQUENCE {
+usim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+adf-usim File,
+ef-imsi File,
+ef-arr File,
+ef-keys File OPTIONAL,
+ef-keysPS File OPTIONAL,
+ef-hpplmn File OPTIONAL,
+ef-ust File, /* The content of UST file shall be modified by the eUICC during profile installation according to the functionality supported by the eUICC platform  i.e. in the case where a service is not supported (and not indicated as required) the related bit(s) will be set to zero */
+ef-fdn File OPTIONAL,
+ef-sms File OPTIONAL,
+ef-smsp File OPTIONAL,
+ef-smss File OPTIONAL,
+ef-spn File,
+ef-est File,
+ef-start-hfn File OPTIONAL,
+ef-threshold File OPTIONAL,
+ef-psloci File OPTIONAL,
+ef-acc File,
+ef-fplmn File OPTIONAL,
+ef-loci File OPTIONAL,
+ef-ad File OPTIONAL,
+ef-ecc File,
+ef-netpar File OPTIONAL,
+ef-epsloci File OPTIONAL,
+ef-epsnsc File OPTIONAL
+}
+
+PE-OPT-USIM ::= SEQUENCE {
+optusim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+ef-li File OPTIONAL,
+ef-acmax File OPTIONAL,
+ef-acm File OPTIONAL,
+ef-gid1 File OPTIONAL,
+ef-gid2 File OPTIONAL,
+ef-msisdn File OPTIONAL,
+ef-puct File OPTIONAL,
+ef-cbmi File OPTIONAL,
+ef-cbmid File OPTIONAL,
+ef-sdn File OPTIONAL,
+ef-ext2 File OPTIONAL,
+ef-ext3 File OPTIONAL,
+ef-cbmir File OPTIONAL,
+ef-plmnwact File OPTIONAL,
+ef-oplmnwact File OPTIONAL,
+ef-hplmnwact File OPTIONAL,
+ef-dck File OPTIONAL,
+ef-cnl File OPTIONAL,
+ef-smsr File OPTIONAL,
+ef-bdn File OPTIONAL,
+ef-ext5 File OPTIONAL,
+ef-ccp2 File OPTIONAL,
+ef-ext4 File OPTIONAL,
+ef-acl File OPTIONAL,
+ef-cmi File OPTIONAL,
+ef-ici File OPTIONAL,
+ef-oci File OPTIONAL,
+ef-ict File OPTIONAL,
+ef-oct File OPTIONAL,
+ef-vgcs File OPTIONAL,
+ef-vgcss File OPTIONAL,
+ef-vbs File OPTIONAL,
+ef-vbss File OPTIONAL,
+ef-emlpp File OPTIONAL,
+ef-aaem File OPTIONAL,
+ef-hiddenkey File OPTIONAL,
+ef-pnn File OPTIONAL,
+ef-opl File OPTIONAL,
+ef-mbdn File OPTIONAL,
+ef-ext6 File OPTIONAL,
+ef-mbi File OPTIONAL,
+ef-mwis File OPTIONAL,
+ef-cfis File OPTIONAL,
+ef-ext7 File OPTIONAL,
+ef-spdi File OPTIONAL,
+ef-mmsn File OPTIONAL,
+ef-ext8 File OPTIONAL,
+ef-mmsicp File OPTIONAL,
+ef-mmsup File OPTIONAL,
+ef-mmsucp File OPTIONAL,
+ef-nia File OPTIONAL,
+ef-vgcsca File OPTIONAL,
+ef-vbsca File OPTIONAL,
+ef-gbabp File OPTIONAL,
+ef-msk File OPTIONAL,
+ef-muk File OPTIONAL,
+ef-ehplmn File OPTIONAL,
+ef-gbanl File OPTIONAL,
+ef-ehplmnpi File OPTIONAL,
+ef-lrplmnsi File OPTIONAL,
+ef-nafkca File OPTIONAL,
+ef-spni File OPTIONAL,
+ef-pnni File OPTIONAL,
+ef-ncp-ip File OPTIONAL,
+ef-ufc File OPTIONAL,
+ef-nasconfig File OPTIONAL,
+ef-uicciari File OPTIONAL,
+ef-pws File OPTIONAL,
+ef-fdnuri File OPTIONAL,
+ef-bdnuri File OPTIONAL,
+ef-sdnuri File OPTIONAL,
+ef-ial File OPTIONAL,	-- This file was known as ef-iwl in Version 3.2 and earlier of this specification
+ef-ips File OPTIONAL,
+ef-ipd File OPTIONAL,
+ef-epdgid File OPTIONAL,
+ef-epdgselection File OPTIONAL,
+ef-epdgidem File OPTIONAL,
+ef-epdgselectionem File OPTIONAL,
+ef-frompreferred File OPTIONAL,
+ef-imsconfigdata File OPTIONAL,
+ef-3gpppsdataoff File OPTIONAL,
+ef-3gpppsdataoffservicelist File OPTIONAL,
+ef-xcapconfigdata File OPTIONAL,
+ef-earfcnlist File OPTIONAL,
+ef-mudmidconfigdata File OPTIONAL,
+ef-eaka File OPTIONAL,
+ef-ocst File OPTIONAL,
+ef-ac-gbauapi File OPTIONAL,
+ef-imsdci File OPTIONAL
+}
+
+PE-PHONEBOOK ::= SEQUENCE {
+phonebook-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-phonebook File,
+ef-pbr File OPTIONAL,
+ef-ext1 File OPTIONAL,
+ef-aas File OPTIONAL,
+ef-gas File OPTIONAL,
+ef-psc File OPTIONAL,
+ef-cc File OPTIONAL,
+ef-puid File OPTIONAL,
+ef-iap File OPTIONAL,
+ef-adn File OPTIONAL,
+ef-pbc File OPTIONAL,
+ef-anr File OPTIONAL,
+ef-puri File OPTIONAL,
+ef-email File OPTIONAL,
+ef-sne File OPTIONAL,
+ef-uid File OPTIONAL,
+ef-grp File OPTIONAL,
+ef-ccp1 File OPTIONAL
+}
+
+PE-GSM-ACCESS ::= SEQUENCE {
+gsm-access-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-gsm-access File,
+ef-kc File OPTIONAL,
+ef-kcgprs File OPTIONAL,
+ef-cpbcch File OPTIONAL,
+ef-invscan File OPTIONAL
+}
+
+PE-DF-5GS ::= SEQUENCE {
+df-5gs-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-df-5gs File,
+ef-5gs3gpploci File OPTIONAL,
+ef-5gsn3gpploci File OPTIONAL,
+ef-5gs3gppnsc File OPTIONAL,
+ef-5gsn3gppnsc File OPTIONAL,
+ef-5gauthkeys File OPTIONAL,
+ef-uac-aic File OPTIONAL,
+ef-suci-calc-info File OPTIONAL,
+ef-opl5g File OPTIONAL,
+ef-supinai File OPTIONAL,
+ef-routing-indicator File OPTIONAL,
+ef-ursp File OPTIONAL,
+ef-tn3gppsnn File OPTIONAL,
+ef-cag File OPTIONAL,
+ef-sor-cmci File OPTIONAL,
+ef-dri File OPTIONAL,
+ef-5gsedrx File OPTIONAL,
+ef-5gnswo-conf File OPTIONAL,
+ef-mchpplmn File OPTIONAL,
+ef-kausf-derivation File OPTIONAL
+}
+
+PE-DF-SAIP ::= SEQUENCE {
+df-saip-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-df-saip File,
+ef-suci-calc-info-usim File OPTIONAL
+}
+
+PE-DF-SNPN ::= SEQUENCE {
+df-snpn-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-df-snpn File,
+ef-pws-snpn File OPTIONAL,
+ef-nid File OPTIONAL
+}
+
+PE-DF-5GPROSE ::= SEQUENCE {
+df-5g-prose-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-df-5g-prose File,
+ef-5g-prose-st File OPTIONAL,
+ef-5g-prose-dd File OPTIONAL,
+ef-5g-prose-dc File OPTIONAL,
+ef-5g-prose-u2nru File OPTIONAL,
+ef-5g-prose-ru File OPTIONAL,
+ef-5g-prose-uir File OPTIONAL,
+ef-5g-prose-u2uru File OPTIONAL,
+ef-5g-prose-eu File OPTIONAL
+}
+
+PE-ISIM ::= SEQUENCE {
+isim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+adf-isim File,
+ef-impi File,
+ef-impu File,
+ef-domain File,
+ef-ist File, /* The content of IST file shall be modified by the eUICC during profile installation according to the functionality supported by the eUICC platform i.e. in the case where a service is not supported (and not indicated as required) the related bit(s) will be set to zero */
+ef-ad File OPTIONAL,
+ef-arr File
+}
+
+PE-OPT-ISIM ::= SEQUENCE {
+optisim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+ef-pcscf File OPTIONAL,
+ef-sms File OPTIONAL,
+ef-smsp File OPTIONAL,
+ef-smss File OPTIONAL,
+ef-smsr File OPTIONAL,
+ef-gbabp File OPTIONAL,
+ef-gbanl File OPTIONAL,
+ef-nafkca File OPTIONAL,
+ef-uicciari File OPTIONAL,
+ef-frompreferred File OPTIONAL,
+ef-imsconfigdata File OPTIONAL,
+ef-xcapconfigdata File OPTIONAL,
+ef-webrtcuri File OPTIONAL,
+ef-mudmidconfigdata File OPTIONAL,
+ef-ac-gbauapi File OPTIONAL,
+ef-imsdci File OPTIONAL
+}
+
+PE-CSIM ::= SEQUENCE {
+csim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+adf-csim File,
+ef-arr File,
+ef-call-count File,
+ef-imsi-m File,
+ef-imsi-t File,
+ef-tmsi File,
+ef-ah File,
+ef-aop File,
+ef-aloc File,
+ef-cdmahome File,
+ef-znregi File,
+ef-snregi File,
+ef-distregi File,
+ef-accolc File,
+ef-term File,
+ef-acp File,
+ef-prl File,
+ef-ruimid File,
+ef-csim-st File,
+ef-spc File,
+ef-otapaspc File,
+ef-namlock File,
+ef-ota File,
+ef-sp File,
+ef-esn-meid-me File,
+ef-li File,
+ef-usgind File,
+ef-ad File,
+ef-max-prl File,
+ef-spcs File,
+ef-mecrp File,
+ef-home-tag File,
+ef-group-tag File,
+ef-specific-tag File,
+ef-call-prompt File
+}
+
+PE-OPT-CSIM ::= SEQUENCE {
+optcsim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+ef-ssci File OPTIONAL,
+ef-fdn File OPTIONAL,
+ef-sms File OPTIONAL,
+ef-smsp File OPTIONAL,
+ef-smss File OPTIONAL,
+ef-ssfc File OPTIONAL,
+ef-spn File OPTIONAL,
+ef-mdn File OPTIONAL,
+ef-ecc File OPTIONAL,
+ef-me3gpdopc File OPTIONAL,
+ef-3gpdopm File OPTIONAL,
+ef-sipcap File OPTIONAL,
+ef-mipcap File OPTIONAL,
+ef-sipupp File OPTIONAL,
+ef-mipupp File OPTIONAL,
+ef-sipsp File OPTIONAL,
+ef-mipsp File OPTIONAL,
+ef-sippapss File OPTIONAL,
+ef-puzl File OPTIONAL,
+ef-maxpuzl File OPTIONAL,
+ef-hrpdcap File OPTIONAL,
+ef-hrpdupp File OPTIONAL,
+ef-csspr File OPTIONAL,
+ef-atc File OPTIONAL,
+ef-eprl File OPTIONAL,
+ef-bcsmscfg File OPTIONAL,
+ef-bcsmspref File OPTIONAL,
+ef-bcsmstable File OPTIONAL,
+ef-bcsmsp File OPTIONAL,
+ef-bakpara File OPTIONAL,
+ef-upbakpara File OPTIONAL,
+ef-mmsn File OPTIONAL,
+ef-ext8 File OPTIONAL,
+ef-mmsicp File OPTIONAL,
+ef-mmsup File OPTIONAL,
+ef-mmsucp File OPTIONAL,
+ef-auth-capability File OPTIONAL,
+ef-3gcik File OPTIONAL,
+ef-dck File OPTIONAL,
+ef-gid1 File OPTIONAL,
+ef-gid2 File OPTIONAL,
+ef-cdmacnl File OPTIONAL,
+ef-sf-euimid File OPTIONAL,
+ef-est File OPTIONAL,
+ef-hidden-key File OPTIONAL,
+ef-lcsver File OPTIONAL,
+ef-lcscp File OPTIONAL,
+ef-sdn File OPTIONAL,
+ef-ext2 File OPTIONAL,
+ef-ext3 File OPTIONAL,
+ef-ici File OPTIONAL,
+ef-oci File OPTIONAL,
+ef-ext5 File OPTIONAL,
+ef-ccp2 File OPTIONAL,
+ef-applabels File OPTIONAL,
+ef-model File OPTIONAL,
+ef-rc File OPTIONAL,
+ef-smscap File OPTIONAL,
+ef-mipflags File OPTIONAL,
+ef-3gpduppext File OPTIONAL,
+ef-ipv6cap File OPTIONAL,
+ef-tcpconfig File OPTIONAL,
+ef-dgc File OPTIONAL,
+ef-wapbrowsercp File OPTIONAL,
+ef-wapbrowserbm File OPTIONAL,
+ef-mmsconfig File OPTIONAL,
+ef-jdl File OPTIONAL
+}
+
+PE-EAP ::= SEQUENCE {
+eap-header PEHeader,
+templateID OBJECT IDENTIFIER,
+df-eap File,
+ef-eapkeys File OPTIONAL,
+ef-eapstatus File,
+ef-puid File OPTIONAL,
+ef-ps File OPTIONAL,
+ef-curid File OPTIONAL,
+ef-reid File OPTIONAL,
+ef-realm File OPTIONAL
+}
+
+PE-IoT ::= SEQUENCE {
+iot-header PEHeader,
+templateID OBJECT IDENTIFIER,
+mf File OPTIONAL,
+ef-pl File OPTIONAL,
+ef-iccid File OPTIONAL,
+ef-dir File OPTIONAL,
+ef-arr File OPTIONAL,
+ef-umpc File OPTIONAL,
+adf-usim File OPTIONAL,
+ef-imsi File,
+ef-arr-usim File OPTIONAL,
+ef-keys File OPTIONAL,
+ef-keysPS File OPTIONAL,
+ef-hpplmn File OPTIONAL,
+ef-ust File OPTIONAL,
+ef-start-hfn File OPTIONAL,
+ef-threshold File OPTIONAL,
+ef-psloci File OPTIONAL,
+ef-acc File,
+ef-fplmn File OPTIONAL,
+ef-loci File OPTIONAL,
+ef-ad File OPTIONAL,
+ef-ecc File OPTIONAL,
+ef-netpar File OPTIONAL
+}
+
+PE-OPT-IoT ::= SEQUENCE {
+optiot-header PEHeader,
+templateID OBJECT IDENTIFIER,
+ef-fdn File OPTIONAL,
+ef-sms File OPTIONAL,
+ef-smsp File OPTIONAL,
+ef-smss File OPTIONAL,
+ef-spn File OPTIONAL,
+ef-est File OPTIONAL,
+ef-oplmnwact File OPTIONAL,
+ef-hplmnwact File OPTIONAL,
+ef-ehplmn File OPTIONAL,
+ef-epsloci File OPTIONAL,
+ef-epsnsc File OPTIONAL,
+df-df-5gs File OPTIONAL,
+ef-5gs3gpploci File OPTIONAL,
+ef-5gsn3gpploci File OPTIONAL,
+ef-5gs3gppnsc File OPTIONAL,
+ef-5gsn3gppnsc File OPTIONAL,
+ef-5gauthkeys File OPTIONAL,
+ef-uac-aic File OPTIONAL,
+ef-suci-calc-info File OPTIONAL,
+ef-opl5g File OPTIONAL,
+ef-supi-nai File OPTIONAL,
+ef-routing-indicator File OPTIONAL,
+ef-ursp File OPTIONAL,
+ef-tn3gppsnn File OPTIONAL,
+df-df-saip File OPTIONAL,
+ef-suci-calc-info-usim File OPTIONAL
+}
+
+PE-SSIM ::= SEQUENCE {
+ssim-header PEHeader,
+templateID OBJECT IDENTIFIER,
+adf-ssim File,
+ef-arr File,
+ef-eapId File,
+ef-nssai File,
+ef-eapStatus File
+}
+
+/* Create GenericFileManagement
+*/
+PE-GenericFileManagement ::= SEQUENCE {
+		gfm-header PEHeader,
+	fileManagementCMD SEQUENCE (SIZE (1..MAX)) OF FileManagement
+}
+
+FileManagement ::= SEQUENCE (SIZE (1..MAX)) OF CHOICE {
+filePath [0] OCTET STRING (SIZE (0..8)), -- Use Temporary File ID for ADF
+createFCP [APPLICATION 2] Fcp,
+fillFileOffset UInt16,
+fillFileContent [1] OCTET STRING
+}
+
+MappingParameter ::= SEQUENCE {
+mappingOptions	OCTET STRING (SIZE(1)),
+	mappingSource	ApplicationIdentifier
+}
+
+AlgoParameter ::= SEQUENCE {
+algorithmID INTEGER {
+   milenage(1),
+   tuak(2),
+   usim-test-algorithm(3)
+},
+algorithmOptions	OCTET STRING (SIZE(1)),
+key OCTET STRING,
+opc OCTET STRING, /* OPc for Milenage; TOPc for TUAK; ignored in case of usim-test-algorithm */
+
+/* rotationConstants only apply for Milenage; ignored in case of TUAK and usim-test-algorithm */
+	rotationConstants	OCTET STRING (SIZE (5)) DEFAULT '4000204060'H,
+
+/* xoringConstants only apply for Milenage; ignored in case of TUAK and usim-test-algorithm */
+xoringConstants	OCTET STRING (SIZE (80)) DEFAULT '0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000020000000000000000000000000000000400000000000000000000000000000008'H,
+authCounterMax	OCTET STRING (SIZE(3)) OPTIONAL, /* ignored in case of usim-test-algorithm */
+
+/* Number of iterations of Keccak-f[1600] (noted:  ) permutation as recommended by 3GPP TS 35.231 [TUAK] in section 7.2.
+This parameter only applies for TUAK; ignored otherwise.*/
+numberOfKeccak	UInt8 DEFAULT 1
+}
+
+PE-AKAParameter ::= SEQUENCE {
+	aka-header PEHeader,
+algoConfiguration CHOICE {
+		mappingParameter	MappingParameter,
+		algoParameter	AlgoParameter
+},
+
+sqnOptions		OCTET STRING (SIZE(1)) DEFAULT '02'H, /* ignored in case of usim-test-algorithm */
+-- maximum value for sqnDelta and sqnAgeLimit is '07FFFFFFFFFF'H
+sqnDelta		OCTET STRING (SIZE(6)) DEFAULT '000010000000'H, /* ignored in case of usim-test-algorithm */
+sqnAgeLimit 	OCTET STRING (SIZE(6)) DEFAULT '000010000000'H, /* ignored in case of usim-test-algorithm */
+
+-- Sequence numbers do not include the index (IND)
+-- maximum for any values within sqnInit is '07FFFFFFFFFF'H
+sqnInit SEQUENCE (SIZE (32)) OF OCTET STRING (SIZE (6)) DEFAULT {
+/* Index 0 */'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H, '000000000000'H,'000000000000'H, '000000000000'H, '000000000000'H,
+/* Index 31 */'000000000000'H }, /* ignored in case of usim-test-algorithm */
+
+-- The following parameters may be used only in the context of SSIM
+ssimParameters SEQUENCE {
+	networkName UTF8String OPTIONAL, -- Used for comparison with AT_KDF_INPUT value provided during authentication as defined in RFC 9048 [RFC9048]
+	keyDerivationFunctions SEQUENCE OF OCTET STRING (SIZE(1)) DEFAULT {'01'H} -- AT_KDF values as defined in RFC 9048 [RFC9048]
+} OPTIONAL
+}
+
+PE-CDMAParameter ::= SEQUENCE {
+	cdma-header PEHeader,
+
+/* A-Key for CAVE Authentication */ 
+authenticationKey OCTET STRING (SIZE(8)),
+
+/* 
+Optional value for ssd
+Bytes 1..8: value if shared secret data A
+Bytes 9..16: value if shared secret data B
+*/ 
+ssd OCTET STRING (SIZE (16)) OPTIONAL,
+
+/* 
+   Shared Secrets for HRPD access authentication 
+   Includes the shared secret data. This field is coded as defined in section 4.5.7.10 HRPD Access Authentication CHAP SS Parameters of [S0016].
+*/ 
+hrpdAccessAuthenticationData OCTET STRING (SIZE (2..32)) OPTIONAL,
+
+/* 
+   Parameters for simple IP authentication are coded as defined in section 4.5.7.7 SimpleIP CHAP SS Parameters of [S0016].
+*/ 
+simpleIPAuthenticationData OCTET STRING (SIZE (3..483)) OPTIONAL,
+
+/* 
+   Parameters for mobile IP authentication are coded as defined in section 4.5.7.8 MobileIP SS Parameters of [S0016].
+*/ 
+mobileIPAuthenticationData OCTET STRING (SIZE (5..957)) OPTIONAL
+}
+
+PE-SSIM-EAPTLSParameters ::= SEQUENCE {
+	ssim-eaptls-header PEHeader,
+	eapSSIMCertificate Certificate,	-- TLS certificate containing the public key of the SSIM application
+	eapSSIMCertificateChain SEQUENCE OF Certificate OPTIONAL, -- TLS certificate chain for the SSIM application not including the SSIM Root CA
+	eapCACertificate Certificate,		-- TLS Server Root CA certificate
+	privateKey OCTET STRING			-- TLS Private key of the SSIM application
+}
+
+PINKeyReferenceValue ::= INTEGER {
+pinAppl1(1),		-- PIN global of App 1
+pinAppl2(2), 		-- PIN global of App 2
+pinAppl3(3), 		-- PIN global of App 3
+pinAppl4(4), 		-- PIN global of App 4
+pinAppl5(5), 		-- PIN global of App 5
+pinAppl6(6), 		-- PIN global of App 6
+pinAppl7(7), 		-- PIN global of App 7
+pinAppl8(8), 		-- PIN global of App 8
+adm1(10),			-- Administrative Key 1
+adm2(11), 			-- Administrative Key 2
+adm3(12), 			-- Administrative Key 3
+adm4(13), 			-- Administrative Key 4
+adm5(14), 			-- Administrative Key 5
+secondPINAppl1(129),	-- PIN local of App 1
+secondPINAppl2(130), 	-- PIN local of App 2
+secondPINAppl3(131), 	-- PIN local of App 3
+secondPINAppl4(132), 	-- PIN local of App 4
+secondPINAppl5(133), 	-- PIN local of App 5
+secondPINAppl6(134), 	-- PIN local of App 6
+secondPINAppl7(135), 	-- PIN local of App 7
+secondPINAppl8(136), 	-- PIN local of App 8
+adm6(138), 			-- Administrative Key 6
+adm7(139), 			-- Administrative Key 7
+adm8(140), 			-- Administrative Key 8
+adm9(141), 			-- Administrative Key 9
+adm10(142) 			-- Administrative Key 10
+}
+
+PINConfiguration ::= SEQUENCE {
+/*
+For every value defined in PINKeyReferenceValue only one entry may be included per PE-PINCodes.
+Within the PE-PINCodes sent in the context of the MF only global PIN key references shall be used. For PINs in any ADF/DF only local PINs shall be defined: secondPINAppl1  secondPINAppl8. It is allowed to define the same PINKeyReferenceValue in multiple directories (e.g. secondPINAppl1 may be defined in the ISIM NAA and within the USIM NAA). Provided they are not linked they shall be handled as two independent PIN values which also may reference different PUK references.
+*/
+	keyReference PINKeyReferenceValue,
+	pinValue OCTET STRING (SIZE (8)),
+/*
+In case no unblockingPINReference is set, no PUK applies for the corresponding PIN.
+In case a PUKKeyReferenceValue is defined the related PUKKeyReferenceValue shall exist within the PE-PUKCodes list.
+Any value defined in PUKKeyReferenceValue may be applied for any PINKeyReferenceValue.
+*/
+	unblockingPINReference PUKKeyReferenceValue OPTIONAL,
+	pinAttributes UInt8 DEFAULT 7,
+	maxNumOfAttemps-retryNumLeft UInt8 DEFAULT 51
+/* maxNumOfAttemps-retryNumLeft is encoded as follows: max Number of Attempts is encoded in the high nibble of this value (Bits b8 to b5) and the Number of retry left is encoded in the low nibble of this value (Bits b4 to b1)*/
+}
+
+PE-PINCodes ::= SEQUENCE {
+	pin-Header PEHeader,
+pinCodes CHOICE {
+	pinconfig SEQUENCE (SIZE (1..26))OF PINConfiguration,
+	filePath OCTET STRING (SIZE (0..8)) /* temporary File ID for ADF, coding according to section 8.3.5 */
+}
+/* PIN can be either defined in the current context or shared
+ with another DF/ADF
+ Up to 26 PIN could be defined according to TS 102 221 [102 221]
+*/
+}
+
+PUKKeyReferenceValue ::= INTEGER {
+pukAppl1(1),		-- PUK Reference 1
+pukAppl2(2), 		-- PUK Reference 2
+pukAppl3(3), 		-- PUK Reference 3
+pukAppl4(4), 		-- PUK Reference 4
+pukAppl5(5), 		-- PUK Reference 5
+pukAppl6(6), 		-- PUK Reference 6
+pukAppl7(7), 		-- PUK Reference 7
+pukAppl8(8), 		-- PUK Reference 8
+secondPUKAppl1(129),	-- PUK Reference 9
+secondPUKAppl2(130), 	-- PUK Reference 10
+secondPUKAppl3(131), 	-- PUK Reference 11
+secondPUKAppl4(132), 	-- PUK Reference 12
+secondPUKAppl5(133), 	-- PUK Reference 13
+secondPUKAppl6(134), 	-- PUK Reference 14
+secondPUKAppl7(135), 	-- PUK Reference 15
+secondPUKAppl8(136) 	-- PUK Reference 16
+}
+
+PUKConfiguration ::= SEQUENCE {
+/*
+Any PUKKeyReferenceValue shall only be defined once within PE-PUKCodes.
+*/
+	keyReference PUKKeyReferenceValue,
+	pukValue OCTET STRING (SIZE (8)),
+	maxNumOfAttemps-retryNumLeft UInt8 DEFAULT 170
+/* maxNumOfAttemps-retryNumLeft is encoded as follows: max Number of Attempts is encoded in the high nibble of this value (Bits b8 to b5) and the Number of retry left is encoded in the low nibble of this value (Bits b4 to b1)*/
+}
+
+PE-PUKCodes ::= SEQUENCE {
+	puk-Header PEHeader,
+pukCodes SEQUENCE (SIZE (1..16))OF PUKConfiguration
+}
+
+PE-SecurityDomain ::= SEQUENCE {
+	sd-Header PEHeader,
+instance ApplicationInstance, -- see section 8.7.3
+keyList SEQUENCE (SIZE (1..MAX)) OF KeyObject OPTIONAL, -- see section 8.6.3
+sdPersoData SEQUENCE (SIZE (1..MAX)) OF OCTET STRING OPTIONAL, /* see section 8.6.4 */
+openPersoData SEQUENCE {
+	restrictParameter [PRIVATE 25] OCTET STRING (SIZE(1)) OPTIONAL,
+	contactlessProtocolParameters OCTET STRING OPTIONAL
+} OPTIONAL, /* see section 8.6.6 */
+catTpParameters SEQUENCE
+{	catTpMaxSduSize UInt16,
+	catTpMaxPduSize UInt16
+} OPTIONAL -- see section 8.6.7
+}
+
+KeyObject::= SEQUENCE {
+keyUsageQualifier [21] OCTET STRING (SIZE (1..2)), /* see [GPCS] section 11.1.9 */
+keyAccess [22] OCTET STRING (SIZE (1)) DEFAULT '00'H,
+keyIdentifier [2] OCTET STRING (SIZE (1)),
+keyVersionNumber [3] OCTET STRING (SIZE (1)),
+keyCounterValue [5] OCTET STRING OPTIONAL,
+keyCompontents SEQUENCE (SIZE (1..MAX)) OF SEQUENCE {
+		keyType [0] OCTET STRING,
+		keyData [6] OCTET STRING,
+		macLength[7] UInt8 DEFAULT 8
+	}
+}
+
+PE-Application ::= SEQUENCE {
+	app-Header PEHeader,
+loadBlock ApplicationLoadPackage OPTIONAL,
+instanceList SEQUENCE (SIZE (1..MAX)) OF ApplicationInstance OPTIONAL
+}
+
+ApplicationLoadPackage ::= SEQUENCE {
+loadPackageAID [APPLICATION 15] ApplicationIdentifier,
+securityDomainAID [APPLICATION 15] ApplicationIdentifier OPTIONAL,
+nonVolatileCodeLimitC6 [PRIVATE 6] OCTET STRING OPTIONAL,
+volatileDataLimitC7 [PRIVATE 7] OCTET STRING OPTIONAL,
+nonVolatileDataLimitC8 [PRIVATE 8] OCTET STRING OPTIONAL,
+hashValue [PRIVATE 1] OCTET STRING OPTIONAL,
+loadBlockObject [PRIVATE 4] OCTET STRING
+}
+
+ApplicationInstance ::= SEQUENCE {
+applicationLoadPackageAID [APPLICATION 15] ApplicationIdentifier,
+classAID [APPLICATION 15] ApplicationIdentifier,
+instanceAID [APPLICATION 15] ApplicationIdentifier,
+extraditeSecurityDomainAID [APPLICATION 15] ApplicationIdentifier OPTIONAL,
+applicationPrivileges [2] OCTET STRING,
+lifeCycleState [3] OCTET STRING (SIZE(1)) DEFAULT '07'H,
+/* Coding according to GP Life Cycle State.  */
+
+applicationSpecificParametersC9 [PRIVATE 9] OCTET STRING,
+systemSpecificParameters [PRIVATE 15] ApplicationSystemParameters OPTIONAL,
+applicationParameters [PRIVATE 10] UICCApplicationParameters OPTIONAL,
+processData SEQUENCE (SIZE (1..MAX)) OF OCTET STRING OPTIONAL,
+controlReferenceTemplate [16] ControlReferenceTemplate OPTIONAL
+}
+
+ApplicationSystemParameters ::= SEQUENCE{
+volatileMemoryQuotaC7 [PRIVATE 7] OCTET STRING (SIZE (2..4)) OPTIONAL,
+nonVolatileMemoryQuotaC8 [PRIVATE 8] OCTET STRING (SIZE (2..4)) OPTIONAL,
+globalServiceParameters [PRIVATE 11] OCTET STRING OPTIONAL,
+implicitSelectionParameter [PRIVATE 15] OCTET STRING OPTIONAL,
+volatileReservedMemory [PRIVATE 23] OCTET STRING (SIZE (2..4)) OPTIONAL,
+nonVolatileReservedMemory [PRIVATE 24] OCTET STRING (SIZE (2..4)) OPTIONAL,
+ts102226SIMFileAccessToolkitParameter [PRIVATE 10] OCTET STRING OPTIONAL,
+ts102226AdditionalContactlessParameters [0] TS102226AdditionalContactlessParameters OPTIONAL,
+contactlessProtocolParameters [PRIVATE 25] OCTET STRING OPTIONAL, /* Coded according to Contactless Protocol Parameters Structure as defined in GP Amd. C */
+userInteractionContactlessParameters [PRIVATE 26] OCTET STRING OPTIONAL,  /* Coded according to User Interaction Parameters Structure as defined in GP Amd. C */
+cumulativeGrantedVolatileMemory [2] OCTET STRING (SIZE (2..4)) OPTIONAL, /* 
+Coded according to Contactless Specific Parameters as defined in GP Amd. C */
+
+cumulativeGrantedNonVolatileMemory [3] OCTET STRING (SIZE (2..4)) OPTIONAL /* 
+Coded according to Contactless Specific Parameters as defined in GP Amd. C */
+}
+
+UICCApplicationParameters ::= SEQUENCE {
+uiccToolkitApplicationSpecificParametersField [0] OCTET STRING OPTIONAL,
+uiccAccessApplicationSpecificParametersField [1] OCTET STRING OPTIONAL,
+uiccAdministrativeAccessApplicationSpecificParametersField [2] OCTET STRING OPTIONAL
+}
+
+TS102226AdditionalContactlessParameters ::= SEQUENCE{
+protocolParameterData OCTET STRING /* Parameters for contactless applications encoded according to TS 102 226 */
+}
+
+ControlReferenceTemplate ::= SEQUENCE{
+applicationProviderIdentifier [APPLICATION 32] OCTET STRING
+}
+
+
+PE-RFM ::= SEQUENCE {
+rfm-header [0] PEHeader,
+
+	/* instanceAID 
+	AID of the RFM instance
+	*/
+	instanceAID [APPLICATION 15] ApplicationIdentifier,
+
+	/* securityDomainAID to which the RFM instance is associated
+	*/
+	securityDomainAID [APPLICATION 15] ApplicationIdentifier OPTIONAL,
+
+	tarList [0] SEQUENCE (SIZE (1..MAX)) OF OCTET STRING (SIZE(3)) OPTIONAL,
+
+	minimumSecurityLevel [1] OCTET STRING (SIZE (1)),
+
+uiccAccessDomain OCTET STRING,
+      uiccAdminAccessDomain OCTET STRING,
+
+	/*
+       If the following parameter is available the respective ADF shall be the directory selected by default within an RFM script. In case it is not available the MF shall be the default selection.
+        */
+      adfRFMAccess ADFRFMAccess OPTIONAL
+}
+
+ADFRFMAccess ::= SEQUENCE {
+    	adfAID ApplicationIdentifier,
+      adfAccessDomain OCTET STRING,
+      adfAdminAccessDomain OCTET STRING
+}
+
+PE-NonStandard ::= SEQUENCE {
+nonStandard-header PEHeader,
+issuerID OBJECT IDENTIFIER,
+content OCTET STRING
+}
+
+PE-End ::= SEQUENCE {
+end-header PEHeader
+}
+
+PEStatus ::= SEQUENCE {
+status INTEGER {
+ok(0), pe-not-supported(1), memory-failure(2),bad-values(3),
+not-enough-memory(4),invalid-request-format(5), invalid-parameter(6),
+runtime-not-supported (7), lib-not-supported (8),
+template-not-supported (9), feature-not-supported (10),
+pin-code-missing (11),
+unsupported-profile-version(31)
+/* ISO 7816 standard status values apply in the range of [24576...28671]
+and [36864...40959] for reporting status values '6xxx'H and '9xxx'H
+proprietary values apply in the range [40960...65535]
+*/
+},
+identification UInt15 OPTIONAL,
+-- Identification number of the PE triggering the error
+additional-information UInt8 OPTIONAL,
+-- Additional information related to the status code
+offset UInt31 OPTIONAL
+-- Position of the part of the PE generating this status code
+}
+
+EUICCResponse ::= SEQUENCE {
+	peStatus SEQUENCE OF PEStatus,
+profileInstallationAborted NULL OPTIONAL,
+statusMessage UTF8String (SIZE (2..64)) OPTIONAL
+}
+
+END

--- a/rasn-compiler-tests/tests/snapshots/edge_cases__integer_type_alias_with_literal_default.snap
+++ b/rasn-compiler-tests/tests/snapshots/edge_cases__integer_type_alias_with_literal_default.snap
@@ -1,0 +1,42 @@
+---
+source: rasn-compiler-tests/tests/edge_cases.rs
+description: "\n        MySeq ::= SEQUENCE { count MyUInt8 DEFAULT 1 }\n        MyUInt8 ::= INTEGER (0..255)\n    "
+---
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod test_module {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct MySeq {
+        #[rasn(default = "my_seq_count_default")]
+        pub count: MyUInt8,
+    }
+    impl MySeq {
+        pub fn new(count: MyUInt8) -> Self {
+            Self { count }
+        }
+    }
+    impl std::default::Default for MySeq {
+        fn default() -> Self {
+            Self {
+                count: my_seq_count_default(),
+            }
+        }
+    }
+    fn my_seq_count_default() -> MyUInt8 {
+        MyUInt8(1)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct MyUInt8(pub u8);
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x411_1999_MTAAbstractService.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x411_1999_MTAAbstractService.asn1.snap
@@ -387,8 +387,9 @@ pub mod mtaabstract_service {
             }
         }
     }
-    fn per_recipient_message_transfer_fields_extensions_default() -> SequenceOf<ExtensionField> {
-        alloc::vec![]
+    fn per_recipient_message_transfer_fields_extensions_default(
+    ) -> PerRecipientMessageTransferFieldsExtensions {
+        PerRecipientMessageTransferFieldsExtensions(alloc::vec![])
     }
     #[doc = " Inner type "]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
@@ -428,8 +429,9 @@ pub mod mtaabstract_service {
             }
         }
     }
-    fn per_recipient_probe_transfer_fields_extensions_default() -> SequenceOf<ExtensionField> {
-        alloc::vec![]
+    fn per_recipient_probe_transfer_fields_extensions_default(
+    ) -> PerRecipientProbeTransferFieldsExtensions {
+        PerRecipientProbeTransferFieldsExtensions(alloc::vec![])
     }
     #[doc = " Inner type "]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
@@ -477,8 +479,9 @@ pub mod mtaabstract_service {
             }
         }
     }
-    fn per_recipient_report_transfer_fields_extensions_default() -> SequenceOf<ExtensionField> {
-        alloc::vec![]
+    fn per_recipient_report_transfer_fields_extensions_default(
+    ) -> PerRecipientReportTransferFieldsExtensions {
+        PerRecipientReportTransferFieldsExtensions(alloc::vec![])
     }
     #[doc = " Inner type "]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
@@ -530,8 +533,8 @@ pub mod mtaabstract_service {
             }
         }
     }
-    fn per_report_transfer_fields_extensions_default() -> SequenceOf<ExtensionField> {
-        alloc::vec![]
+    fn per_report_transfer_fields_extensions_default() -> PerReportTransferFieldsExtensions {
+        PerReportTransferFieldsExtensions(alloc::vec![])
     }
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(delegate)]
@@ -621,8 +624,8 @@ pub mod mtaabstract_service {
             }
         }
     }
-    fn report_transfer_envelope_extensions_default() -> SequenceOf<ExtensionField> {
-        alloc::vec![]
+    fn report_transfer_envelope_extensions_default() -> ReportTransferEnvelopeExtensions {
+        ReportTransferEnvelopeExtensions(alloc::vec![])
     }
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash, Copy)]
     #[rasn(enumerated)]

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x420_1999_IPMSAutoActionTypes.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@itu-t_x_x420_1999_IPMSAutoActionTypes.asn1.snap
@@ -332,8 +332,9 @@ pub mod ipmsauto_action_types {
             }
         }
     }
-    fn per_message_auto_forward_fields_extensions_default() -> SequenceOf<ExtensionField> {
-        alloc::vec![]
+    fn per_message_auto_forward_fields_extensions_default() -> PerMessageAutoForwardFieldsExtensions
+    {
+        PerMessageAutoForwardFieldsExtensions(alloc::vec![])
     }
     #[doc = " Inner type "]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
@@ -369,7 +370,8 @@ pub mod ipmsauto_action_types {
             }
         }
     }
-    fn per_recipient_auto_forward_fields_extensions_default() -> SequenceOf<ExtensionField> {
-        alloc::vec![]
+    fn per_recipient_auto_forward_fields_extensions_default(
+    ) -> PerRecipientAutoForwardFieldsExtensions {
+        PerRecipientAutoForwardFieldsExtensions(alloc::vec![])
     }
 }

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@tca_PEDefinitions_v2.3.1.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@tca_PEDefinitions_v2.3.1.asn1.snap
@@ -1,0 +1,2823 @@
+---
+source: rasn-compiler-tests/tests/parse_test.rs
+input_file: rasn-compiler-tests/tests/modules/tca_PEDefinitions_v2.3.1.asn1
+---
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod pedefinitions {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ADFRFMAccess {
+        #[rasn(identifier = "adfAID")]
+        pub adf_aid: ApplicationIdentifier,
+        #[rasn(identifier = "adfAccessDomain")]
+        pub adf_access_domain: OctetString,
+        #[rasn(identifier = "adfAdminAccessDomain")]
+        pub adf_admin_access_domain: OctetString,
+    }
+    impl ADFRFMAccess {
+        pub fn new(
+            adf_aid: ApplicationIdentifier,
+            adf_access_domain: OctetString,
+            adf_admin_access_domain: OctetString,
+        ) -> Self {
+            Self {
+                adf_aid,
+                adf_access_domain,
+                adf_admin_access_domain,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct AlgoParameter {
+        #[rasn(identifier = "algorithmID")]
+        pub algorithm_id: Integer,
+        #[rasn(size("1"), identifier = "algorithmOptions")]
+        pub algorithm_options: OctetString,
+        pub key: OctetString,
+        pub opc: OctetString,
+        #[rasn(
+            size("5"),
+            default = "algo_parameter_rotation_constants_default",
+            identifier = "rotationConstants"
+        )]
+        pub rotation_constants: OctetString,
+        #[rasn(
+            size("80"),
+            default = "algo_parameter_xoring_constants_default",
+            identifier = "xoringConstants"
+        )]
+        pub xoring_constants: OctetString,
+        #[rasn(size("3"), identifier = "authCounterMax")]
+        pub auth_counter_max: Option<OctetString>,
+        #[rasn(
+            default = "algo_parameter_number_of_keccak_default",
+            identifier = "numberOfKeccak"
+        )]
+        pub number_of_keccak: UInt8,
+    }
+    impl AlgoParameter {
+        pub fn new(
+            algorithm_id: Integer,
+            algorithm_options: OctetString,
+            key: OctetString,
+            opc: OctetString,
+            rotation_constants: OctetString,
+            xoring_constants: OctetString,
+            auth_counter_max: Option<OctetString>,
+            number_of_keccak: UInt8,
+        ) -> Self {
+            Self {
+                algorithm_id,
+                algorithm_options,
+                key,
+                opc,
+                rotation_constants,
+                xoring_constants,
+                auth_counter_max,
+                number_of_keccak,
+            }
+        }
+    }
+    fn algo_parameter_rotation_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[64, 0, 32, 64, 96])
+    }
+    fn algo_parameter_xoring_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8,
+        ])
+    }
+    fn algo_parameter_number_of_keccak_default() -> UInt8 {
+        UInt8(1)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("5..=16"))]
+    pub struct ApplicationIdentifier(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationInstance {
+        #[rasn(tag(application, 15), identifier = "applicationLoadPackageAID")]
+        pub application_load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "classAID")]
+        pub class_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "extraditeSecurityDomainAID")]
+        pub extradite_security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 2), identifier = "applicationPrivileges")]
+        pub application_privileges: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 3),
+            default = "application_instance_life_cycle_state_default",
+            identifier = "lifeCycleState"
+        )]
+        pub life_cycle_state: OctetString,
+        #[rasn(tag(private, 9), identifier = "applicationSpecificParametersC9")]
+        pub application_specific_parameters_c9: OctetString,
+        #[rasn(tag(private, 15), identifier = "systemSpecificParameters")]
+        pub system_specific_parameters: Option<ApplicationSystemParameters>,
+        #[rasn(tag(private, 10), identifier = "applicationParameters")]
+        pub application_parameters: Option<UICCApplicationParameters>,
+        #[rasn(size("1.."), identifier = "processData")]
+        pub process_data: Option<SequenceOf<OctetString>>,
+    }
+    impl ApplicationInstance {
+        pub fn new(
+            application_load_package_aid: ApplicationIdentifier,
+            class_aid: ApplicationIdentifier,
+            instance_aid: ApplicationIdentifier,
+            extradite_security_domain_aid: Option<ApplicationIdentifier>,
+            application_privileges: OctetString,
+            life_cycle_state: OctetString,
+            application_specific_parameters_c9: OctetString,
+            system_specific_parameters: Option<ApplicationSystemParameters>,
+            application_parameters: Option<UICCApplicationParameters>,
+            process_data: Option<SequenceOf<OctetString>>,
+        ) -> Self {
+            Self {
+                application_load_package_aid,
+                class_aid,
+                instance_aid,
+                extradite_security_domain_aid,
+                application_privileges,
+                life_cycle_state,
+                application_specific_parameters_c9,
+                system_specific_parameters,
+                application_parameters,
+                process_data,
+            }
+        }
+    }
+    fn application_instance_life_cycle_state_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[7])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationLoadPackage {
+        #[rasn(tag(application, 15), identifier = "loadPackageAID")]
+        pub load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(private, 6), identifier = "nonVolatileCodeLimitC6")]
+        pub non_volatile_code_limit_c6: Option<OctetString>,
+        #[rasn(tag(private, 7), identifier = "volatileDataLimitC7")]
+        pub volatile_data_limit_c7: Option<OctetString>,
+        #[rasn(tag(private, 8), identifier = "nonVolatileDataLimitC8")]
+        pub non_volatile_data_limit_c8: Option<OctetString>,
+        #[rasn(tag(private, 1), identifier = "hashValue")]
+        pub hash_value: Option<OctetString>,
+        #[rasn(tag(private, 4), identifier = "loadBlockObject")]
+        pub load_block_object: OctetString,
+    }
+    impl ApplicationLoadPackage {
+        pub fn new(
+            load_package_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            non_volatile_code_limit_c6: Option<OctetString>,
+            volatile_data_limit_c7: Option<OctetString>,
+            non_volatile_data_limit_c8: Option<OctetString>,
+            hash_value: Option<OctetString>,
+            load_block_object: OctetString,
+        ) -> Self {
+            Self {
+                load_package_aid,
+                security_domain_aid,
+                non_volatile_code_limit_c6,
+                volatile_data_limit_c7,
+                non_volatile_data_limit_c8,
+                hash_value,
+                load_block_object,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationSystemParameters {
+        #[rasn(size("2..=4"), tag(private, 7), identifier = "volatileMemoryQuotaC7")]
+        pub volatile_memory_quota_c7: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 8),
+            identifier = "nonVolatileMemoryQuotaC8"
+        )]
+        pub non_volatile_memory_quota_c8: Option<OctetString>,
+        #[rasn(tag(private, 11), identifier = "globalServiceParameters")]
+        pub global_service_parameters: Option<OctetString>,
+        #[rasn(tag(private, 15), identifier = "implicitSelectionParameter")]
+        pub implicit_selection_parameter: Option<OctetString>,
+        #[rasn(size("2..=4"), tag(private, 23), identifier = "volatileReservedMemory")]
+        pub volatile_reserved_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 24),
+            identifier = "nonVolatileReservedMemory"
+        )]
+        pub non_volatile_reserved_memory: Option<OctetString>,
+        #[rasn(tag(private, 10), identifier = "ts102226SIMFileAccessToolkitParameter")]
+        pub ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+        #[rasn(
+            tag(context, 0),
+            identifier = "ts102226AdditionalContactlessParameters"
+        )]
+        pub ts102226_additional_contactless_parameters:
+            Option<TS102226AdditionalContactlessParameters>,
+        #[rasn(tag(private, 25), identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+        #[rasn(tag(private, 26), identifier = "userInteractionContactlessParameters")]
+        pub user_interaction_contactless_parameters: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 2),
+            identifier = "cumulativeGrantedVolatileMemory"
+        )]
+        pub cumulative_granted_volatile_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 3),
+            identifier = "cumulativeGrantedNonVolatileMemory"
+        )]
+        pub cumulative_granted_non_volatile_memory: Option<OctetString>,
+    }
+    impl ApplicationSystemParameters {
+        pub fn new(
+            volatile_memory_quota_c7: Option<OctetString>,
+            non_volatile_memory_quota_c8: Option<OctetString>,
+            global_service_parameters: Option<OctetString>,
+            implicit_selection_parameter: Option<OctetString>,
+            volatile_reserved_memory: Option<OctetString>,
+            non_volatile_reserved_memory: Option<OctetString>,
+            ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+            ts102226_additional_contactless_parameters: Option<
+                TS102226AdditionalContactlessParameters,
+            >,
+            contactless_protocol_parameters: Option<OctetString>,
+            user_interaction_contactless_parameters: Option<OctetString>,
+            cumulative_granted_volatile_memory: Option<OctetString>,
+            cumulative_granted_non_volatile_memory: Option<OctetString>,
+        ) -> Self {
+            Self {
+                volatile_memory_quota_c7,
+                non_volatile_memory_quota_c8,
+                global_service_parameters,
+                implicit_selection_parameter,
+                volatile_reserved_memory,
+                non_volatile_reserved_memory,
+                ts102226_simfile_access_toolkit_parameter,
+                ts102226_additional_contactless_parameters,
+                contactless_protocol_parameters,
+                user_interaction_contactless_parameters,
+                cumulative_granted_volatile_memory,
+                cumulative_granted_non_volatile_memory,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct EUICCResponse {
+        #[rasn(identifier = "peStatus")]
+        pub pe_status: SequenceOf<PEStatus>,
+        #[rasn(identifier = "profileInstallationAborted")]
+        pub profile_installation_aborted: Option<()>,
+        #[rasn(identifier = "statusMessage")]
+        pub status_message: Option<Utf8String>,
+    }
+    impl EUICCResponse {
+        pub fn new(
+            pe_status: SequenceOf<PEStatus>,
+            profile_installation_aborted: Option<()>,
+            status_message: Option<Utf8String>,
+        ) -> Self {
+            Self {
+                pe_status,
+                profile_installation_aborted,
+                status_message,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct Fcp {
+        #[rasn(size("2..=4"), tag(context, 2), identifier = "fileDescriptor")]
+        pub file_descriptor: Option<OctetString>,
+        #[rasn(size("2"), tag(context, 3), identifier = "fileID")]
+        pub file_id: Option<OctetString>,
+        #[rasn(tag(context, 4), identifier = "dfName")]
+        pub df_name: Option<ApplicationIdentifier>,
+        #[rasn(size("1"), tag(context, 10), default = "fcp_lcsi_default")]
+        pub lcsi: OctetString,
+        #[rasn(
+            size("1..=3"),
+            tag(context, 11),
+            identifier = "securityAttributesReferenced"
+        )]
+        pub security_attributes_referenced: Option<OctetString>,
+        #[rasn(tag(context, 0), identifier = "efFileSize")]
+        pub ef_file_size: Option<OctetString>,
+        #[rasn(tag(private, 6), identifier = "pinStatusTemplateDO")]
+        pub pin_status_template_do: Option<OctetString>,
+        #[rasn(size("0..=1"), tag(context, 8), identifier = "shortEFID")]
+        pub short_efid: Option<OctetString>,
+        #[rasn(tag(context, 5), identifier = "proprietaryEFInfo")]
+        pub proprietary_efinfo: Option<ProprietaryInfo>,
+        #[rasn(tag(private, 7), identifier = "linkPath")]
+        pub link_path: Option<OctetString>,
+    }
+    impl Fcp {
+        pub fn new(
+            file_descriptor: Option<OctetString>,
+            file_id: Option<OctetString>,
+            df_name: Option<ApplicationIdentifier>,
+            lcsi: OctetString,
+            security_attributes_referenced: Option<OctetString>,
+            ef_file_size: Option<OctetString>,
+            pin_status_template_do: Option<OctetString>,
+            short_efid: Option<OctetString>,
+            proprietary_efinfo: Option<ProprietaryInfo>,
+            link_path: Option<OctetString>,
+        ) -> Self {
+            Self {
+                file_descriptor,
+                file_id,
+                df_name,
+                lcsi,
+                security_attributes_referenced,
+                ef_file_size,
+                pin_status_template_do,
+                short_efid,
+                proprietary_efinfo,
+                link_path,
+            }
+        }
+    }
+    fn fcp_lcsi_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[5])
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFile {
+        doNotCreate(()),
+        fileDescriptor(Fcp),
+        fillFileOffset(UInt16),
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct File(pub SequenceOf<AnonymousFile>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFileManagement {
+        #[rasn(size("0..=8"), tag(context, 0))]
+        filePath(OctetString),
+        #[rasn(tag(application, 2))]
+        createFCP(Fcp),
+        fillFileOffset(UInt16),
+        #[rasn(tag(context, 1))]
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct FileManagement(pub SequenceOf<AnonymousFileManagement>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousKeyObjectKeyCompontents {
+        #[rasn(tag(context, 0), identifier = "keyType")]
+        pub key_type: OctetString,
+        #[rasn(tag(context, 6), identifier = "keyData")]
+        pub key_data: OctetString,
+        #[rasn(
+            tag(context, 7),
+            default = "anonymous_key_object_key_compontents_mac_length_default",
+            identifier = "macLength"
+        )]
+        pub mac_length: UInt8,
+    }
+    impl AnonymousKeyObjectKeyCompontents {
+        pub fn new(key_type: OctetString, key_data: OctetString, mac_length: UInt8) -> Self {
+            Self {
+                key_type,
+                key_data,
+                mac_length,
+            }
+        }
+    }
+    fn anonymous_key_object_key_compontents_mac_length_default() -> UInt8 {
+        UInt8(8)
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct KeyObjectKeyCompontents(pub SequenceOf<AnonymousKeyObjectKeyCompontents>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct KeyObject {
+        #[rasn(size("1..=2"), tag(context, 21), identifier = "keyUsageQualifier")]
+        pub key_usage_qualifier: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 22),
+            default = "key_object_key_access_default",
+            identifier = "keyAccess"
+        )]
+        pub key_access: OctetString,
+        #[rasn(size("1"), tag(context, 2), identifier = "keyIdentifier")]
+        pub key_identifier: OctetString,
+        #[rasn(size("1"), tag(context, 3), identifier = "keyVersionNumber")]
+        pub key_version_number: OctetString,
+        #[rasn(tag(context, 5), identifier = "keyCounterValue")]
+        pub key_counter_value: Option<OctetString>,
+        #[rasn(identifier = "keyCompontents")]
+        pub key_compontents: KeyObjectKeyCompontents,
+    }
+    impl KeyObject {
+        pub fn new(
+            key_usage_qualifier: OctetString,
+            key_access: OctetString,
+            key_identifier: OctetString,
+            key_version_number: OctetString,
+            key_counter_value: Option<OctetString>,
+            key_compontents: KeyObjectKeyCompontents,
+        ) -> Self {
+            Self {
+                key_usage_qualifier,
+                key_access,
+                key_identifier,
+                key_version_number,
+                key_counter_value,
+                key_compontents,
+            }
+        }
+    }
+    fn key_object_key_access_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MappingParameter {
+        #[rasn(size("1"), identifier = "mappingOptions")]
+        pub mapping_options: OctetString,
+        #[rasn(identifier = "mappingSource")]
+        pub mapping_source: ApplicationIdentifier,
+    }
+    impl MappingParameter {
+        pub fn new(mapping_options: OctetString, mapping_source: ApplicationIdentifier) -> Self {
+            Self {
+                mapping_options,
+                mapping_source,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEAKAParameterAlgoConfiguration {
+        mappingParameter(MappingParameter),
+        algoParameter(AlgoParameter),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPEAKAParameterSqnInit(pub FixedOctetString<6usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("32"))]
+    pub struct PEAKAParameterSqnInit(pub SequenceOf<AnonymousPEAKAParameterSqnInit>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-AKAParameter")]
+    #[non_exhaustive]
+    pub struct PEAKAParameter {
+        #[rasn(identifier = "aka-header")]
+        pub aka_header: PEHeader,
+        #[rasn(identifier = "algoConfiguration")]
+        pub algo_configuration: PEAKAParameterAlgoConfiguration,
+        #[rasn(
+            size("1"),
+            default = "peakaparameter_sqn_options_default",
+            identifier = "sqnOptions"
+        )]
+        pub sqn_options: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_delta_default",
+            identifier = "sqnDelta"
+        )]
+        pub sqn_delta: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_age_limit_default",
+            identifier = "sqnAgeLimit"
+        )]
+        pub sqn_age_limit: OctetString,
+        #[rasn(default = "peakaparameter_sqn_init_default", identifier = "sqnInit")]
+        pub sqn_init: PEAKAParameterSqnInit,
+    }
+    impl PEAKAParameter {
+        pub fn new(
+            aka_header: PEHeader,
+            algo_configuration: PEAKAParameterAlgoConfiguration,
+            sqn_options: OctetString,
+            sqn_delta: OctetString,
+            sqn_age_limit: OctetString,
+            sqn_init: PEAKAParameterSqnInit,
+        ) -> Self {
+            Self {
+                aka_header,
+                algo_configuration,
+                sqn_options,
+                sqn_delta,
+                sqn_age_limit,
+                sqn_init,
+            }
+        }
+    }
+    fn peakaparameter_sqn_options_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[2])
+    }
+    fn peakaparameter_sqn_delta_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_age_limit_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_init_default() -> PEAKAParameterSqnInit {
+        PEAKAParameterSqnInit(alloc::vec![
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8]))
+        ])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Application")]
+    #[non_exhaustive]
+    pub struct PEApplication {
+        #[rasn(identifier = "app-Header")]
+        pub app_header: PEHeader,
+        #[rasn(identifier = "loadBlock")]
+        pub load_block: Option<ApplicationLoadPackage>,
+        #[rasn(size("1.."), identifier = "instanceList")]
+        pub instance_list: Option<SequenceOf<ApplicationInstance>>,
+    }
+    impl PEApplication {
+        pub fn new(
+            app_header: PEHeader,
+            load_block: Option<ApplicationLoadPackage>,
+            instance_list: Option<SequenceOf<ApplicationInstance>>,
+        ) -> Self {
+            Self {
+                app_header,
+                load_block,
+                instance_list,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CD")]
+    #[non_exhaustive]
+    pub struct PECD {
+        #[rasn(identifier = "cd-header")]
+        pub cd_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-cd")]
+        pub df_cd: File,
+        #[rasn(identifier = "ef-launchpad")]
+        pub ef_launchpad: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+    }
+    impl PECD {
+        pub fn new(
+            cd_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_cd: File,
+            ef_launchpad: Option<File>,
+            ef_icon: Option<File>,
+        ) -> Self {
+            Self {
+                cd_header,
+                template_id,
+                df_cd,
+                ef_launchpad,
+                ef_icon,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CDMAParameter")]
+    #[non_exhaustive]
+    pub struct PECDMAParameter {
+        #[rasn(identifier = "cdma-header")]
+        pub cdma_header: PEHeader,
+        #[rasn(size("8"), identifier = "authenticationKey")]
+        pub authentication_key: OctetString,
+        #[rasn(size("16"))]
+        pub ssd: Option<OctetString>,
+        #[rasn(size("2..=32"), identifier = "hrpdAccessAuthenticationData")]
+        pub hrpd_access_authentication_data: Option<OctetString>,
+        #[rasn(size("3..=483"), identifier = "simpleIPAuthenticationData")]
+        pub simple_ipauthentication_data: Option<OctetString>,
+        #[rasn(size("5..=957"), identifier = "mobileIPAuthenticationData")]
+        pub mobile_ipauthentication_data: Option<OctetString>,
+    }
+    impl PECDMAParameter {
+        pub fn new(
+            cdma_header: PEHeader,
+            authentication_key: OctetString,
+            ssd: Option<OctetString>,
+            hrpd_access_authentication_data: Option<OctetString>,
+            simple_ipauthentication_data: Option<OctetString>,
+            mobile_ipauthentication_data: Option<OctetString>,
+        ) -> Self {
+            Self {
+                cdma_header,
+                authentication_key,
+                ssd,
+                hrpd_access_authentication_data,
+                simple_ipauthentication_data,
+                mobile_ipauthentication_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CSIM")]
+    #[non_exhaustive]
+    pub struct PECSIM {
+        #[rasn(identifier = "csim-header")]
+        pub csim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-csim")]
+        pub adf_csim: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-call-count")]
+        pub ef_call_count: File,
+        #[rasn(identifier = "ef-imsi-m")]
+        pub ef_imsi_m: File,
+        #[rasn(identifier = "ef-imsi-t")]
+        pub ef_imsi_t: File,
+        #[rasn(identifier = "ef-tmsi")]
+        pub ef_tmsi: File,
+        #[rasn(identifier = "ef-ah")]
+        pub ef_ah: File,
+        #[rasn(identifier = "ef-aop")]
+        pub ef_aop: File,
+        #[rasn(identifier = "ef-aloc")]
+        pub ef_aloc: File,
+        #[rasn(identifier = "ef-cdmahome")]
+        pub ef_cdmahome: File,
+        #[rasn(identifier = "ef-znregi")]
+        pub ef_znregi: File,
+        #[rasn(identifier = "ef-snregi")]
+        pub ef_snregi: File,
+        #[rasn(identifier = "ef-distregi")]
+        pub ef_distregi: File,
+        #[rasn(identifier = "ef-accolc")]
+        pub ef_accolc: File,
+        #[rasn(identifier = "ef-term")]
+        pub ef_term: File,
+        #[rasn(identifier = "ef-acp")]
+        pub ef_acp: File,
+        #[rasn(identifier = "ef-prl")]
+        pub ef_prl: File,
+        #[rasn(identifier = "ef-ruimid")]
+        pub ef_ruimid: File,
+        #[rasn(identifier = "ef-csim-st")]
+        pub ef_csim_st: File,
+        #[rasn(identifier = "ef-spc")]
+        pub ef_spc: File,
+        #[rasn(identifier = "ef-otapaspc")]
+        pub ef_otapaspc: File,
+        #[rasn(identifier = "ef-namlock")]
+        pub ef_namlock: File,
+        #[rasn(identifier = "ef-ota")]
+        pub ef_ota: File,
+        #[rasn(identifier = "ef-sp")]
+        pub ef_sp: File,
+        #[rasn(identifier = "ef-esn-meid-me")]
+        pub ef_esn_meid_me: File,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: File,
+        #[rasn(identifier = "ef-usgind")]
+        pub ef_usgind: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: File,
+        #[rasn(identifier = "ef-max-prl")]
+        pub ef_max_prl: File,
+        #[rasn(identifier = "ef-spcs")]
+        pub ef_spcs: File,
+        #[rasn(identifier = "ef-mecrp")]
+        pub ef_mecrp: File,
+        #[rasn(identifier = "ef-home-tag")]
+        pub ef_home_tag: File,
+        #[rasn(identifier = "ef-group-tag")]
+        pub ef_group_tag: File,
+        #[rasn(identifier = "ef-specific-tag")]
+        pub ef_specific_tag: File,
+        #[rasn(identifier = "ef-call-prompt")]
+        pub ef_call_prompt: File,
+    }
+    impl PECSIM {
+        pub fn new(
+            csim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_csim: File,
+            ef_arr: File,
+            ef_call_count: File,
+            ef_imsi_m: File,
+            ef_imsi_t: File,
+            ef_tmsi: File,
+            ef_ah: File,
+            ef_aop: File,
+            ef_aloc: File,
+            ef_cdmahome: File,
+            ef_znregi: File,
+            ef_snregi: File,
+            ef_distregi: File,
+            ef_accolc: File,
+            ef_term: File,
+            ef_acp: File,
+            ef_prl: File,
+            ef_ruimid: File,
+            ef_csim_st: File,
+            ef_spc: File,
+            ef_otapaspc: File,
+            ef_namlock: File,
+            ef_ota: File,
+            ef_sp: File,
+            ef_esn_meid_me: File,
+            ef_li: File,
+            ef_usgind: File,
+            ef_ad: File,
+            ef_max_prl: File,
+            ef_spcs: File,
+            ef_mecrp: File,
+            ef_home_tag: File,
+            ef_group_tag: File,
+            ef_specific_tag: File,
+            ef_call_prompt: File,
+        ) -> Self {
+            Self {
+                csim_header,
+                template_id,
+                adf_csim,
+                ef_arr,
+                ef_call_count,
+                ef_imsi_m,
+                ef_imsi_t,
+                ef_tmsi,
+                ef_ah,
+                ef_aop,
+                ef_aloc,
+                ef_cdmahome,
+                ef_znregi,
+                ef_snregi,
+                ef_distregi,
+                ef_accolc,
+                ef_term,
+                ef_acp,
+                ef_prl,
+                ef_ruimid,
+                ef_csim_st,
+                ef_spc,
+                ef_otapaspc,
+                ef_namlock,
+                ef_ota,
+                ef_sp,
+                ef_esn_meid_me,
+                ef_li,
+                ef_usgind,
+                ef_ad,
+                ef_max_prl,
+                ef_spcs,
+                ef_mecrp,
+                ef_home_tag,
+                ef_group_tag,
+                ef_specific_tag,
+                ef_call_prompt,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-5GS")]
+    #[non_exhaustive]
+    pub struct PEDF5GS {
+        #[rasn(identifier = "df-5gs-header")]
+        pub df_5gs_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-5gs")]
+        pub df_df_5gs: File,
+        #[rasn(identifier = "ef-5gs3gpploci")]
+        pub ef_5gs3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gpploci")]
+        pub ef_5gsn3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gs3gppnsc")]
+        pub ef_5gs3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gppnsc")]
+        pub ef_5gsn3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gauthkeys")]
+        pub ef_5gauthkeys: Option<File>,
+        #[rasn(identifier = "ef-uac-aic")]
+        pub ef_uac_aic: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info")]
+        pub ef_suci_calc_info: Option<File>,
+        #[rasn(identifier = "ef-opl5g")]
+        pub ef_opl5g: Option<File>,
+        #[rasn(identifier = "ef-nsi")]
+        pub ef_nsi: Option<File>,
+        #[rasn(identifier = "ef-routing-indicator")]
+        pub ef_routing_indicator: Option<File>,
+    }
+    impl PEDF5GS {
+        pub fn new(
+            df_5gs_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_5gs: File,
+            ef_5gs3gpploci: Option<File>,
+            ef_5gsn3gpploci: Option<File>,
+            ef_5gs3gppnsc: Option<File>,
+            ef_5gsn3gppnsc: Option<File>,
+            ef_5gauthkeys: Option<File>,
+            ef_uac_aic: Option<File>,
+            ef_suci_calc_info: Option<File>,
+            ef_opl5g: Option<File>,
+            ef_nsi: Option<File>,
+            ef_routing_indicator: Option<File>,
+        ) -> Self {
+            Self {
+                df_5gs_header,
+                template_id,
+                df_df_5gs,
+                ef_5gs3gpploci,
+                ef_5gsn3gpploci,
+                ef_5gs3gppnsc,
+                ef_5gsn3gppnsc,
+                ef_5gauthkeys,
+                ef_uac_aic,
+                ef_suci_calc_info,
+                ef_opl5g,
+                ef_nsi,
+                ef_routing_indicator,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-SAIP")]
+    #[non_exhaustive]
+    pub struct PEDFSAIP {
+        #[rasn(identifier = "df-saip-header")]
+        pub df_saip_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-saip")]
+        pub df_df_saip: File,
+        #[rasn(identifier = "ef-suci-calc-info-usim")]
+        pub ef_suci_calc_info_usim: Option<File>,
+    }
+    impl PEDFSAIP {
+        pub fn new(
+            df_saip_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_saip: File,
+            ef_suci_calc_info_usim: Option<File>,
+        ) -> Self {
+            Self {
+                df_saip_header,
+                template_id,
+                df_df_saip,
+                ef_suci_calc_info_usim,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Dummy")]
+    #[non_exhaustive]
+    pub struct PEDummy {}
+    impl PEDummy {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+    impl std::default::Default for PEDummy {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-EAP")]
+    #[non_exhaustive]
+    pub struct PEEAP {
+        #[rasn(identifier = "eap-header")]
+        pub eap_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-eap")]
+        pub df_eap: File,
+        #[rasn(identifier = "ef-eapkeys")]
+        pub ef_eapkeys: Option<File>,
+        #[rasn(identifier = "ef-eapstatus")]
+        pub ef_eapstatus: File,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-ps")]
+        pub ef_ps: Option<File>,
+        #[rasn(identifier = "ef-curid")]
+        pub ef_curid: Option<File>,
+        #[rasn(identifier = "ef-reid")]
+        pub ef_reid: Option<File>,
+        #[rasn(identifier = "ef-realm")]
+        pub ef_realm: Option<File>,
+    }
+    impl PEEAP {
+        pub fn new(
+            eap_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_eap: File,
+            ef_eapkeys: Option<File>,
+            ef_eapstatus: File,
+            ef_puid: Option<File>,
+            ef_ps: Option<File>,
+            ef_curid: Option<File>,
+            ef_reid: Option<File>,
+            ef_realm: Option<File>,
+        ) -> Self {
+            Self {
+                eap_header,
+                template_id,
+                df_eap,
+                ef_eapkeys,
+                ef_eapstatus,
+                ef_puid,
+                ef_ps,
+                ef_curid,
+                ef_reid,
+                ef_realm,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-End")]
+    #[non_exhaustive]
+    pub struct PEEnd {
+        #[rasn(identifier = "end-header")]
+        pub end_header: PEHeader,
+    }
+    impl PEEnd {
+        pub fn new(end_header: PEHeader) -> Self {
+            Self { end_header }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GSM-ACCESS")]
+    #[non_exhaustive]
+    pub struct PEGSMACCESS {
+        #[rasn(identifier = "gsm-access-header")]
+        pub gsm_access_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-gsm-access")]
+        pub df_gsm_access: File,
+        #[rasn(identifier = "ef-kc")]
+        pub ef_kc: Option<File>,
+        #[rasn(identifier = "ef-kcgprs")]
+        pub ef_kcgprs: Option<File>,
+        #[rasn(identifier = "ef-cpbcch")]
+        pub ef_cpbcch: Option<File>,
+        #[rasn(identifier = "ef-invscan")]
+        pub ef_invscan: Option<File>,
+    }
+    impl PEGSMACCESS {
+        pub fn new(
+            gsm_access_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_gsm_access: File,
+            ef_kc: Option<File>,
+            ef_kcgprs: Option<File>,
+            ef_cpbcch: Option<File>,
+            ef_invscan: Option<File>,
+        ) -> Self {
+            Self {
+                gsm_access_header,
+                template_id,
+                df_gsm_access,
+                ef_kc,
+                ef_kcgprs,
+                ef_cpbcch,
+                ef_invscan,
+            }
+        }
+    }
+    #[doc = " Create GenericFileManagement"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GenericFileManagement")]
+    #[non_exhaustive]
+    pub struct PEGenericFileManagement {
+        #[rasn(identifier = "gfm-header")]
+        pub gfm_header: PEHeader,
+        #[rasn(size("1.."), identifier = "fileManagementCMD")]
+        pub file_management_cmd: SequenceOf<FileManagement>,
+    }
+    impl PEGenericFileManagement {
+        pub fn new(gfm_header: PEHeader, file_management_cmd: SequenceOf<FileManagement>) -> Self {
+            Self {
+                gfm_header,
+                file_management_cmd,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-ISIM")]
+    #[non_exhaustive]
+    pub struct PEISIM {
+        #[rasn(identifier = "isim-header")]
+        pub isim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-isim")]
+        pub adf_isim: File,
+        #[rasn(identifier = "ef-impi")]
+        pub ef_impi: File,
+        #[rasn(identifier = "ef-impu")]
+        pub ef_impu: File,
+        #[rasn(identifier = "ef-domain")]
+        pub ef_domain: File,
+        #[rasn(identifier = "ef-ist")]
+        pub ef_ist: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+    }
+    impl PEISIM {
+        pub fn new(
+            isim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_isim: File,
+            ef_impi: File,
+            ef_impu: File,
+            ef_domain: File,
+            ef_ist: File,
+            ef_ad: Option<File>,
+            ef_arr: File,
+        ) -> Self {
+            Self {
+                isim_header,
+                template_id,
+                adf_isim,
+                ef_impi,
+                ef_impu,
+                ef_domain,
+                ef_ist,
+                ef_ad,
+                ef_arr,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-MF")]
+    #[non_exhaustive]
+    pub struct PEMF {
+        #[rasn(identifier = "mf-header")]
+        pub mf_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        pub mf: File,
+        #[rasn(identifier = "ef-pl")]
+        pub ef_pl: Option<File>,
+        #[rasn(identifier = "ef-iccid")]
+        pub ef_iccid: File,
+        #[rasn(identifier = "ef-dir")]
+        pub ef_dir: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-umpc")]
+        pub ef_umpc: Option<File>,
+    }
+    impl PEMF {
+        pub fn new(
+            mf_header: PEHeader,
+            template_id: ObjectIdentifier,
+            mf: File,
+            ef_pl: Option<File>,
+            ef_iccid: File,
+            ef_dir: File,
+            ef_arr: File,
+            ef_umpc: Option<File>,
+        ) -> Self {
+            Self {
+                mf_header,
+                template_id,
+                mf,
+                ef_pl,
+                ef_iccid,
+                ef_dir,
+                ef_arr,
+                ef_umpc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-NonStandard")]
+    #[non_exhaustive]
+    pub struct PENonStandard {
+        #[rasn(identifier = "nonStandard-header")]
+        pub non_standard_header: PEHeader,
+        #[rasn(identifier = "issuerID")]
+        pub issuer_id: ObjectIdentifier,
+        pub content: OctetString,
+    }
+    impl PENonStandard {
+        pub fn new(
+            non_standard_header: PEHeader,
+            issuer_id: ObjectIdentifier,
+            content: OctetString,
+        ) -> Self {
+            Self {
+                non_standard_header,
+                issuer_id,
+                content,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-CSIM")]
+    #[non_exhaustive]
+    pub struct PEOPTCSIM {
+        #[rasn(identifier = "optcsim-header")]
+        pub optcsim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-ssci")]
+        pub ef_ssci: Option<File>,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-ssfc")]
+        pub ef_ssfc: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: Option<File>,
+        #[rasn(identifier = "ef-mdn")]
+        pub ef_mdn: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: Option<File>,
+        #[rasn(identifier = "ef-me3gpdopc")]
+        pub ef_me3gpdopc: Option<File>,
+        #[rasn(identifier = "ef-3gpdopm")]
+        pub ef_3gpdopm: Option<File>,
+        #[rasn(identifier = "ef-sipcap")]
+        pub ef_sipcap: Option<File>,
+        #[rasn(identifier = "ef-mipcap")]
+        pub ef_mipcap: Option<File>,
+        #[rasn(identifier = "ef-sipupp")]
+        pub ef_sipupp: Option<File>,
+        #[rasn(identifier = "ef-mipupp")]
+        pub ef_mipupp: Option<File>,
+        #[rasn(identifier = "ef-sipsp")]
+        pub ef_sipsp: Option<File>,
+        #[rasn(identifier = "ef-mipsp")]
+        pub ef_mipsp: Option<File>,
+        #[rasn(identifier = "ef-sippapss")]
+        pub ef_sippapss: Option<File>,
+        #[rasn(identifier = "ef-puzl")]
+        pub ef_puzl: Option<File>,
+        #[rasn(identifier = "ef-maxpuzl")]
+        pub ef_maxpuzl: Option<File>,
+        #[rasn(identifier = "ef-hrpdcap")]
+        pub ef_hrpdcap: Option<File>,
+        #[rasn(identifier = "ef-hrpdupp")]
+        pub ef_hrpdupp: Option<File>,
+        #[rasn(identifier = "ef-csspr")]
+        pub ef_csspr: Option<File>,
+        #[rasn(identifier = "ef-atc")]
+        pub ef_atc: Option<File>,
+        #[rasn(identifier = "ef-eprl")]
+        pub ef_eprl: Option<File>,
+        #[rasn(identifier = "ef-bcsmscfg")]
+        pub ef_bcsmscfg: Option<File>,
+        #[rasn(identifier = "ef-bcsmspref")]
+        pub ef_bcsmspref: Option<File>,
+        #[rasn(identifier = "ef-bcsmstable")]
+        pub ef_bcsmstable: Option<File>,
+        #[rasn(identifier = "ef-bcsmsp")]
+        pub ef_bcsmsp: Option<File>,
+        #[rasn(identifier = "ef-bakpara")]
+        pub ef_bakpara: Option<File>,
+        #[rasn(identifier = "ef-upbakpara")]
+        pub ef_upbakpara: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-auth-capability")]
+        pub ef_auth_capability: Option<File>,
+        #[rasn(identifier = "ef-3gcik")]
+        pub ef_3gcik: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-cdmacnl")]
+        pub ef_cdmacnl: Option<File>,
+        #[rasn(identifier = "ef-sf-euimid")]
+        pub ef_sf_euimid: Option<File>,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: Option<File>,
+        #[rasn(identifier = "ef-hidden-key")]
+        pub ef_hidden_key: Option<File>,
+        #[rasn(identifier = "ef-lcsver")]
+        pub ef_lcsver: Option<File>,
+        #[rasn(identifier = "ef-lcscp")]
+        pub ef_lcscp: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-applabels")]
+        pub ef_applabels: Option<File>,
+        #[rasn(identifier = "ef-model")]
+        pub ef_model: Option<File>,
+        #[rasn(identifier = "ef-rc")]
+        pub ef_rc: Option<File>,
+        #[rasn(identifier = "ef-smscap")]
+        pub ef_smscap: Option<File>,
+        #[rasn(identifier = "ef-mipflags")]
+        pub ef_mipflags: Option<File>,
+        #[rasn(identifier = "ef-3gpduppext")]
+        pub ef_3gpduppext: Option<File>,
+        #[rasn(identifier = "ef-ipv6cap")]
+        pub ef_ipv6cap: Option<File>,
+        #[rasn(identifier = "ef-tcpconfig")]
+        pub ef_tcpconfig: Option<File>,
+        #[rasn(identifier = "ef-dgc")]
+        pub ef_dgc: Option<File>,
+        #[rasn(identifier = "ef-wapbrowsercp")]
+        pub ef_wapbrowsercp: Option<File>,
+        #[rasn(identifier = "ef-wapbrowserbm")]
+        pub ef_wapbrowserbm: Option<File>,
+        #[rasn(identifier = "ef-mmsconfig")]
+        pub ef_mmsconfig: Option<File>,
+        #[rasn(identifier = "ef-jdl")]
+        pub ef_jdl: Option<File>,
+    }
+    impl PEOPTCSIM {
+        pub fn new(
+            optcsim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_ssci: Option<File>,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_ssfc: Option<File>,
+            ef_spn: Option<File>,
+            ef_mdn: Option<File>,
+            ef_ecc: Option<File>,
+            ef_me3gpdopc: Option<File>,
+            ef_3gpdopm: Option<File>,
+            ef_sipcap: Option<File>,
+            ef_mipcap: Option<File>,
+            ef_sipupp: Option<File>,
+            ef_mipupp: Option<File>,
+            ef_sipsp: Option<File>,
+            ef_mipsp: Option<File>,
+            ef_sippapss: Option<File>,
+            ef_puzl: Option<File>,
+            ef_maxpuzl: Option<File>,
+            ef_hrpdcap: Option<File>,
+            ef_hrpdupp: Option<File>,
+            ef_csspr: Option<File>,
+            ef_atc: Option<File>,
+            ef_eprl: Option<File>,
+            ef_bcsmscfg: Option<File>,
+            ef_bcsmspref: Option<File>,
+            ef_bcsmstable: Option<File>,
+            ef_bcsmsp: Option<File>,
+            ef_bakpara: Option<File>,
+            ef_upbakpara: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_auth_capability: Option<File>,
+            ef_3gcik: Option<File>,
+            ef_dck: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_cdmacnl: Option<File>,
+            ef_sf_euimid: Option<File>,
+            ef_est: Option<File>,
+            ef_hidden_key: Option<File>,
+            ef_lcsver: Option<File>,
+            ef_lcscp: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_applabels: Option<File>,
+            ef_model: Option<File>,
+            ef_rc: Option<File>,
+            ef_smscap: Option<File>,
+            ef_mipflags: Option<File>,
+            ef_3gpduppext: Option<File>,
+            ef_ipv6cap: Option<File>,
+            ef_tcpconfig: Option<File>,
+            ef_dgc: Option<File>,
+            ef_wapbrowsercp: Option<File>,
+            ef_wapbrowserbm: Option<File>,
+            ef_mmsconfig: Option<File>,
+            ef_jdl: Option<File>,
+        ) -> Self {
+            Self {
+                optcsim_header,
+                template_id,
+                ef_ssci,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_ssfc,
+                ef_spn,
+                ef_mdn,
+                ef_ecc,
+                ef_me3gpdopc,
+                ef_3gpdopm,
+                ef_sipcap,
+                ef_mipcap,
+                ef_sipupp,
+                ef_mipupp,
+                ef_sipsp,
+                ef_mipsp,
+                ef_sippapss,
+                ef_puzl,
+                ef_maxpuzl,
+                ef_hrpdcap,
+                ef_hrpdupp,
+                ef_csspr,
+                ef_atc,
+                ef_eprl,
+                ef_bcsmscfg,
+                ef_bcsmspref,
+                ef_bcsmstable,
+                ef_bcsmsp,
+                ef_bakpara,
+                ef_upbakpara,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_auth_capability,
+                ef_3gcik,
+                ef_dck,
+                ef_gid1,
+                ef_gid2,
+                ef_cdmacnl,
+                ef_sf_euimid,
+                ef_est,
+                ef_hidden_key,
+                ef_lcsver,
+                ef_lcscp,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_ici,
+                ef_oci,
+                ef_ext5,
+                ef_ccp2,
+                ef_applabels,
+                ef_model,
+                ef_rc,
+                ef_smscap,
+                ef_mipflags,
+                ef_3gpduppext,
+                ef_ipv6cap,
+                ef_tcpconfig,
+                ef_dgc,
+                ef_wapbrowsercp,
+                ef_wapbrowserbm,
+                ef_mmsconfig,
+                ef_jdl,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-ISIM")]
+    #[non_exhaustive]
+    pub struct PEOPTISIM {
+        #[rasn(identifier = "optisim-header")]
+        pub optisim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-pcscf")]
+        pub ef_pcscf: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+    }
+    impl PEOPTISIM {
+        pub fn new(
+            optisim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_pcscf: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_smsr: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_uicciari: Option<File>,
+        ) -> Self {
+            Self {
+                optisim_header,
+                template_id,
+                ef_pcscf,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_smsr,
+                ef_gbabp,
+                ef_gbanl,
+                ef_nafkca,
+                ef_uicciari,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-USIM")]
+    #[non_exhaustive]
+    pub struct PEOPTUSIM {
+        #[rasn(identifier = "optusim-header")]
+        pub optusim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: Option<File>,
+        #[rasn(identifier = "ef-acmax")]
+        pub ef_acmax: Option<File>,
+        #[rasn(identifier = "ef-acm")]
+        pub ef_acm: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-msisdn")]
+        pub ef_msisdn: Option<File>,
+        #[rasn(identifier = "ef-puct")]
+        pub ef_puct: Option<File>,
+        #[rasn(identifier = "ef-cbmi")]
+        pub ef_cbmi: Option<File>,
+        #[rasn(identifier = "ef-cbmid")]
+        pub ef_cbmid: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-cbmir")]
+        pub ef_cbmir: Option<File>,
+        #[rasn(identifier = "ef-plmnwact")]
+        pub ef_plmnwact: Option<File>,
+        #[rasn(identifier = "ef-oplmnwact")]
+        pub ef_oplmnwact: Option<File>,
+        #[rasn(identifier = "ef-hplmnwact")]
+        pub ef_hplmnwact: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-cnl")]
+        pub ef_cnl: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-bdn")]
+        pub ef_bdn: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-ext4")]
+        pub ef_ext4: Option<File>,
+        #[rasn(identifier = "ef-acl")]
+        pub ef_acl: Option<File>,
+        #[rasn(identifier = "ef-cmi")]
+        pub ef_cmi: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ict")]
+        pub ef_ict: Option<File>,
+        #[rasn(identifier = "ef-oct")]
+        pub ef_oct: Option<File>,
+        #[rasn(identifier = "ef-vgcs")]
+        pub ef_vgcs: Option<File>,
+        #[rasn(identifier = "ef-vgcss")]
+        pub ef_vgcss: Option<File>,
+        #[rasn(identifier = "ef-vbs")]
+        pub ef_vbs: Option<File>,
+        #[rasn(identifier = "ef-vbss")]
+        pub ef_vbss: Option<File>,
+        #[rasn(identifier = "ef-emlpp")]
+        pub ef_emlpp: Option<File>,
+        #[rasn(identifier = "ef-aaem")]
+        pub ef_aaem: Option<File>,
+        #[rasn(identifier = "ef-hiddenkey")]
+        pub ef_hiddenkey: Option<File>,
+        #[rasn(identifier = "ef-pnn")]
+        pub ef_pnn: Option<File>,
+        #[rasn(identifier = "ef-opl")]
+        pub ef_opl: Option<File>,
+        #[rasn(identifier = "ef-mbdn")]
+        pub ef_mbdn: Option<File>,
+        #[rasn(identifier = "ef-ext6")]
+        pub ef_ext6: Option<File>,
+        #[rasn(identifier = "ef-mbi")]
+        pub ef_mbi: Option<File>,
+        #[rasn(identifier = "ef-mwis")]
+        pub ef_mwis: Option<File>,
+        #[rasn(identifier = "ef-cfis")]
+        pub ef_cfis: Option<File>,
+        #[rasn(identifier = "ef-ext7")]
+        pub ef_ext7: Option<File>,
+        #[rasn(identifier = "ef-spdi")]
+        pub ef_spdi: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-nia")]
+        pub ef_nia: Option<File>,
+        #[rasn(identifier = "ef-vgcsca")]
+        pub ef_vgcsca: Option<File>,
+        #[rasn(identifier = "ef-vbsca")]
+        pub ef_vbsca: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-msk")]
+        pub ef_msk: Option<File>,
+        #[rasn(identifier = "ef-muk")]
+        pub ef_muk: Option<File>,
+        #[rasn(identifier = "ef-ehplmn")]
+        pub ef_ehplmn: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-ehplmnpi")]
+        pub ef_ehplmnpi: Option<File>,
+        #[rasn(identifier = "ef-lrplmnsi")]
+        pub ef_lrplmnsi: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-spni")]
+        pub ef_spni: Option<File>,
+        #[rasn(identifier = "ef-pnni")]
+        pub ef_pnni: Option<File>,
+        #[rasn(identifier = "ef-ncp-ip")]
+        pub ef_ncp_ip: Option<File>,
+        #[rasn(identifier = "ef-ufc")]
+        pub ef_ufc: Option<File>,
+        #[rasn(identifier = "ef-nasconfig")]
+        pub ef_nasconfig: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+        #[rasn(identifier = "ef-pws")]
+        pub ef_pws: Option<File>,
+        #[rasn(identifier = "ef-fdnuri")]
+        pub ef_fdnuri: Option<File>,
+        #[rasn(identifier = "ef-bdnuri")]
+        pub ef_bdnuri: Option<File>,
+        #[rasn(identifier = "ef-sdnuri")]
+        pub ef_sdnuri: Option<File>,
+        #[rasn(identifier = "ef-iwl")]
+        pub ef_iwl: Option<File>,
+        #[rasn(identifier = "ef-ips")]
+        pub ef_ips: Option<File>,
+        #[rasn(identifier = "ef-ipd")]
+        pub ef_ipd: Option<File>,
+    }
+    impl PEOPTUSIM {
+        pub fn new(
+            optusim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_li: Option<File>,
+            ef_acmax: Option<File>,
+            ef_acm: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_msisdn: Option<File>,
+            ef_puct: Option<File>,
+            ef_cbmi: Option<File>,
+            ef_cbmid: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_cbmir: Option<File>,
+            ef_plmnwact: Option<File>,
+            ef_oplmnwact: Option<File>,
+            ef_hplmnwact: Option<File>,
+            ef_dck: Option<File>,
+            ef_cnl: Option<File>,
+            ef_smsr: Option<File>,
+            ef_bdn: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_ext4: Option<File>,
+            ef_acl: Option<File>,
+            ef_cmi: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ict: Option<File>,
+            ef_oct: Option<File>,
+            ef_vgcs: Option<File>,
+            ef_vgcss: Option<File>,
+            ef_vbs: Option<File>,
+            ef_vbss: Option<File>,
+            ef_emlpp: Option<File>,
+            ef_aaem: Option<File>,
+            ef_hiddenkey: Option<File>,
+            ef_pnn: Option<File>,
+            ef_opl: Option<File>,
+            ef_mbdn: Option<File>,
+            ef_ext6: Option<File>,
+            ef_mbi: Option<File>,
+            ef_mwis: Option<File>,
+            ef_cfis: Option<File>,
+            ef_ext7: Option<File>,
+            ef_spdi: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_nia: Option<File>,
+            ef_vgcsca: Option<File>,
+            ef_vbsca: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_msk: Option<File>,
+            ef_muk: Option<File>,
+            ef_ehplmn: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_ehplmnpi: Option<File>,
+            ef_lrplmnsi: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_spni: Option<File>,
+            ef_pnni: Option<File>,
+            ef_ncp_ip: Option<File>,
+            ef_ufc: Option<File>,
+            ef_nasconfig: Option<File>,
+            ef_uicciari: Option<File>,
+            ef_pws: Option<File>,
+            ef_fdnuri: Option<File>,
+            ef_bdnuri: Option<File>,
+            ef_sdnuri: Option<File>,
+            ef_iwl: Option<File>,
+            ef_ips: Option<File>,
+            ef_ipd: Option<File>,
+        ) -> Self {
+            Self {
+                optusim_header,
+                template_id,
+                ef_li,
+                ef_acmax,
+                ef_acm,
+                ef_gid1,
+                ef_gid2,
+                ef_msisdn,
+                ef_puct,
+                ef_cbmi,
+                ef_cbmid,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_cbmir,
+                ef_plmnwact,
+                ef_oplmnwact,
+                ef_hplmnwact,
+                ef_dck,
+                ef_cnl,
+                ef_smsr,
+                ef_bdn,
+                ef_ext5,
+                ef_ccp2,
+                ef_ext4,
+                ef_acl,
+                ef_cmi,
+                ef_ici,
+                ef_oci,
+                ef_ict,
+                ef_oct,
+                ef_vgcs,
+                ef_vgcss,
+                ef_vbs,
+                ef_vbss,
+                ef_emlpp,
+                ef_aaem,
+                ef_hiddenkey,
+                ef_pnn,
+                ef_opl,
+                ef_mbdn,
+                ef_ext6,
+                ef_mbi,
+                ef_mwis,
+                ef_cfis,
+                ef_ext7,
+                ef_spdi,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_nia,
+                ef_vgcsca,
+                ef_vbsca,
+                ef_gbabp,
+                ef_msk,
+                ef_muk,
+                ef_ehplmn,
+                ef_gbanl,
+                ef_ehplmnpi,
+                ef_lrplmnsi,
+                ef_nafkca,
+                ef_spni,
+                ef_pnni,
+                ef_ncp_ip,
+                ef_ufc,
+                ef_nasconfig,
+                ef_uicciari,
+                ef_pws,
+                ef_fdnuri,
+                ef_bdnuri,
+                ef_sdnuri,
+                ef_iwl,
+                ef_ips,
+                ef_ipd,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PHONEBOOK")]
+    #[non_exhaustive]
+    pub struct PEPHONEBOOK {
+        #[rasn(identifier = "phonebook-header")]
+        pub phonebook_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: File,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+    }
+    impl PEPHONEBOOK {
+        pub fn new(
+            phonebook_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_phonebook: File,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+        ) -> Self {
+            Self {
+                phonebook_header,
+                template_id,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEPINCodesPinCodes {
+        #[rasn(size("1..=26"))]
+        pinconfig(SequenceOf<PINConfiguration>),
+        #[rasn(size("0..=8"))]
+        filePath(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PINCodes")]
+    #[non_exhaustive]
+    pub struct PEPINCodes {
+        #[rasn(identifier = "pin-Header")]
+        pub pin_header: PEHeader,
+        #[rasn(identifier = "pinCodes")]
+        pub pin_codes: PEPINCodesPinCodes,
+    }
+    impl PEPINCodes {
+        pub fn new(pin_header: PEHeader, pin_codes: PEPINCodesPinCodes) -> Self {
+            Self {
+                pin_header,
+                pin_codes,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PUKCodes")]
+    #[non_exhaustive]
+    pub struct PEPUKCodes {
+        #[rasn(identifier = "puk-Header")]
+        pub puk_header: PEHeader,
+        #[rasn(size("1..=16"), identifier = "pukCodes")]
+        pub puk_codes: SequenceOf<PUKConfiguration>,
+    }
+    impl PEPUKCodes {
+        pub fn new(puk_header: PEHeader, puk_codes: SequenceOf<PUKConfiguration>) -> Self {
+            Self {
+                puk_header,
+                puk_codes,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPERFMTarList(pub FixedOctetString<3usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct PERFMTarList(pub SequenceOf<AnonymousPERFMTarList>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "PE-RFM")]
+    #[non_exhaustive]
+    pub struct PERFM {
+        #[rasn(tag(context, 0), identifier = "rfm-header")]
+        pub rfm_header: PEHeader,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 0), identifier = "tarList")]
+        pub tar_list: Option<PERFMTarList>,
+        #[rasn(size("1"), tag(context, 1), identifier = "minimumSecurityLevel")]
+        pub minimum_security_level: OctetString,
+        #[rasn(identifier = "uiccAccessDomain")]
+        pub uicc_access_domain: OctetString,
+        #[rasn(identifier = "uiccAdminAccessDomain")]
+        pub uicc_admin_access_domain: OctetString,
+        #[rasn(identifier = "adfRFMAccess")]
+        pub adf_rfmaccess: Option<ADFRFMAccess>,
+    }
+    impl PERFM {
+        pub fn new(
+            rfm_header: PEHeader,
+            instance_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            tar_list: Option<PERFMTarList>,
+            minimum_security_level: OctetString,
+            uicc_access_domain: OctetString,
+            uicc_admin_access_domain: OctetString,
+            adf_rfmaccess: Option<ADFRFMAccess>,
+        ) -> Self {
+            Self {
+                rfm_header,
+                instance_aid,
+                security_domain_aid,
+                tar_list,
+                minimum_security_level,
+                uicc_access_domain,
+                uicc_admin_access_domain,
+                adf_rfmaccess,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainOpenPersoData {
+        #[rasn(tag(private, 25), identifier = "restrictParameter")]
+        pub restrict_parameter: Option<OctetString>,
+        #[rasn(identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+    }
+    impl PESecurityDomainOpenPersoData {
+        pub fn new(
+            restrict_parameter: Option<OctetString>,
+            contactless_protocol_parameters: Option<OctetString>,
+        ) -> Self {
+            Self {
+                restrict_parameter,
+                contactless_protocol_parameters,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainCatTpParameters {
+        #[rasn(identifier = "catTpMaxSduSize")]
+        pub cat_tp_max_sdu_size: UInt16,
+        #[rasn(identifier = "catTpMaxPduSize")]
+        pub cat_tp_max_pdu_size: UInt16,
+    }
+    impl PESecurityDomainCatTpParameters {
+        pub fn new(cat_tp_max_sdu_size: UInt16, cat_tp_max_pdu_size: UInt16) -> Self {
+            Self {
+                cat_tp_max_sdu_size,
+                cat_tp_max_pdu_size,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SecurityDomain")]
+    #[non_exhaustive]
+    pub struct PESecurityDomain {
+        #[rasn(identifier = "sd-Header")]
+        pub sd_header: PEHeader,
+        pub instance: ApplicationInstance,
+        #[rasn(size("1.."), identifier = "keyList")]
+        pub key_list: Option<SequenceOf<KeyObject>>,
+        #[rasn(size("1.."), identifier = "sdPersoData")]
+        pub sd_perso_data: Option<SequenceOf<OctetString>>,
+        #[rasn(identifier = "openPersoData")]
+        pub open_perso_data: Option<PESecurityDomainOpenPersoData>,
+        #[rasn(identifier = "catTpParameters")]
+        pub cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+    }
+    impl PESecurityDomain {
+        pub fn new(
+            sd_header: PEHeader,
+            instance: ApplicationInstance,
+            key_list: Option<SequenceOf<KeyObject>>,
+            sd_perso_data: Option<SequenceOf<OctetString>>,
+            open_perso_data: Option<PESecurityDomainOpenPersoData>,
+            cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+        ) -> Self {
+            Self {
+                sd_header,
+                instance,
+                key_list,
+                sd_perso_data,
+                open_perso_data,
+                cat_tp_parameters,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-TELECOM")]
+    #[non_exhaustive]
+    pub struct PETELECOM {
+        #[rasn(identifier = "telecom-header")]
+        pub telecom_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-telecom")]
+        pub df_telecom: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: Option<File>,
+        #[rasn(identifier = "ef-rma")]
+        pub ef_rma: Option<File>,
+        #[rasn(identifier = "ef-sume")]
+        pub ef_sume: Option<File>,
+        #[rasn(identifier = "ef-ice-dn")]
+        pub ef_ice_dn: Option<File>,
+        #[rasn(identifier = "ef-ice-ff")]
+        pub ef_ice_ff: Option<File>,
+        #[rasn(identifier = "ef-psismsc")]
+        pub ef_psismsc: Option<File>,
+        #[rasn(identifier = "df-graphics")]
+        pub df_graphics: Option<File>,
+        #[rasn(identifier = "ef-img")]
+        pub ef_img: Option<File>,
+        #[rasn(identifier = "ef-iidf")]
+        pub ef_iidf: Option<File>,
+        #[rasn(identifier = "ef-ice-graphics")]
+        pub ef_ice_graphics: Option<File>,
+        #[rasn(identifier = "ef-launch-scws")]
+        pub ef_launch_scws: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: Option<File>,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+        #[rasn(identifier = "df-multimedia")]
+        pub df_multimedia: Option<File>,
+        #[rasn(identifier = "ef-mml")]
+        pub ef_mml: Option<File>,
+        #[rasn(identifier = "ef-mmdf")]
+        pub ef_mmdf: Option<File>,
+        #[rasn(identifier = "df-mmss")]
+        pub df_mmss: Option<File>,
+        #[rasn(identifier = "ef-mlpl")]
+        pub ef_mlpl: Option<File>,
+        #[rasn(identifier = "ef-mspl")]
+        pub ef_mspl: Option<File>,
+        #[rasn(identifier = "ef-mmssmode")]
+        pub ef_mmssmode: Option<File>,
+    }
+    impl PETELECOM {
+        pub fn new(
+            telecom_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_telecom: File,
+            ef_arr: Option<File>,
+            ef_rma: Option<File>,
+            ef_sume: Option<File>,
+            ef_ice_dn: Option<File>,
+            ef_ice_ff: Option<File>,
+            ef_psismsc: Option<File>,
+            df_graphics: Option<File>,
+            ef_img: Option<File>,
+            ef_iidf: Option<File>,
+            ef_ice_graphics: Option<File>,
+            ef_launch_scws: Option<File>,
+            ef_icon: Option<File>,
+            df_phonebook: Option<File>,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+            df_multimedia: Option<File>,
+            ef_mml: Option<File>,
+            ef_mmdf: Option<File>,
+            df_mmss: Option<File>,
+            ef_mlpl: Option<File>,
+            ef_mspl: Option<File>,
+            ef_mmssmode: Option<File>,
+        ) -> Self {
+            Self {
+                telecom_header,
+                template_id,
+                df_telecom,
+                ef_arr,
+                ef_rma,
+                ef_sume,
+                ef_ice_dn,
+                ef_ice_ff,
+                ef_psismsc,
+                df_graphics,
+                ef_img,
+                ef_iidf,
+                ef_ice_graphics,
+                ef_launch_scws,
+                ef_icon,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+                df_multimedia,
+                ef_mml,
+                ef_mmdf,
+                df_mmss,
+                ef_mlpl,
+                ef_mspl,
+                ef_mmssmode,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-USIM")]
+    #[non_exhaustive]
+    pub struct PEUSIM {
+        #[rasn(identifier = "usim-header")]
+        pub usim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-usim")]
+        pub adf_usim: File,
+        #[rasn(identifier = "ef-imsi")]
+        pub ef_imsi: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-keys")]
+        pub ef_keys: Option<File>,
+        #[rasn(identifier = "ef-keysPS")]
+        pub ef_keys_ps: Option<File>,
+        #[rasn(identifier = "ef-hpplmn")]
+        pub ef_hpplmn: Option<File>,
+        #[rasn(identifier = "ef-ust")]
+        pub ef_ust: File,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: File,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: File,
+        #[rasn(identifier = "ef-start-hfn")]
+        pub ef_start_hfn: Option<File>,
+        #[rasn(identifier = "ef-threshold")]
+        pub ef_threshold: Option<File>,
+        #[rasn(identifier = "ef-psloci")]
+        pub ef_psloci: Option<File>,
+        #[rasn(identifier = "ef-acc")]
+        pub ef_acc: File,
+        #[rasn(identifier = "ef-fplmn")]
+        pub ef_fplmn: Option<File>,
+        #[rasn(identifier = "ef-loci")]
+        pub ef_loci: Option<File>,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: File,
+        #[rasn(identifier = "ef-netpar")]
+        pub ef_netpar: Option<File>,
+        #[rasn(identifier = "ef-epsloci")]
+        pub ef_epsloci: Option<File>,
+        #[rasn(identifier = "ef-epsnsc")]
+        pub ef_epsnsc: Option<File>,
+    }
+    impl PEUSIM {
+        pub fn new(
+            usim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_usim: File,
+            ef_imsi: File,
+            ef_arr: File,
+            ef_keys: Option<File>,
+            ef_keys_ps: Option<File>,
+            ef_hpplmn: Option<File>,
+            ef_ust: File,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_spn: File,
+            ef_est: File,
+            ef_start_hfn: Option<File>,
+            ef_threshold: Option<File>,
+            ef_psloci: Option<File>,
+            ef_acc: File,
+            ef_fplmn: Option<File>,
+            ef_loci: Option<File>,
+            ef_ad: Option<File>,
+            ef_ecc: File,
+            ef_netpar: Option<File>,
+            ef_epsloci: Option<File>,
+            ef_epsnsc: Option<File>,
+        ) -> Self {
+            Self {
+                usim_header,
+                template_id,
+                adf_usim,
+                ef_imsi,
+                ef_arr,
+                ef_keys,
+                ef_keys_ps,
+                ef_hpplmn,
+                ef_ust,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_spn,
+                ef_est,
+                ef_start_hfn,
+                ef_threshold,
+                ef_psloci,
+                ef_acc,
+                ef_fplmn,
+                ef_loci,
+                ef_ad,
+                ef_ecc,
+                ef_netpar,
+                ef_epsloci,
+                ef_epsnsc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEHeader {
+        pub mandated: Option<()>,
+        pub identification: UInt15,
+    }
+    impl PEHeader {
+        pub fn new(mandated: Option<()>, identification: UInt15) -> Self {
+            Self {
+                mandated,
+                identification,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEStatus {
+        pub status: Integer,
+        pub identification: Option<UInt15>,
+        #[rasn(identifier = "additional-information")]
+        pub additional_information: Option<UInt8>,
+        pub offset: Option<UInt31>,
+    }
+    impl PEStatus {
+        pub fn new(
+            status: Integer,
+            identification: Option<UInt15>,
+            additional_information: Option<UInt8>,
+            offset: Option<UInt31>,
+        ) -> Self {
+            Self {
+                status,
+                identification,
+                additional_information,
+                offset,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PINConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PINKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pinValue")]
+        pub pin_value: OctetString,
+        #[rasn(identifier = "unblockingPINReference")]
+        pub unblocking_pinreference: Option<PUKKeyReferenceValue>,
+        #[rasn(
+            default = "pinconfiguration_pin_attributes_default",
+            identifier = "pinAttributes"
+        )]
+        pub pin_attributes: UInt8,
+        #[rasn(
+            default = "pinconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PINConfiguration {
+        pub fn new(
+            key_reference: PINKeyReferenceValue,
+            pin_value: OctetString,
+            unblocking_pinreference: Option<PUKKeyReferenceValue>,
+            pin_attributes: UInt8,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                pin_value,
+                unblocking_pinreference,
+                pin_attributes,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pinconfiguration_pin_attributes_default() -> UInt8 {
+        UInt8(7)
+    }
+    fn pinconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(51)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PINKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PUKConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PUKKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pukValue")]
+        pub puk_value: OctetString,
+        #[rasn(
+            default = "pukconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PUKConfiguration {
+        pub fn new(
+            key_reference: PUKKeyReferenceValue,
+            puk_value: OctetString,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                puk_value,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pukconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(170)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PUKKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ProfileElement {
+        header(ProfileHeader),
+        genericFileManagement(PEGenericFileManagement),
+        pinCodes(PEPINCodes),
+        pukCodes(PEPUKCodes),
+        akaParameter(PEAKAParameter),
+        cdmaParameter(PECDMAParameter),
+        securityDomain(PESecurityDomain),
+        rfm(PERFM),
+        application(PEApplication),
+        nonStandard(PENonStandard),
+        end(PEEnd),
+        rfu1(PEDummy),
+        rfu2(PEDummy),
+        rfu3(PEDummy),
+        rfu4(PEDummy),
+        rfu5(PEDummy),
+        mf(PEMF),
+        cd(PECD),
+        telecom(PETELECOM),
+        usim(PEUSIM),
+        #[rasn(identifier = "opt-usim")]
+        opt_usim(PEOPTUSIM),
+        isim(PEISIM),
+        #[rasn(identifier = "opt-isim")]
+        opt_isim(PEOPTISIM),
+        phonebook(PEPHONEBOOK),
+        #[rasn(identifier = "gsm-access")]
+        gsm_access(PEGSMACCESS),
+        csim(PECSIM),
+        #[rasn(identifier = "opt-csim")]
+        opt_csim(PEOPTCSIM),
+        eap(PEEAP),
+        #[rasn(identifier = "df-5gs")]
+        df_5gs(PEDF5GS),
+        #[rasn(identifier = "df-saip")]
+        df_saip(PEDFSAIP),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub aid: ApplicationIdentifier,
+        #[rasn(size("2"))]
+        pub version: OctetString,
+    }
+    impl AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub fn new(aid: ApplicationIdentifier, version: OctetString) -> Self {
+            Self { aid, version }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ProfileHeaderEUICCMandatoryAIDs(
+        pub SequenceOf<AnonymousProfileHeaderEUICCMandatoryAIDs>,
+    );
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ProfileHeader {
+        #[rasn(identifier = "major-version")]
+        pub major_version: UInt8,
+        #[rasn(identifier = "minor-version")]
+        pub minor_version: UInt8,
+        #[rasn(identifier = "profileType")]
+        pub profile_type: Option<Utf8String>,
+        #[rasn(size("10"))]
+        pub iccid: OctetString,
+        pub pol: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-services")]
+        pub e_uicc_mandatory_services: ServicesList,
+        #[rasn(identifier = "eUICC-Mandatory-GFSTEList")]
+        pub e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+        #[rasn(identifier = "connectivityParameters")]
+        pub connectivity_parameters: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-AIDs")]
+        pub e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+    }
+    impl ProfileHeader {
+        pub fn new(
+            major_version: UInt8,
+            minor_version: UInt8,
+            profile_type: Option<Utf8String>,
+            iccid: OctetString,
+            pol: Option<OctetString>,
+            e_uicc_mandatory_services: ServicesList,
+            e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+            connectivity_parameters: Option<OctetString>,
+            e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+        ) -> Self {
+            Self {
+                major_version,
+                minor_version,
+                profile_type,
+                iccid,
+                pol,
+                e_uicc_mandatory_services,
+                e_uicc_mandatory_gfstelist,
+                connectivity_parameters,
+                e_uicc_mandatory_aids,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ProprietaryInfo {
+        #[rasn(
+            size("1"),
+            tag(private, 0),
+            default = "proprietary_info_special_file_information_default",
+            identifier = "specialFileInformation"
+        )]
+        pub special_file_information: OctetString,
+        #[rasn(size("1..=200"), tag(private, 1), identifier = "fillPattern")]
+        pub fill_pattern: Option<OctetString>,
+        #[rasn(size("1..=200"), tag(private, 2), identifier = "repeatPattern")]
+        pub repeat_pattern: Option<OctetString>,
+    }
+    impl ProprietaryInfo {
+        pub fn new(
+            special_file_information: OctetString,
+            fill_pattern: Option<OctetString>,
+            repeat_pattern: Option<OctetString>,
+        ) -> Self {
+            Self {
+                special_file_information,
+                fill_pattern,
+                repeat_pattern,
+            }
+        }
+    }
+    fn proprietary_info_special_file_information_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ServicesList {
+        pub contactless: Option<()>,
+        pub usim: Option<()>,
+        pub isim: Option<()>,
+        pub csim: Option<()>,
+        pub milenage: Option<()>,
+        pub tuak128: Option<()>,
+        pub cave: Option<()>,
+        #[rasn(identifier = "gba-usim")]
+        pub gba_usim: Option<()>,
+        #[rasn(identifier = "gba-isim")]
+        pub gba_isim: Option<()>,
+        pub mbms: Option<()>,
+        pub eap: Option<()>,
+        pub javacard: Option<()>,
+        pub multos: Option<()>,
+        #[rasn(identifier = "multiple-usim")]
+        pub multiple_usim: Option<()>,
+        #[rasn(identifier = "multiple-isim")]
+        pub multiple_isim: Option<()>,
+        #[rasn(identifier = "multiple-csim")]
+        pub multiple_csim: Option<()>,
+        pub tuak256: Option<()>,
+        #[rasn(identifier = "usim-test-algorithm")]
+        pub usim_test_algorithm: Option<()>,
+        #[rasn(identifier = "ber-tlv")]
+        pub ber_tlv: Option<()>,
+        #[rasn(identifier = "dfLink")]
+        pub df_link: Option<()>,
+        #[rasn(identifier = "cat-tp")]
+        pub cat_tp: Option<()>,
+        #[rasn(identifier = "get-identity")]
+        pub get_identity: Option<()>,
+        #[rasn(identifier = "profile-a-x25519")]
+        pub profile_a_x25519: Option<()>,
+        #[rasn(identifier = "profile-b-p256")]
+        pub profile_b_p256: Option<()>,
+    }
+    impl ServicesList {
+        pub fn new(
+            contactless: Option<()>,
+            usim: Option<()>,
+            isim: Option<()>,
+            csim: Option<()>,
+            milenage: Option<()>,
+            tuak128: Option<()>,
+            cave: Option<()>,
+            gba_usim: Option<()>,
+            gba_isim: Option<()>,
+            mbms: Option<()>,
+            eap: Option<()>,
+            javacard: Option<()>,
+            multos: Option<()>,
+            multiple_usim: Option<()>,
+            multiple_isim: Option<()>,
+            multiple_csim: Option<()>,
+            tuak256: Option<()>,
+            usim_test_algorithm: Option<()>,
+            ber_tlv: Option<()>,
+            df_link: Option<()>,
+            cat_tp: Option<()>,
+            get_identity: Option<()>,
+            profile_a_x25519: Option<()>,
+            profile_b_p256: Option<()>,
+        ) -> Self {
+            Self {
+                contactless,
+                usim,
+                isim,
+                csim,
+                milenage,
+                tuak128,
+                cave,
+                gba_usim,
+                gba_isim,
+                mbms,
+                eap,
+                javacard,
+                multos,
+                multiple_usim,
+                multiple_isim,
+                multiple_csim,
+                tuak256,
+                usim_test_algorithm,
+                ber_tlv,
+                df_link,
+                cat_tp,
+                get_identity,
+                profile_a_x25519,
+                profile_b_p256,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TS102226AdditionalContactlessParameters {
+        #[rasn(identifier = "protocolParameterData")]
+        pub protocol_parameter_data: OctetString,
+    }
+    impl TS102226AdditionalContactlessParameters {
+        pub fn new(protocol_parameter_data: OctetString) -> Self {
+            Self {
+                protocol_parameter_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct UICCApplicationParameters {
+        #[rasn(
+            tag(context, 0),
+            identifier = "uiccToolkitApplicationSpecificParametersField"
+        )]
+        pub uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 1),
+            identifier = "uiccAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_access_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 2),
+            identifier = "uiccAdministrativeAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+    }
+    impl UICCApplicationParameters {
+        pub fn new(
+            uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+            uicc_access_application_specific_parameters_field: Option<OctetString>,
+            uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+        ) -> Self {
+            Self {
+                uicc_toolkit_application_specific_parameters_field,
+                uicc_access_application_specific_parameters_field,
+                uicc_administrative_access_application_specific_parameters_field,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=32767"))]
+    pub struct UInt15(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct UInt16(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=2147483647"))]
+    pub struct UInt31(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct UInt8(pub u8);
+    pub static MAX_UINT15: LazyLock<Integer> = LazyLock::new(|| Integer::from(32767i128));
+    pub static MAX_UINT16: LazyLock<Integer> = LazyLock::new(|| Integer::from(65535i128));
+    pub static MAX_UINT31: LazyLock<Integer> = LazyLock::new(|| Integer::from(2147483647i128));
+    #[doc = " Basic integer types, for size constraints"]
+    pub static MAX_UINT8: LazyLock<Integer> = LazyLock::new(|| Integer::from(255i128));
+}

--- a/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@tca_PEDefinitions_v3.4.1.asn1.snap
+++ b/rasn-compiler-tests/tests/snapshots/parse_test__parses_modules@tca_PEDefinitions_v3.4.1.asn1.snap
@@ -1,0 +1,3561 @@
+---
+source: rasn-compiler-tests/tests/parse_test.rs
+input_file: rasn-compiler-tests/tests/modules/tca_PEDefinitions_v3.4.1.asn1
+---
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod pedefinitions {
+    extern crate alloc;
+    use super::pkix1_explicit88::Certificate;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ADFRFMAccess {
+        #[rasn(identifier = "adfAID")]
+        pub adf_aid: ApplicationIdentifier,
+        #[rasn(identifier = "adfAccessDomain")]
+        pub adf_access_domain: OctetString,
+        #[rasn(identifier = "adfAdminAccessDomain")]
+        pub adf_admin_access_domain: OctetString,
+    }
+    impl ADFRFMAccess {
+        pub fn new(
+            adf_aid: ApplicationIdentifier,
+            adf_access_domain: OctetString,
+            adf_admin_access_domain: OctetString,
+        ) -> Self {
+            Self {
+                adf_aid,
+                adf_access_domain,
+                adf_admin_access_domain,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct AlgoParameter {
+        #[rasn(identifier = "algorithmID")]
+        pub algorithm_id: Integer,
+        #[rasn(size("1"), identifier = "algorithmOptions")]
+        pub algorithm_options: OctetString,
+        pub key: OctetString,
+        pub opc: OctetString,
+        #[rasn(
+            size("5"),
+            default = "algo_parameter_rotation_constants_default",
+            identifier = "rotationConstants"
+        )]
+        pub rotation_constants: OctetString,
+        #[rasn(
+            size("80"),
+            default = "algo_parameter_xoring_constants_default",
+            identifier = "xoringConstants"
+        )]
+        pub xoring_constants: OctetString,
+        #[rasn(size("3"), identifier = "authCounterMax")]
+        pub auth_counter_max: Option<OctetString>,
+        #[rasn(
+            default = "algo_parameter_number_of_keccak_default",
+            identifier = "numberOfKeccak"
+        )]
+        pub number_of_keccak: UInt8,
+    }
+    impl AlgoParameter {
+        pub fn new(
+            algorithm_id: Integer,
+            algorithm_options: OctetString,
+            key: OctetString,
+            opc: OctetString,
+            rotation_constants: OctetString,
+            xoring_constants: OctetString,
+            auth_counter_max: Option<OctetString>,
+            number_of_keccak: UInt8,
+        ) -> Self {
+            Self {
+                algorithm_id,
+                algorithm_options,
+                key,
+                opc,
+                rotation_constants,
+                xoring_constants,
+                auth_counter_max,
+                number_of_keccak,
+            }
+        }
+    }
+    fn algo_parameter_rotation_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[64, 0, 32, 64, 96])
+    }
+    fn algo_parameter_xoring_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8,
+        ])
+    }
+    fn algo_parameter_number_of_keccak_default() -> UInt8 {
+        UInt8(1)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("5..=16"))]
+    pub struct ApplicationIdentifier(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationInstance {
+        #[rasn(tag(application, 15), identifier = "applicationLoadPackageAID")]
+        pub application_load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "classAID")]
+        pub class_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "extraditeSecurityDomainAID")]
+        pub extradite_security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 2), identifier = "applicationPrivileges")]
+        pub application_privileges: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 3),
+            default = "application_instance_life_cycle_state_default",
+            identifier = "lifeCycleState"
+        )]
+        pub life_cycle_state: OctetString,
+        #[rasn(tag(private, 9), identifier = "applicationSpecificParametersC9")]
+        pub application_specific_parameters_c9: OctetString,
+        #[rasn(tag(private, 15), identifier = "systemSpecificParameters")]
+        pub system_specific_parameters: Option<ApplicationSystemParameters>,
+        #[rasn(tag(private, 10), identifier = "applicationParameters")]
+        pub application_parameters: Option<UICCApplicationParameters>,
+        #[rasn(size("1.."), identifier = "processData")]
+        pub process_data: Option<SequenceOf<OctetString>>,
+        #[rasn(tag(context, 16), identifier = "controlReferenceTemplate")]
+        pub control_reference_template: Option<ControlReferenceTemplate>,
+    }
+    impl ApplicationInstance {
+        pub fn new(
+            application_load_package_aid: ApplicationIdentifier,
+            class_aid: ApplicationIdentifier,
+            instance_aid: ApplicationIdentifier,
+            extradite_security_domain_aid: Option<ApplicationIdentifier>,
+            application_privileges: OctetString,
+            life_cycle_state: OctetString,
+            application_specific_parameters_c9: OctetString,
+            system_specific_parameters: Option<ApplicationSystemParameters>,
+            application_parameters: Option<UICCApplicationParameters>,
+            process_data: Option<SequenceOf<OctetString>>,
+            control_reference_template: Option<ControlReferenceTemplate>,
+        ) -> Self {
+            Self {
+                application_load_package_aid,
+                class_aid,
+                instance_aid,
+                extradite_security_domain_aid,
+                application_privileges,
+                life_cycle_state,
+                application_specific_parameters_c9,
+                system_specific_parameters,
+                application_parameters,
+                process_data,
+                control_reference_template,
+            }
+        }
+    }
+    fn application_instance_life_cycle_state_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[7])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationLoadPackage {
+        #[rasn(tag(application, 15), identifier = "loadPackageAID")]
+        pub load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(private, 6), identifier = "nonVolatileCodeLimitC6")]
+        pub non_volatile_code_limit_c6: Option<OctetString>,
+        #[rasn(tag(private, 7), identifier = "volatileDataLimitC7")]
+        pub volatile_data_limit_c7: Option<OctetString>,
+        #[rasn(tag(private, 8), identifier = "nonVolatileDataLimitC8")]
+        pub non_volatile_data_limit_c8: Option<OctetString>,
+        #[rasn(tag(private, 1), identifier = "hashValue")]
+        pub hash_value: Option<OctetString>,
+        #[rasn(tag(private, 4), identifier = "loadBlockObject")]
+        pub load_block_object: OctetString,
+    }
+    impl ApplicationLoadPackage {
+        pub fn new(
+            load_package_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            non_volatile_code_limit_c6: Option<OctetString>,
+            volatile_data_limit_c7: Option<OctetString>,
+            non_volatile_data_limit_c8: Option<OctetString>,
+            hash_value: Option<OctetString>,
+            load_block_object: OctetString,
+        ) -> Self {
+            Self {
+                load_package_aid,
+                security_domain_aid,
+                non_volatile_code_limit_c6,
+                volatile_data_limit_c7,
+                non_volatile_data_limit_c8,
+                hash_value,
+                load_block_object,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationSystemParameters {
+        #[rasn(size("2..=4"), tag(private, 7), identifier = "volatileMemoryQuotaC7")]
+        pub volatile_memory_quota_c7: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 8),
+            identifier = "nonVolatileMemoryQuotaC8"
+        )]
+        pub non_volatile_memory_quota_c8: Option<OctetString>,
+        #[rasn(tag(private, 11), identifier = "globalServiceParameters")]
+        pub global_service_parameters: Option<OctetString>,
+        #[rasn(tag(private, 15), identifier = "implicitSelectionParameter")]
+        pub implicit_selection_parameter: Option<OctetString>,
+        #[rasn(size("2..=4"), tag(private, 23), identifier = "volatileReservedMemory")]
+        pub volatile_reserved_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 24),
+            identifier = "nonVolatileReservedMemory"
+        )]
+        pub non_volatile_reserved_memory: Option<OctetString>,
+        #[rasn(tag(private, 10), identifier = "ts102226SIMFileAccessToolkitParameter")]
+        pub ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+        #[rasn(
+            tag(context, 0),
+            identifier = "ts102226AdditionalContactlessParameters"
+        )]
+        pub ts102226_additional_contactless_parameters:
+            Option<TS102226AdditionalContactlessParameters>,
+        #[rasn(tag(private, 25), identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+        #[rasn(tag(private, 26), identifier = "userInteractionContactlessParameters")]
+        pub user_interaction_contactless_parameters: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 2),
+            identifier = "cumulativeGrantedVolatileMemory"
+        )]
+        pub cumulative_granted_volatile_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 3),
+            identifier = "cumulativeGrantedNonVolatileMemory"
+        )]
+        pub cumulative_granted_non_volatile_memory: Option<OctetString>,
+    }
+    impl ApplicationSystemParameters {
+        pub fn new(
+            volatile_memory_quota_c7: Option<OctetString>,
+            non_volatile_memory_quota_c8: Option<OctetString>,
+            global_service_parameters: Option<OctetString>,
+            implicit_selection_parameter: Option<OctetString>,
+            volatile_reserved_memory: Option<OctetString>,
+            non_volatile_reserved_memory: Option<OctetString>,
+            ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+            ts102226_additional_contactless_parameters: Option<
+                TS102226AdditionalContactlessParameters,
+            >,
+            contactless_protocol_parameters: Option<OctetString>,
+            user_interaction_contactless_parameters: Option<OctetString>,
+            cumulative_granted_volatile_memory: Option<OctetString>,
+            cumulative_granted_non_volatile_memory: Option<OctetString>,
+        ) -> Self {
+            Self {
+                volatile_memory_quota_c7,
+                non_volatile_memory_quota_c8,
+                global_service_parameters,
+                implicit_selection_parameter,
+                volatile_reserved_memory,
+                non_volatile_reserved_memory,
+                ts102226_simfile_access_toolkit_parameter,
+                ts102226_additional_contactless_parameters,
+                contactless_protocol_parameters,
+                user_interaction_contactless_parameters,
+                cumulative_granted_volatile_memory,
+                cumulative_granted_non_volatile_memory,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ControlReferenceTemplate {
+        #[rasn(tag(application, 32), identifier = "applicationProviderIdentifier")]
+        pub application_provider_identifier: OctetString,
+    }
+    impl ControlReferenceTemplate {
+        pub fn new(application_provider_identifier: OctetString) -> Self {
+            Self {
+                application_provider_identifier,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct EUICCResponse {
+        #[rasn(identifier = "peStatus")]
+        pub pe_status: SequenceOf<PEStatus>,
+        #[rasn(identifier = "profileInstallationAborted")]
+        pub profile_installation_aborted: Option<()>,
+        #[rasn(identifier = "statusMessage")]
+        pub status_message: Option<Utf8String>,
+    }
+    impl EUICCResponse {
+        pub fn new(
+            pe_status: SequenceOf<PEStatus>,
+            profile_installation_aborted: Option<()>,
+            status_message: Option<Utf8String>,
+        ) -> Self {
+            Self {
+                pe_status,
+                profile_installation_aborted,
+                status_message,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct Fcp {
+        #[rasn(size("2..=4"), tag(context, 2), identifier = "fileDescriptor")]
+        pub file_descriptor: Option<OctetString>,
+        #[rasn(size("2"), tag(context, 3), identifier = "fileID")]
+        pub file_id: Option<OctetString>,
+        #[rasn(tag(context, 4), identifier = "dfName")]
+        pub df_name: Option<ApplicationIdentifier>,
+        #[rasn(size("1"), tag(context, 10), default = "fcp_lcsi_default")]
+        pub lcsi: OctetString,
+        #[rasn(
+            size("1..=3"),
+            tag(context, 11),
+            identifier = "securityAttributesReferenced"
+        )]
+        pub security_attributes_referenced: Option<OctetString>,
+        #[rasn(tag(context, 0), identifier = "efFileSize")]
+        pub ef_file_size: Option<OctetString>,
+        #[rasn(tag(private, 6), identifier = "pinStatusTemplateDO")]
+        pub pin_status_template_do: Option<OctetString>,
+        #[rasn(size("0..=1"), tag(context, 8), identifier = "shortEFID")]
+        pub short_efid: Option<OctetString>,
+        #[rasn(tag(context, 5), identifier = "proprietaryEFInfo")]
+        pub proprietary_efinfo: Option<ProprietaryInfo>,
+        #[rasn(size("0..=8"), tag(private, 7), identifier = "linkPath")]
+        pub link_path: Option<OctetString>,
+    }
+    impl Fcp {
+        pub fn new(
+            file_descriptor: Option<OctetString>,
+            file_id: Option<OctetString>,
+            df_name: Option<ApplicationIdentifier>,
+            lcsi: OctetString,
+            security_attributes_referenced: Option<OctetString>,
+            ef_file_size: Option<OctetString>,
+            pin_status_template_do: Option<OctetString>,
+            short_efid: Option<OctetString>,
+            proprietary_efinfo: Option<ProprietaryInfo>,
+            link_path: Option<OctetString>,
+        ) -> Self {
+            Self {
+                file_descriptor,
+                file_id,
+                df_name,
+                lcsi,
+                security_attributes_referenced,
+                ef_file_size,
+                pin_status_template_do,
+                short_efid,
+                proprietary_efinfo,
+                link_path,
+            }
+        }
+    }
+    fn fcp_lcsi_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[5])
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFile {
+        doNotCreate(()),
+        fileDescriptor(Fcp),
+        fillFileOffset(UInt16),
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct File(pub SequenceOf<AnonymousFile>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFileManagement {
+        #[rasn(size("0..=8"), tag(context, 0))]
+        filePath(OctetString),
+        #[rasn(tag(application, 2))]
+        createFCP(Fcp),
+        fillFileOffset(UInt16),
+        #[rasn(tag(context, 1))]
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct FileManagement(pub SequenceOf<AnonymousFileManagement>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct IotOptions {
+        #[rasn(size("7..=11"))]
+        pub pix: OctetString,
+    }
+    impl IotOptions {
+        pub fn new(pix: OctetString) -> Self {
+            Self { pix }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousKeyObjectKeyCompontents {
+        #[rasn(tag(context, 0), identifier = "keyType")]
+        pub key_type: OctetString,
+        #[rasn(tag(context, 6), identifier = "keyData")]
+        pub key_data: OctetString,
+        #[rasn(
+            tag(context, 7),
+            default = "anonymous_key_object_key_compontents_mac_length_default",
+            identifier = "macLength"
+        )]
+        pub mac_length: UInt8,
+    }
+    impl AnonymousKeyObjectKeyCompontents {
+        pub fn new(key_type: OctetString, key_data: OctetString, mac_length: UInt8) -> Self {
+            Self {
+                key_type,
+                key_data,
+                mac_length,
+            }
+        }
+    }
+    fn anonymous_key_object_key_compontents_mac_length_default() -> UInt8 {
+        UInt8(8)
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct KeyObjectKeyCompontents(pub SequenceOf<AnonymousKeyObjectKeyCompontents>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct KeyObject {
+        #[rasn(size("1..=2"), tag(context, 21), identifier = "keyUsageQualifier")]
+        pub key_usage_qualifier: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 22),
+            default = "key_object_key_access_default",
+            identifier = "keyAccess"
+        )]
+        pub key_access: OctetString,
+        #[rasn(size("1"), tag(context, 2), identifier = "keyIdentifier")]
+        pub key_identifier: OctetString,
+        #[rasn(size("1"), tag(context, 3), identifier = "keyVersionNumber")]
+        pub key_version_number: OctetString,
+        #[rasn(tag(context, 5), identifier = "keyCounterValue")]
+        pub key_counter_value: Option<OctetString>,
+        #[rasn(identifier = "keyCompontents")]
+        pub key_compontents: KeyObjectKeyCompontents,
+    }
+    impl KeyObject {
+        pub fn new(
+            key_usage_qualifier: OctetString,
+            key_access: OctetString,
+            key_identifier: OctetString,
+            key_version_number: OctetString,
+            key_counter_value: Option<OctetString>,
+            key_compontents: KeyObjectKeyCompontents,
+        ) -> Self {
+            Self {
+                key_usage_qualifier,
+                key_access,
+                key_identifier,
+                key_version_number,
+                key_counter_value,
+                key_compontents,
+            }
+        }
+    }
+    fn key_object_key_access_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MappingParameter {
+        #[rasn(size("1"), identifier = "mappingOptions")]
+        pub mapping_options: OctetString,
+        #[rasn(identifier = "mappingSource")]
+        pub mapping_source: ApplicationIdentifier,
+    }
+    impl MappingParameter {
+        pub fn new(mapping_options: OctetString, mapping_source: ApplicationIdentifier) -> Self {
+            Self {
+                mapping_options,
+                mapping_source,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEAKAParameterAlgoConfiguration {
+        mappingParameter(MappingParameter),
+        algoParameter(AlgoParameter),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPEAKAParameterSqnInit(pub FixedOctetString<6usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("32"))]
+    pub struct PEAKAParameterSqnInit(pub SequenceOf<AnonymousPEAKAParameterSqnInit>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPEAKAParameterSsimParametersKeyDerivationFunctions(
+        pub FixedOctetString<1usize>,
+    );
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PEAKAParameterSsimParametersKeyDerivationFunctions(
+        pub SequenceOf<AnonymousPEAKAParameterSsimParametersKeyDerivationFunctions>,
+    );
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEAKAParameterSsimParameters {
+        #[rasn(identifier = "networkName")]
+        pub network_name: Option<Utf8String>,
+        #[rasn(
+            default = "peakaparameter_ssim_parameters_key_derivation_functions_default",
+            identifier = "keyDerivationFunctions"
+        )]
+        pub key_derivation_functions: PEAKAParameterSsimParametersKeyDerivationFunctions,
+    }
+    impl PEAKAParameterSsimParameters {
+        pub fn new(
+            network_name: Option<Utf8String>,
+            key_derivation_functions: PEAKAParameterSsimParametersKeyDerivationFunctions,
+        ) -> Self {
+            Self {
+                network_name,
+                key_derivation_functions,
+            }
+        }
+    }
+    fn peakaparameter_ssim_parameters_key_derivation_functions_default(
+    ) -> PEAKAParameterSsimParametersKeyDerivationFunctions {
+        PEAKAParameterSsimParametersKeyDerivationFunctions(alloc::vec![
+            AnonymousPEAKAParameterSsimParametersKeyDerivationFunctions(FixedOctetString::new([
+                1u8
+            ]))
+        ])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-AKAParameter")]
+    #[non_exhaustive]
+    pub struct PEAKAParameter {
+        #[rasn(identifier = "aka-header")]
+        pub aka_header: PEHeader,
+        #[rasn(identifier = "algoConfiguration")]
+        pub algo_configuration: PEAKAParameterAlgoConfiguration,
+        #[rasn(
+            size("1"),
+            default = "peakaparameter_sqn_options_default",
+            identifier = "sqnOptions"
+        )]
+        pub sqn_options: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_delta_default",
+            identifier = "sqnDelta"
+        )]
+        pub sqn_delta: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_age_limit_default",
+            identifier = "sqnAgeLimit"
+        )]
+        pub sqn_age_limit: OctetString,
+        #[rasn(default = "peakaparameter_sqn_init_default", identifier = "sqnInit")]
+        pub sqn_init: PEAKAParameterSqnInit,
+        #[rasn(identifier = "ssimParameters")]
+        pub ssim_parameters: Option<PEAKAParameterSsimParameters>,
+    }
+    impl PEAKAParameter {
+        pub fn new(
+            aka_header: PEHeader,
+            algo_configuration: PEAKAParameterAlgoConfiguration,
+            sqn_options: OctetString,
+            sqn_delta: OctetString,
+            sqn_age_limit: OctetString,
+            sqn_init: PEAKAParameterSqnInit,
+            ssim_parameters: Option<PEAKAParameterSsimParameters>,
+        ) -> Self {
+            Self {
+                aka_header,
+                algo_configuration,
+                sqn_options,
+                sqn_delta,
+                sqn_age_limit,
+                sqn_init,
+                ssim_parameters,
+            }
+        }
+    }
+    fn peakaparameter_sqn_options_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[2])
+    }
+    fn peakaparameter_sqn_delta_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_age_limit_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_init_default() -> PEAKAParameterSqnInit {
+        PEAKAParameterSqnInit(alloc::vec![
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8]))
+        ])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Application")]
+    #[non_exhaustive]
+    pub struct PEApplication {
+        #[rasn(identifier = "app-Header")]
+        pub app_header: PEHeader,
+        #[rasn(identifier = "loadBlock")]
+        pub load_block: Option<ApplicationLoadPackage>,
+        #[rasn(size("1.."), identifier = "instanceList")]
+        pub instance_list: Option<SequenceOf<ApplicationInstance>>,
+    }
+    impl PEApplication {
+        pub fn new(
+            app_header: PEHeader,
+            load_block: Option<ApplicationLoadPackage>,
+            instance_list: Option<SequenceOf<ApplicationInstance>>,
+        ) -> Self {
+            Self {
+                app_header,
+                load_block,
+                instance_list,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CD")]
+    #[non_exhaustive]
+    pub struct PECD {
+        #[rasn(identifier = "cd-header")]
+        pub cd_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-cd")]
+        pub df_cd: File,
+        #[rasn(identifier = "ef-launchpad")]
+        pub ef_launchpad: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+    }
+    impl PECD {
+        pub fn new(
+            cd_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_cd: File,
+            ef_launchpad: Option<File>,
+            ef_icon: Option<File>,
+        ) -> Self {
+            Self {
+                cd_header,
+                template_id,
+                df_cd,
+                ef_launchpad,
+                ef_icon,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CDMAParameter")]
+    #[non_exhaustive]
+    pub struct PECDMAParameter {
+        #[rasn(identifier = "cdma-header")]
+        pub cdma_header: PEHeader,
+        #[rasn(size("8"), identifier = "authenticationKey")]
+        pub authentication_key: OctetString,
+        #[rasn(size("16"))]
+        pub ssd: Option<OctetString>,
+        #[rasn(size("2..=32"), identifier = "hrpdAccessAuthenticationData")]
+        pub hrpd_access_authentication_data: Option<OctetString>,
+        #[rasn(size("3..=483"), identifier = "simpleIPAuthenticationData")]
+        pub simple_ipauthentication_data: Option<OctetString>,
+        #[rasn(size("5..=957"), identifier = "mobileIPAuthenticationData")]
+        pub mobile_ipauthentication_data: Option<OctetString>,
+    }
+    impl PECDMAParameter {
+        pub fn new(
+            cdma_header: PEHeader,
+            authentication_key: OctetString,
+            ssd: Option<OctetString>,
+            hrpd_access_authentication_data: Option<OctetString>,
+            simple_ipauthentication_data: Option<OctetString>,
+            mobile_ipauthentication_data: Option<OctetString>,
+        ) -> Self {
+            Self {
+                cdma_header,
+                authentication_key,
+                ssd,
+                hrpd_access_authentication_data,
+                simple_ipauthentication_data,
+                mobile_ipauthentication_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CSIM")]
+    #[non_exhaustive]
+    pub struct PECSIM {
+        #[rasn(identifier = "csim-header")]
+        pub csim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-csim")]
+        pub adf_csim: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-call-count")]
+        pub ef_call_count: File,
+        #[rasn(identifier = "ef-imsi-m")]
+        pub ef_imsi_m: File,
+        #[rasn(identifier = "ef-imsi-t")]
+        pub ef_imsi_t: File,
+        #[rasn(identifier = "ef-tmsi")]
+        pub ef_tmsi: File,
+        #[rasn(identifier = "ef-ah")]
+        pub ef_ah: File,
+        #[rasn(identifier = "ef-aop")]
+        pub ef_aop: File,
+        #[rasn(identifier = "ef-aloc")]
+        pub ef_aloc: File,
+        #[rasn(identifier = "ef-cdmahome")]
+        pub ef_cdmahome: File,
+        #[rasn(identifier = "ef-znregi")]
+        pub ef_znregi: File,
+        #[rasn(identifier = "ef-snregi")]
+        pub ef_snregi: File,
+        #[rasn(identifier = "ef-distregi")]
+        pub ef_distregi: File,
+        #[rasn(identifier = "ef-accolc")]
+        pub ef_accolc: File,
+        #[rasn(identifier = "ef-term")]
+        pub ef_term: File,
+        #[rasn(identifier = "ef-acp")]
+        pub ef_acp: File,
+        #[rasn(identifier = "ef-prl")]
+        pub ef_prl: File,
+        #[rasn(identifier = "ef-ruimid")]
+        pub ef_ruimid: File,
+        #[rasn(identifier = "ef-csim-st")]
+        pub ef_csim_st: File,
+        #[rasn(identifier = "ef-spc")]
+        pub ef_spc: File,
+        #[rasn(identifier = "ef-otapaspc")]
+        pub ef_otapaspc: File,
+        #[rasn(identifier = "ef-namlock")]
+        pub ef_namlock: File,
+        #[rasn(identifier = "ef-ota")]
+        pub ef_ota: File,
+        #[rasn(identifier = "ef-sp")]
+        pub ef_sp: File,
+        #[rasn(identifier = "ef-esn-meid-me")]
+        pub ef_esn_meid_me: File,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: File,
+        #[rasn(identifier = "ef-usgind")]
+        pub ef_usgind: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: File,
+        #[rasn(identifier = "ef-max-prl")]
+        pub ef_max_prl: File,
+        #[rasn(identifier = "ef-spcs")]
+        pub ef_spcs: File,
+        #[rasn(identifier = "ef-mecrp")]
+        pub ef_mecrp: File,
+        #[rasn(identifier = "ef-home-tag")]
+        pub ef_home_tag: File,
+        #[rasn(identifier = "ef-group-tag")]
+        pub ef_group_tag: File,
+        #[rasn(identifier = "ef-specific-tag")]
+        pub ef_specific_tag: File,
+        #[rasn(identifier = "ef-call-prompt")]
+        pub ef_call_prompt: File,
+    }
+    impl PECSIM {
+        pub fn new(
+            csim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_csim: File,
+            ef_arr: File,
+            ef_call_count: File,
+            ef_imsi_m: File,
+            ef_imsi_t: File,
+            ef_tmsi: File,
+            ef_ah: File,
+            ef_aop: File,
+            ef_aloc: File,
+            ef_cdmahome: File,
+            ef_znregi: File,
+            ef_snregi: File,
+            ef_distregi: File,
+            ef_accolc: File,
+            ef_term: File,
+            ef_acp: File,
+            ef_prl: File,
+            ef_ruimid: File,
+            ef_csim_st: File,
+            ef_spc: File,
+            ef_otapaspc: File,
+            ef_namlock: File,
+            ef_ota: File,
+            ef_sp: File,
+            ef_esn_meid_me: File,
+            ef_li: File,
+            ef_usgind: File,
+            ef_ad: File,
+            ef_max_prl: File,
+            ef_spcs: File,
+            ef_mecrp: File,
+            ef_home_tag: File,
+            ef_group_tag: File,
+            ef_specific_tag: File,
+            ef_call_prompt: File,
+        ) -> Self {
+            Self {
+                csim_header,
+                template_id,
+                adf_csim,
+                ef_arr,
+                ef_call_count,
+                ef_imsi_m,
+                ef_imsi_t,
+                ef_tmsi,
+                ef_ah,
+                ef_aop,
+                ef_aloc,
+                ef_cdmahome,
+                ef_znregi,
+                ef_snregi,
+                ef_distregi,
+                ef_accolc,
+                ef_term,
+                ef_acp,
+                ef_prl,
+                ef_ruimid,
+                ef_csim_st,
+                ef_spc,
+                ef_otapaspc,
+                ef_namlock,
+                ef_ota,
+                ef_sp,
+                ef_esn_meid_me,
+                ef_li,
+                ef_usgind,
+                ef_ad,
+                ef_max_prl,
+                ef_spcs,
+                ef_mecrp,
+                ef_home_tag,
+                ef_group_tag,
+                ef_specific_tag,
+                ef_call_prompt,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-5GPROSE")]
+    #[non_exhaustive]
+    pub struct PEDF5GPROSE {
+        #[rasn(identifier = "df-5g-prose-header")]
+        pub df_5g_prose_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-5g-prose")]
+        pub df_df_5g_prose: File,
+        #[rasn(identifier = "ef-5g-prose-st")]
+        pub ef_5g_prose_st: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-dd")]
+        pub ef_5g_prose_dd: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-dc")]
+        pub ef_5g_prose_dc: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-u2nru")]
+        pub ef_5g_prose_u2nru: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-ru")]
+        pub ef_5g_prose_ru: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-uir")]
+        pub ef_5g_prose_uir: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-u2uru")]
+        pub ef_5g_prose_u2uru: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-eu")]
+        pub ef_5g_prose_eu: Option<File>,
+    }
+    impl PEDF5GPROSE {
+        pub fn new(
+            df_5g_prose_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_5g_prose: File,
+            ef_5g_prose_st: Option<File>,
+            ef_5g_prose_dd: Option<File>,
+            ef_5g_prose_dc: Option<File>,
+            ef_5g_prose_u2nru: Option<File>,
+            ef_5g_prose_ru: Option<File>,
+            ef_5g_prose_uir: Option<File>,
+            ef_5g_prose_u2uru: Option<File>,
+            ef_5g_prose_eu: Option<File>,
+        ) -> Self {
+            Self {
+                df_5g_prose_header,
+                template_id,
+                df_df_5g_prose,
+                ef_5g_prose_st,
+                ef_5g_prose_dd,
+                ef_5g_prose_dc,
+                ef_5g_prose_u2nru,
+                ef_5g_prose_ru,
+                ef_5g_prose_uir,
+                ef_5g_prose_u2uru,
+                ef_5g_prose_eu,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-5GS")]
+    #[non_exhaustive]
+    pub struct PEDF5GS {
+        #[rasn(identifier = "df-5gs-header")]
+        pub df_5gs_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-5gs")]
+        pub df_df_5gs: File,
+        #[rasn(identifier = "ef-5gs3gpploci")]
+        pub ef_5gs3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gpploci")]
+        pub ef_5gsn3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gs3gppnsc")]
+        pub ef_5gs3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gppnsc")]
+        pub ef_5gsn3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gauthkeys")]
+        pub ef_5gauthkeys: Option<File>,
+        #[rasn(identifier = "ef-uac-aic")]
+        pub ef_uac_aic: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info")]
+        pub ef_suci_calc_info: Option<File>,
+        #[rasn(identifier = "ef-opl5g")]
+        pub ef_opl5g: Option<File>,
+        #[rasn(identifier = "ef-supinai")]
+        pub ef_supinai: Option<File>,
+        #[rasn(identifier = "ef-routing-indicator")]
+        pub ef_routing_indicator: Option<File>,
+        #[rasn(identifier = "ef-ursp")]
+        pub ef_ursp: Option<File>,
+        #[rasn(identifier = "ef-tn3gppsnn")]
+        pub ef_tn3gppsnn: Option<File>,
+        #[rasn(identifier = "ef-cag")]
+        pub ef_cag: Option<File>,
+        #[rasn(identifier = "ef-sor-cmci")]
+        pub ef_sor_cmci: Option<File>,
+        #[rasn(identifier = "ef-dri")]
+        pub ef_dri: Option<File>,
+        #[rasn(identifier = "ef-5gsedrx")]
+        pub ef_5gsedrx: Option<File>,
+        #[rasn(identifier = "ef-5gnswo-conf")]
+        pub ef_5gnswo_conf: Option<File>,
+        #[rasn(identifier = "ef-mchpplmn")]
+        pub ef_mchpplmn: Option<File>,
+        #[rasn(identifier = "ef-kausf-derivation")]
+        pub ef_kausf_derivation: Option<File>,
+    }
+    impl PEDF5GS {
+        pub fn new(
+            df_5gs_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_5gs: File,
+            ef_5gs3gpploci: Option<File>,
+            ef_5gsn3gpploci: Option<File>,
+            ef_5gs3gppnsc: Option<File>,
+            ef_5gsn3gppnsc: Option<File>,
+            ef_5gauthkeys: Option<File>,
+            ef_uac_aic: Option<File>,
+            ef_suci_calc_info: Option<File>,
+            ef_opl5g: Option<File>,
+            ef_supinai: Option<File>,
+            ef_routing_indicator: Option<File>,
+            ef_ursp: Option<File>,
+            ef_tn3gppsnn: Option<File>,
+            ef_cag: Option<File>,
+            ef_sor_cmci: Option<File>,
+            ef_dri: Option<File>,
+            ef_5gsedrx: Option<File>,
+            ef_5gnswo_conf: Option<File>,
+            ef_mchpplmn: Option<File>,
+            ef_kausf_derivation: Option<File>,
+        ) -> Self {
+            Self {
+                df_5gs_header,
+                template_id,
+                df_df_5gs,
+                ef_5gs3gpploci,
+                ef_5gsn3gpploci,
+                ef_5gs3gppnsc,
+                ef_5gsn3gppnsc,
+                ef_5gauthkeys,
+                ef_uac_aic,
+                ef_suci_calc_info,
+                ef_opl5g,
+                ef_supinai,
+                ef_routing_indicator,
+                ef_ursp,
+                ef_tn3gppsnn,
+                ef_cag,
+                ef_sor_cmci,
+                ef_dri,
+                ef_5gsedrx,
+                ef_5gnswo_conf,
+                ef_mchpplmn,
+                ef_kausf_derivation,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-SAIP")]
+    #[non_exhaustive]
+    pub struct PEDFSAIP {
+        #[rasn(identifier = "df-saip-header")]
+        pub df_saip_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-saip")]
+        pub df_df_saip: File,
+        #[rasn(identifier = "ef-suci-calc-info-usim")]
+        pub ef_suci_calc_info_usim: Option<File>,
+    }
+    impl PEDFSAIP {
+        pub fn new(
+            df_saip_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_saip: File,
+            ef_suci_calc_info_usim: Option<File>,
+        ) -> Self {
+            Self {
+                df_saip_header,
+                template_id,
+                df_df_saip,
+                ef_suci_calc_info_usim,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-SNPN")]
+    #[non_exhaustive]
+    pub struct PEDFSNPN {
+        #[rasn(identifier = "df-snpn-header")]
+        pub df_snpn_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-snpn")]
+        pub df_df_snpn: File,
+        #[rasn(identifier = "ef-pws-snpn")]
+        pub ef_pws_snpn: Option<File>,
+        #[rasn(identifier = "ef-nid")]
+        pub ef_nid: Option<File>,
+    }
+    impl PEDFSNPN {
+        pub fn new(
+            df_snpn_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_snpn: File,
+            ef_pws_snpn: Option<File>,
+            ef_nid: Option<File>,
+        ) -> Self {
+            Self {
+                df_snpn_header,
+                template_id,
+                df_df_snpn,
+                ef_pws_snpn,
+                ef_nid,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Dummy")]
+    #[non_exhaustive]
+    pub struct PEDummy {}
+    impl PEDummy {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+    impl std::default::Default for PEDummy {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-EAP")]
+    #[non_exhaustive]
+    pub struct PEEAP {
+        #[rasn(identifier = "eap-header")]
+        pub eap_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-eap")]
+        pub df_eap: File,
+        #[rasn(identifier = "ef-eapkeys")]
+        pub ef_eapkeys: Option<File>,
+        #[rasn(identifier = "ef-eapstatus")]
+        pub ef_eapstatus: File,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-ps")]
+        pub ef_ps: Option<File>,
+        #[rasn(identifier = "ef-curid")]
+        pub ef_curid: Option<File>,
+        #[rasn(identifier = "ef-reid")]
+        pub ef_reid: Option<File>,
+        #[rasn(identifier = "ef-realm")]
+        pub ef_realm: Option<File>,
+    }
+    impl PEEAP {
+        pub fn new(
+            eap_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_eap: File,
+            ef_eapkeys: Option<File>,
+            ef_eapstatus: File,
+            ef_puid: Option<File>,
+            ef_ps: Option<File>,
+            ef_curid: Option<File>,
+            ef_reid: Option<File>,
+            ef_realm: Option<File>,
+        ) -> Self {
+            Self {
+                eap_header,
+                template_id,
+                df_eap,
+                ef_eapkeys,
+                ef_eapstatus,
+                ef_puid,
+                ef_ps,
+                ef_curid,
+                ef_reid,
+                ef_realm,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-End")]
+    #[non_exhaustive]
+    pub struct PEEnd {
+        #[rasn(identifier = "end-header")]
+        pub end_header: PEHeader,
+    }
+    impl PEEnd {
+        pub fn new(end_header: PEHeader) -> Self {
+            Self { end_header }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GSM-ACCESS")]
+    #[non_exhaustive]
+    pub struct PEGSMACCESS {
+        #[rasn(identifier = "gsm-access-header")]
+        pub gsm_access_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-gsm-access")]
+        pub df_gsm_access: File,
+        #[rasn(identifier = "ef-kc")]
+        pub ef_kc: Option<File>,
+        #[rasn(identifier = "ef-kcgprs")]
+        pub ef_kcgprs: Option<File>,
+        #[rasn(identifier = "ef-cpbcch")]
+        pub ef_cpbcch: Option<File>,
+        #[rasn(identifier = "ef-invscan")]
+        pub ef_invscan: Option<File>,
+    }
+    impl PEGSMACCESS {
+        pub fn new(
+            gsm_access_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_gsm_access: File,
+            ef_kc: Option<File>,
+            ef_kcgprs: Option<File>,
+            ef_cpbcch: Option<File>,
+            ef_invscan: Option<File>,
+        ) -> Self {
+            Self {
+                gsm_access_header,
+                template_id,
+                df_gsm_access,
+                ef_kc,
+                ef_kcgprs,
+                ef_cpbcch,
+                ef_invscan,
+            }
+        }
+    }
+    #[doc = " Create GenericFileManagement"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GenericFileManagement")]
+    #[non_exhaustive]
+    pub struct PEGenericFileManagement {
+        #[rasn(identifier = "gfm-header")]
+        pub gfm_header: PEHeader,
+        #[rasn(size("1.."), identifier = "fileManagementCMD")]
+        pub file_management_cmd: SequenceOf<FileManagement>,
+    }
+    impl PEGenericFileManagement {
+        pub fn new(gfm_header: PEHeader, file_management_cmd: SequenceOf<FileManagement>) -> Self {
+            Self {
+                gfm_header,
+                file_management_cmd,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-ISIM")]
+    #[non_exhaustive]
+    pub struct PEISIM {
+        #[rasn(identifier = "isim-header")]
+        pub isim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-isim")]
+        pub adf_isim: File,
+        #[rasn(identifier = "ef-impi")]
+        pub ef_impi: File,
+        #[rasn(identifier = "ef-impu")]
+        pub ef_impu: File,
+        #[rasn(identifier = "ef-domain")]
+        pub ef_domain: File,
+        #[rasn(identifier = "ef-ist")]
+        pub ef_ist: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+    }
+    impl PEISIM {
+        pub fn new(
+            isim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_isim: File,
+            ef_impi: File,
+            ef_impu: File,
+            ef_domain: File,
+            ef_ist: File,
+            ef_ad: Option<File>,
+            ef_arr: File,
+        ) -> Self {
+            Self {
+                isim_header,
+                template_id,
+                adf_isim,
+                ef_impi,
+                ef_impu,
+                ef_domain,
+                ef_ist,
+                ef_ad,
+                ef_arr,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-IoT")]
+    #[non_exhaustive]
+    pub struct PEIoT {
+        #[rasn(identifier = "iot-header")]
+        pub iot_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        pub mf: Option<File>,
+        #[rasn(identifier = "ef-pl")]
+        pub ef_pl: Option<File>,
+        #[rasn(identifier = "ef-iccid")]
+        pub ef_iccid: Option<File>,
+        #[rasn(identifier = "ef-dir")]
+        pub ef_dir: Option<File>,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: Option<File>,
+        #[rasn(identifier = "ef-umpc")]
+        pub ef_umpc: Option<File>,
+        #[rasn(identifier = "adf-usim")]
+        pub adf_usim: Option<File>,
+        #[rasn(identifier = "ef-imsi")]
+        pub ef_imsi: File,
+        #[rasn(identifier = "ef-arr-usim")]
+        pub ef_arr_usim: Option<File>,
+        #[rasn(identifier = "ef-keys")]
+        pub ef_keys: Option<File>,
+        #[rasn(identifier = "ef-keysPS")]
+        pub ef_keys_ps: Option<File>,
+        #[rasn(identifier = "ef-hpplmn")]
+        pub ef_hpplmn: Option<File>,
+        #[rasn(identifier = "ef-ust")]
+        pub ef_ust: Option<File>,
+        #[rasn(identifier = "ef-start-hfn")]
+        pub ef_start_hfn: Option<File>,
+        #[rasn(identifier = "ef-threshold")]
+        pub ef_threshold: Option<File>,
+        #[rasn(identifier = "ef-psloci")]
+        pub ef_psloci: Option<File>,
+        #[rasn(identifier = "ef-acc")]
+        pub ef_acc: File,
+        #[rasn(identifier = "ef-fplmn")]
+        pub ef_fplmn: Option<File>,
+        #[rasn(identifier = "ef-loci")]
+        pub ef_loci: Option<File>,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: Option<File>,
+        #[rasn(identifier = "ef-netpar")]
+        pub ef_netpar: Option<File>,
+    }
+    impl PEIoT {
+        pub fn new(
+            iot_header: PEHeader,
+            template_id: ObjectIdentifier,
+            mf: Option<File>,
+            ef_pl: Option<File>,
+            ef_iccid: Option<File>,
+            ef_dir: Option<File>,
+            ef_arr: Option<File>,
+            ef_umpc: Option<File>,
+            adf_usim: Option<File>,
+            ef_imsi: File,
+            ef_arr_usim: Option<File>,
+            ef_keys: Option<File>,
+            ef_keys_ps: Option<File>,
+            ef_hpplmn: Option<File>,
+            ef_ust: Option<File>,
+            ef_start_hfn: Option<File>,
+            ef_threshold: Option<File>,
+            ef_psloci: Option<File>,
+            ef_acc: File,
+            ef_fplmn: Option<File>,
+            ef_loci: Option<File>,
+            ef_ad: Option<File>,
+            ef_ecc: Option<File>,
+            ef_netpar: Option<File>,
+        ) -> Self {
+            Self {
+                iot_header,
+                template_id,
+                mf,
+                ef_pl,
+                ef_iccid,
+                ef_dir,
+                ef_arr,
+                ef_umpc,
+                adf_usim,
+                ef_imsi,
+                ef_arr_usim,
+                ef_keys,
+                ef_keys_ps,
+                ef_hpplmn,
+                ef_ust,
+                ef_start_hfn,
+                ef_threshold,
+                ef_psloci,
+                ef_acc,
+                ef_fplmn,
+                ef_loci,
+                ef_ad,
+                ef_ecc,
+                ef_netpar,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-MF")]
+    #[non_exhaustive]
+    pub struct PEMF {
+        #[rasn(identifier = "mf-header")]
+        pub mf_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        pub mf: File,
+        #[rasn(identifier = "ef-pl")]
+        pub ef_pl: Option<File>,
+        #[rasn(identifier = "ef-iccid")]
+        pub ef_iccid: File,
+        #[rasn(identifier = "ef-dir")]
+        pub ef_dir: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-umpc")]
+        pub ef_umpc: Option<File>,
+    }
+    impl PEMF {
+        pub fn new(
+            mf_header: PEHeader,
+            template_id: ObjectIdentifier,
+            mf: File,
+            ef_pl: Option<File>,
+            ef_iccid: File,
+            ef_dir: File,
+            ef_arr: File,
+            ef_umpc: Option<File>,
+        ) -> Self {
+            Self {
+                mf_header,
+                template_id,
+                mf,
+                ef_pl,
+                ef_iccid,
+                ef_dir,
+                ef_arr,
+                ef_umpc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-NonStandard")]
+    #[non_exhaustive]
+    pub struct PENonStandard {
+        #[rasn(identifier = "nonStandard-header")]
+        pub non_standard_header: PEHeader,
+        #[rasn(identifier = "issuerID")]
+        pub issuer_id: ObjectIdentifier,
+        pub content: OctetString,
+    }
+    impl PENonStandard {
+        pub fn new(
+            non_standard_header: PEHeader,
+            issuer_id: ObjectIdentifier,
+            content: OctetString,
+        ) -> Self {
+            Self {
+                non_standard_header,
+                issuer_id,
+                content,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-CSIM")]
+    #[non_exhaustive]
+    pub struct PEOPTCSIM {
+        #[rasn(identifier = "optcsim-header")]
+        pub optcsim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-ssci")]
+        pub ef_ssci: Option<File>,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-ssfc")]
+        pub ef_ssfc: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: Option<File>,
+        #[rasn(identifier = "ef-mdn")]
+        pub ef_mdn: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: Option<File>,
+        #[rasn(identifier = "ef-me3gpdopc")]
+        pub ef_me3gpdopc: Option<File>,
+        #[rasn(identifier = "ef-3gpdopm")]
+        pub ef_3gpdopm: Option<File>,
+        #[rasn(identifier = "ef-sipcap")]
+        pub ef_sipcap: Option<File>,
+        #[rasn(identifier = "ef-mipcap")]
+        pub ef_mipcap: Option<File>,
+        #[rasn(identifier = "ef-sipupp")]
+        pub ef_sipupp: Option<File>,
+        #[rasn(identifier = "ef-mipupp")]
+        pub ef_mipupp: Option<File>,
+        #[rasn(identifier = "ef-sipsp")]
+        pub ef_sipsp: Option<File>,
+        #[rasn(identifier = "ef-mipsp")]
+        pub ef_mipsp: Option<File>,
+        #[rasn(identifier = "ef-sippapss")]
+        pub ef_sippapss: Option<File>,
+        #[rasn(identifier = "ef-puzl")]
+        pub ef_puzl: Option<File>,
+        #[rasn(identifier = "ef-maxpuzl")]
+        pub ef_maxpuzl: Option<File>,
+        #[rasn(identifier = "ef-hrpdcap")]
+        pub ef_hrpdcap: Option<File>,
+        #[rasn(identifier = "ef-hrpdupp")]
+        pub ef_hrpdupp: Option<File>,
+        #[rasn(identifier = "ef-csspr")]
+        pub ef_csspr: Option<File>,
+        #[rasn(identifier = "ef-atc")]
+        pub ef_atc: Option<File>,
+        #[rasn(identifier = "ef-eprl")]
+        pub ef_eprl: Option<File>,
+        #[rasn(identifier = "ef-bcsmscfg")]
+        pub ef_bcsmscfg: Option<File>,
+        #[rasn(identifier = "ef-bcsmspref")]
+        pub ef_bcsmspref: Option<File>,
+        #[rasn(identifier = "ef-bcsmstable")]
+        pub ef_bcsmstable: Option<File>,
+        #[rasn(identifier = "ef-bcsmsp")]
+        pub ef_bcsmsp: Option<File>,
+        #[rasn(identifier = "ef-bakpara")]
+        pub ef_bakpara: Option<File>,
+        #[rasn(identifier = "ef-upbakpara")]
+        pub ef_upbakpara: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-auth-capability")]
+        pub ef_auth_capability: Option<File>,
+        #[rasn(identifier = "ef-3gcik")]
+        pub ef_3gcik: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-cdmacnl")]
+        pub ef_cdmacnl: Option<File>,
+        #[rasn(identifier = "ef-sf-euimid")]
+        pub ef_sf_euimid: Option<File>,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: Option<File>,
+        #[rasn(identifier = "ef-hidden-key")]
+        pub ef_hidden_key: Option<File>,
+        #[rasn(identifier = "ef-lcsver")]
+        pub ef_lcsver: Option<File>,
+        #[rasn(identifier = "ef-lcscp")]
+        pub ef_lcscp: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-applabels")]
+        pub ef_applabels: Option<File>,
+        #[rasn(identifier = "ef-model")]
+        pub ef_model: Option<File>,
+        #[rasn(identifier = "ef-rc")]
+        pub ef_rc: Option<File>,
+        #[rasn(identifier = "ef-smscap")]
+        pub ef_smscap: Option<File>,
+        #[rasn(identifier = "ef-mipflags")]
+        pub ef_mipflags: Option<File>,
+        #[rasn(identifier = "ef-3gpduppext")]
+        pub ef_3gpduppext: Option<File>,
+        #[rasn(identifier = "ef-ipv6cap")]
+        pub ef_ipv6cap: Option<File>,
+        #[rasn(identifier = "ef-tcpconfig")]
+        pub ef_tcpconfig: Option<File>,
+        #[rasn(identifier = "ef-dgc")]
+        pub ef_dgc: Option<File>,
+        #[rasn(identifier = "ef-wapbrowsercp")]
+        pub ef_wapbrowsercp: Option<File>,
+        #[rasn(identifier = "ef-wapbrowserbm")]
+        pub ef_wapbrowserbm: Option<File>,
+        #[rasn(identifier = "ef-mmsconfig")]
+        pub ef_mmsconfig: Option<File>,
+        #[rasn(identifier = "ef-jdl")]
+        pub ef_jdl: Option<File>,
+    }
+    impl PEOPTCSIM {
+        pub fn new(
+            optcsim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_ssci: Option<File>,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_ssfc: Option<File>,
+            ef_spn: Option<File>,
+            ef_mdn: Option<File>,
+            ef_ecc: Option<File>,
+            ef_me3gpdopc: Option<File>,
+            ef_3gpdopm: Option<File>,
+            ef_sipcap: Option<File>,
+            ef_mipcap: Option<File>,
+            ef_sipupp: Option<File>,
+            ef_mipupp: Option<File>,
+            ef_sipsp: Option<File>,
+            ef_mipsp: Option<File>,
+            ef_sippapss: Option<File>,
+            ef_puzl: Option<File>,
+            ef_maxpuzl: Option<File>,
+            ef_hrpdcap: Option<File>,
+            ef_hrpdupp: Option<File>,
+            ef_csspr: Option<File>,
+            ef_atc: Option<File>,
+            ef_eprl: Option<File>,
+            ef_bcsmscfg: Option<File>,
+            ef_bcsmspref: Option<File>,
+            ef_bcsmstable: Option<File>,
+            ef_bcsmsp: Option<File>,
+            ef_bakpara: Option<File>,
+            ef_upbakpara: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_auth_capability: Option<File>,
+            ef_3gcik: Option<File>,
+            ef_dck: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_cdmacnl: Option<File>,
+            ef_sf_euimid: Option<File>,
+            ef_est: Option<File>,
+            ef_hidden_key: Option<File>,
+            ef_lcsver: Option<File>,
+            ef_lcscp: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_applabels: Option<File>,
+            ef_model: Option<File>,
+            ef_rc: Option<File>,
+            ef_smscap: Option<File>,
+            ef_mipflags: Option<File>,
+            ef_3gpduppext: Option<File>,
+            ef_ipv6cap: Option<File>,
+            ef_tcpconfig: Option<File>,
+            ef_dgc: Option<File>,
+            ef_wapbrowsercp: Option<File>,
+            ef_wapbrowserbm: Option<File>,
+            ef_mmsconfig: Option<File>,
+            ef_jdl: Option<File>,
+        ) -> Self {
+            Self {
+                optcsim_header,
+                template_id,
+                ef_ssci,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_ssfc,
+                ef_spn,
+                ef_mdn,
+                ef_ecc,
+                ef_me3gpdopc,
+                ef_3gpdopm,
+                ef_sipcap,
+                ef_mipcap,
+                ef_sipupp,
+                ef_mipupp,
+                ef_sipsp,
+                ef_mipsp,
+                ef_sippapss,
+                ef_puzl,
+                ef_maxpuzl,
+                ef_hrpdcap,
+                ef_hrpdupp,
+                ef_csspr,
+                ef_atc,
+                ef_eprl,
+                ef_bcsmscfg,
+                ef_bcsmspref,
+                ef_bcsmstable,
+                ef_bcsmsp,
+                ef_bakpara,
+                ef_upbakpara,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_auth_capability,
+                ef_3gcik,
+                ef_dck,
+                ef_gid1,
+                ef_gid2,
+                ef_cdmacnl,
+                ef_sf_euimid,
+                ef_est,
+                ef_hidden_key,
+                ef_lcsver,
+                ef_lcscp,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_ici,
+                ef_oci,
+                ef_ext5,
+                ef_ccp2,
+                ef_applabels,
+                ef_model,
+                ef_rc,
+                ef_smscap,
+                ef_mipflags,
+                ef_3gpduppext,
+                ef_ipv6cap,
+                ef_tcpconfig,
+                ef_dgc,
+                ef_wapbrowsercp,
+                ef_wapbrowserbm,
+                ef_mmsconfig,
+                ef_jdl,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-ISIM")]
+    #[non_exhaustive]
+    pub struct PEOPTISIM {
+        #[rasn(identifier = "optisim-header")]
+        pub optisim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-pcscf")]
+        pub ef_pcscf: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+        #[rasn(identifier = "ef-frompreferred")]
+        pub ef_frompreferred: Option<File>,
+        #[rasn(identifier = "ef-imsconfigdata")]
+        pub ef_imsconfigdata: Option<File>,
+        #[rasn(identifier = "ef-xcapconfigdata")]
+        pub ef_xcapconfigdata: Option<File>,
+        #[rasn(identifier = "ef-webrtcuri")]
+        pub ef_webrtcuri: Option<File>,
+        #[rasn(identifier = "ef-mudmidconfigdata")]
+        pub ef_mudmidconfigdata: Option<File>,
+        #[rasn(identifier = "ef-ac-gbauapi")]
+        pub ef_ac_gbauapi: Option<File>,
+        #[rasn(identifier = "ef-imsdci")]
+        pub ef_imsdci: Option<File>,
+    }
+    impl PEOPTISIM {
+        pub fn new(
+            optisim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_pcscf: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_smsr: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_uicciari: Option<File>,
+            ef_frompreferred: Option<File>,
+            ef_imsconfigdata: Option<File>,
+            ef_xcapconfigdata: Option<File>,
+            ef_webrtcuri: Option<File>,
+            ef_mudmidconfigdata: Option<File>,
+            ef_ac_gbauapi: Option<File>,
+            ef_imsdci: Option<File>,
+        ) -> Self {
+            Self {
+                optisim_header,
+                template_id,
+                ef_pcscf,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_smsr,
+                ef_gbabp,
+                ef_gbanl,
+                ef_nafkca,
+                ef_uicciari,
+                ef_frompreferred,
+                ef_imsconfigdata,
+                ef_xcapconfigdata,
+                ef_webrtcuri,
+                ef_mudmidconfigdata,
+                ef_ac_gbauapi,
+                ef_imsdci,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-IoT")]
+    #[non_exhaustive]
+    pub struct PEOPTIoT {
+        #[rasn(identifier = "optiot-header")]
+        pub optiot_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: Option<File>,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: Option<File>,
+        #[rasn(identifier = "ef-oplmnwact")]
+        pub ef_oplmnwact: Option<File>,
+        #[rasn(identifier = "ef-hplmnwact")]
+        pub ef_hplmnwact: Option<File>,
+        #[rasn(identifier = "ef-ehplmn")]
+        pub ef_ehplmn: Option<File>,
+        #[rasn(identifier = "ef-epsloci")]
+        pub ef_epsloci: Option<File>,
+        #[rasn(identifier = "ef-epsnsc")]
+        pub ef_epsnsc: Option<File>,
+        #[rasn(identifier = "df-df-5gs")]
+        pub df_df_5gs: Option<File>,
+        #[rasn(identifier = "ef-5gs3gpploci")]
+        pub ef_5gs3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gpploci")]
+        pub ef_5gsn3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gs3gppnsc")]
+        pub ef_5gs3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gppnsc")]
+        pub ef_5gsn3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gauthkeys")]
+        pub ef_5gauthkeys: Option<File>,
+        #[rasn(identifier = "ef-uac-aic")]
+        pub ef_uac_aic: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info")]
+        pub ef_suci_calc_info: Option<File>,
+        #[rasn(identifier = "ef-opl5g")]
+        pub ef_opl5g: Option<File>,
+        #[rasn(identifier = "ef-supi-nai")]
+        pub ef_supi_nai: Option<File>,
+        #[rasn(identifier = "ef-routing-indicator")]
+        pub ef_routing_indicator: Option<File>,
+        #[rasn(identifier = "ef-ursp")]
+        pub ef_ursp: Option<File>,
+        #[rasn(identifier = "ef-tn3gppsnn")]
+        pub ef_tn3gppsnn: Option<File>,
+        #[rasn(identifier = "df-df-saip")]
+        pub df_df_saip: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info-usim")]
+        pub ef_suci_calc_info_usim: Option<File>,
+    }
+    impl PEOPTIoT {
+        pub fn new(
+            optiot_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_spn: Option<File>,
+            ef_est: Option<File>,
+            ef_oplmnwact: Option<File>,
+            ef_hplmnwact: Option<File>,
+            ef_ehplmn: Option<File>,
+            ef_epsloci: Option<File>,
+            ef_epsnsc: Option<File>,
+            df_df_5gs: Option<File>,
+            ef_5gs3gpploci: Option<File>,
+            ef_5gsn3gpploci: Option<File>,
+            ef_5gs3gppnsc: Option<File>,
+            ef_5gsn3gppnsc: Option<File>,
+            ef_5gauthkeys: Option<File>,
+            ef_uac_aic: Option<File>,
+            ef_suci_calc_info: Option<File>,
+            ef_opl5g: Option<File>,
+            ef_supi_nai: Option<File>,
+            ef_routing_indicator: Option<File>,
+            ef_ursp: Option<File>,
+            ef_tn3gppsnn: Option<File>,
+            df_df_saip: Option<File>,
+            ef_suci_calc_info_usim: Option<File>,
+        ) -> Self {
+            Self {
+                optiot_header,
+                template_id,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_spn,
+                ef_est,
+                ef_oplmnwact,
+                ef_hplmnwact,
+                ef_ehplmn,
+                ef_epsloci,
+                ef_epsnsc,
+                df_df_5gs,
+                ef_5gs3gpploci,
+                ef_5gsn3gpploci,
+                ef_5gs3gppnsc,
+                ef_5gsn3gppnsc,
+                ef_5gauthkeys,
+                ef_uac_aic,
+                ef_suci_calc_info,
+                ef_opl5g,
+                ef_supi_nai,
+                ef_routing_indicator,
+                ef_ursp,
+                ef_tn3gppsnn,
+                df_df_saip,
+                ef_suci_calc_info_usim,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-USIM")]
+    #[non_exhaustive]
+    pub struct PEOPTUSIM {
+        #[rasn(identifier = "optusim-header")]
+        pub optusim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: Option<File>,
+        #[rasn(identifier = "ef-acmax")]
+        pub ef_acmax: Option<File>,
+        #[rasn(identifier = "ef-acm")]
+        pub ef_acm: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-msisdn")]
+        pub ef_msisdn: Option<File>,
+        #[rasn(identifier = "ef-puct")]
+        pub ef_puct: Option<File>,
+        #[rasn(identifier = "ef-cbmi")]
+        pub ef_cbmi: Option<File>,
+        #[rasn(identifier = "ef-cbmid")]
+        pub ef_cbmid: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-cbmir")]
+        pub ef_cbmir: Option<File>,
+        #[rasn(identifier = "ef-plmnwact")]
+        pub ef_plmnwact: Option<File>,
+        #[rasn(identifier = "ef-oplmnwact")]
+        pub ef_oplmnwact: Option<File>,
+        #[rasn(identifier = "ef-hplmnwact")]
+        pub ef_hplmnwact: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-cnl")]
+        pub ef_cnl: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-bdn")]
+        pub ef_bdn: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-ext4")]
+        pub ef_ext4: Option<File>,
+        #[rasn(identifier = "ef-acl")]
+        pub ef_acl: Option<File>,
+        #[rasn(identifier = "ef-cmi")]
+        pub ef_cmi: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ict")]
+        pub ef_ict: Option<File>,
+        #[rasn(identifier = "ef-oct")]
+        pub ef_oct: Option<File>,
+        #[rasn(identifier = "ef-vgcs")]
+        pub ef_vgcs: Option<File>,
+        #[rasn(identifier = "ef-vgcss")]
+        pub ef_vgcss: Option<File>,
+        #[rasn(identifier = "ef-vbs")]
+        pub ef_vbs: Option<File>,
+        #[rasn(identifier = "ef-vbss")]
+        pub ef_vbss: Option<File>,
+        #[rasn(identifier = "ef-emlpp")]
+        pub ef_emlpp: Option<File>,
+        #[rasn(identifier = "ef-aaem")]
+        pub ef_aaem: Option<File>,
+        #[rasn(identifier = "ef-hiddenkey")]
+        pub ef_hiddenkey: Option<File>,
+        #[rasn(identifier = "ef-pnn")]
+        pub ef_pnn: Option<File>,
+        #[rasn(identifier = "ef-opl")]
+        pub ef_opl: Option<File>,
+        #[rasn(identifier = "ef-mbdn")]
+        pub ef_mbdn: Option<File>,
+        #[rasn(identifier = "ef-ext6")]
+        pub ef_ext6: Option<File>,
+        #[rasn(identifier = "ef-mbi")]
+        pub ef_mbi: Option<File>,
+        #[rasn(identifier = "ef-mwis")]
+        pub ef_mwis: Option<File>,
+        #[rasn(identifier = "ef-cfis")]
+        pub ef_cfis: Option<File>,
+        #[rasn(identifier = "ef-ext7")]
+        pub ef_ext7: Option<File>,
+        #[rasn(identifier = "ef-spdi")]
+        pub ef_spdi: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-nia")]
+        pub ef_nia: Option<File>,
+        #[rasn(identifier = "ef-vgcsca")]
+        pub ef_vgcsca: Option<File>,
+        #[rasn(identifier = "ef-vbsca")]
+        pub ef_vbsca: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-msk")]
+        pub ef_msk: Option<File>,
+        #[rasn(identifier = "ef-muk")]
+        pub ef_muk: Option<File>,
+        #[rasn(identifier = "ef-ehplmn")]
+        pub ef_ehplmn: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-ehplmnpi")]
+        pub ef_ehplmnpi: Option<File>,
+        #[rasn(identifier = "ef-lrplmnsi")]
+        pub ef_lrplmnsi: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-spni")]
+        pub ef_spni: Option<File>,
+        #[rasn(identifier = "ef-pnni")]
+        pub ef_pnni: Option<File>,
+        #[rasn(identifier = "ef-ncp-ip")]
+        pub ef_ncp_ip: Option<File>,
+        #[rasn(identifier = "ef-ufc")]
+        pub ef_ufc: Option<File>,
+        #[rasn(identifier = "ef-nasconfig")]
+        pub ef_nasconfig: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+        #[rasn(identifier = "ef-pws")]
+        pub ef_pws: Option<File>,
+        #[rasn(identifier = "ef-fdnuri")]
+        pub ef_fdnuri: Option<File>,
+        #[rasn(identifier = "ef-bdnuri")]
+        pub ef_bdnuri: Option<File>,
+        #[rasn(identifier = "ef-sdnuri")]
+        pub ef_sdnuri: Option<File>,
+        #[rasn(identifier = "ef-ial")]
+        pub ef_ial: Option<File>,
+        #[rasn(identifier = "ef-ips")]
+        pub ef_ips: Option<File>,
+        #[rasn(identifier = "ef-ipd")]
+        pub ef_ipd: Option<File>,
+        #[rasn(identifier = "ef-epdgid")]
+        pub ef_epdgid: Option<File>,
+        #[rasn(identifier = "ef-epdgselection")]
+        pub ef_epdgselection: Option<File>,
+        #[rasn(identifier = "ef-epdgidem")]
+        pub ef_epdgidem: Option<File>,
+        #[rasn(identifier = "ef-epdgselectionem")]
+        pub ef_epdgselectionem: Option<File>,
+        #[rasn(identifier = "ef-frompreferred")]
+        pub ef_frompreferred: Option<File>,
+        #[rasn(identifier = "ef-imsconfigdata")]
+        pub ef_imsconfigdata: Option<File>,
+        #[rasn(identifier = "ef-3gpppsdataoff")]
+        pub ef_3gpppsdataoff: Option<File>,
+        #[rasn(identifier = "ef-3gpppsdataoffservicelist")]
+        pub ef_3gpppsdataoffservicelist: Option<File>,
+        #[rasn(identifier = "ef-xcapconfigdata")]
+        pub ef_xcapconfigdata: Option<File>,
+        #[rasn(identifier = "ef-earfcnlist")]
+        pub ef_earfcnlist: Option<File>,
+        #[rasn(identifier = "ef-mudmidconfigdata")]
+        pub ef_mudmidconfigdata: Option<File>,
+        #[rasn(identifier = "ef-eaka")]
+        pub ef_eaka: Option<File>,
+        #[rasn(identifier = "ef-ocst")]
+        pub ef_ocst: Option<File>,
+        #[rasn(identifier = "ef-ac-gbauapi")]
+        pub ef_ac_gbauapi: Option<File>,
+        #[rasn(identifier = "ef-imsdci")]
+        pub ef_imsdci: Option<File>,
+    }
+    impl PEOPTUSIM {
+        pub fn new(
+            optusim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_li: Option<File>,
+            ef_acmax: Option<File>,
+            ef_acm: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_msisdn: Option<File>,
+            ef_puct: Option<File>,
+            ef_cbmi: Option<File>,
+            ef_cbmid: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_cbmir: Option<File>,
+            ef_plmnwact: Option<File>,
+            ef_oplmnwact: Option<File>,
+            ef_hplmnwact: Option<File>,
+            ef_dck: Option<File>,
+            ef_cnl: Option<File>,
+            ef_smsr: Option<File>,
+            ef_bdn: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_ext4: Option<File>,
+            ef_acl: Option<File>,
+            ef_cmi: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ict: Option<File>,
+            ef_oct: Option<File>,
+            ef_vgcs: Option<File>,
+            ef_vgcss: Option<File>,
+            ef_vbs: Option<File>,
+            ef_vbss: Option<File>,
+            ef_emlpp: Option<File>,
+            ef_aaem: Option<File>,
+            ef_hiddenkey: Option<File>,
+            ef_pnn: Option<File>,
+            ef_opl: Option<File>,
+            ef_mbdn: Option<File>,
+            ef_ext6: Option<File>,
+            ef_mbi: Option<File>,
+            ef_mwis: Option<File>,
+            ef_cfis: Option<File>,
+            ef_ext7: Option<File>,
+            ef_spdi: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_nia: Option<File>,
+            ef_vgcsca: Option<File>,
+            ef_vbsca: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_msk: Option<File>,
+            ef_muk: Option<File>,
+            ef_ehplmn: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_ehplmnpi: Option<File>,
+            ef_lrplmnsi: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_spni: Option<File>,
+            ef_pnni: Option<File>,
+            ef_ncp_ip: Option<File>,
+            ef_ufc: Option<File>,
+            ef_nasconfig: Option<File>,
+            ef_uicciari: Option<File>,
+            ef_pws: Option<File>,
+            ef_fdnuri: Option<File>,
+            ef_bdnuri: Option<File>,
+            ef_sdnuri: Option<File>,
+            ef_ial: Option<File>,
+            ef_ips: Option<File>,
+            ef_ipd: Option<File>,
+            ef_epdgid: Option<File>,
+            ef_epdgselection: Option<File>,
+            ef_epdgidem: Option<File>,
+            ef_epdgselectionem: Option<File>,
+            ef_frompreferred: Option<File>,
+            ef_imsconfigdata: Option<File>,
+            ef_3gpppsdataoff: Option<File>,
+            ef_3gpppsdataoffservicelist: Option<File>,
+            ef_xcapconfigdata: Option<File>,
+            ef_earfcnlist: Option<File>,
+            ef_mudmidconfigdata: Option<File>,
+            ef_eaka: Option<File>,
+            ef_ocst: Option<File>,
+            ef_ac_gbauapi: Option<File>,
+            ef_imsdci: Option<File>,
+        ) -> Self {
+            Self {
+                optusim_header,
+                template_id,
+                ef_li,
+                ef_acmax,
+                ef_acm,
+                ef_gid1,
+                ef_gid2,
+                ef_msisdn,
+                ef_puct,
+                ef_cbmi,
+                ef_cbmid,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_cbmir,
+                ef_plmnwact,
+                ef_oplmnwact,
+                ef_hplmnwact,
+                ef_dck,
+                ef_cnl,
+                ef_smsr,
+                ef_bdn,
+                ef_ext5,
+                ef_ccp2,
+                ef_ext4,
+                ef_acl,
+                ef_cmi,
+                ef_ici,
+                ef_oci,
+                ef_ict,
+                ef_oct,
+                ef_vgcs,
+                ef_vgcss,
+                ef_vbs,
+                ef_vbss,
+                ef_emlpp,
+                ef_aaem,
+                ef_hiddenkey,
+                ef_pnn,
+                ef_opl,
+                ef_mbdn,
+                ef_ext6,
+                ef_mbi,
+                ef_mwis,
+                ef_cfis,
+                ef_ext7,
+                ef_spdi,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_nia,
+                ef_vgcsca,
+                ef_vbsca,
+                ef_gbabp,
+                ef_msk,
+                ef_muk,
+                ef_ehplmn,
+                ef_gbanl,
+                ef_ehplmnpi,
+                ef_lrplmnsi,
+                ef_nafkca,
+                ef_spni,
+                ef_pnni,
+                ef_ncp_ip,
+                ef_ufc,
+                ef_nasconfig,
+                ef_uicciari,
+                ef_pws,
+                ef_fdnuri,
+                ef_bdnuri,
+                ef_sdnuri,
+                ef_ial,
+                ef_ips,
+                ef_ipd,
+                ef_epdgid,
+                ef_epdgselection,
+                ef_epdgidem,
+                ef_epdgselectionem,
+                ef_frompreferred,
+                ef_imsconfigdata,
+                ef_3gpppsdataoff,
+                ef_3gpppsdataoffservicelist,
+                ef_xcapconfigdata,
+                ef_earfcnlist,
+                ef_mudmidconfigdata,
+                ef_eaka,
+                ef_ocst,
+                ef_ac_gbauapi,
+                ef_imsdci,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PHONEBOOK")]
+    #[non_exhaustive]
+    pub struct PEPHONEBOOK {
+        #[rasn(identifier = "phonebook-header")]
+        pub phonebook_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: File,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+    }
+    impl PEPHONEBOOK {
+        pub fn new(
+            phonebook_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_phonebook: File,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+        ) -> Self {
+            Self {
+                phonebook_header,
+                template_id,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEPINCodesPinCodes {
+        #[rasn(size("1..=26"))]
+        pinconfig(SequenceOf<PINConfiguration>),
+        #[rasn(size("0..=8"))]
+        filePath(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PINCodes")]
+    #[non_exhaustive]
+    pub struct PEPINCodes {
+        #[rasn(identifier = "pin-Header")]
+        pub pin_header: PEHeader,
+        #[rasn(identifier = "pinCodes")]
+        pub pin_codes: PEPINCodesPinCodes,
+    }
+    impl PEPINCodes {
+        pub fn new(pin_header: PEHeader, pin_codes: PEPINCodesPinCodes) -> Self {
+            Self {
+                pin_header,
+                pin_codes,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PUKCodes")]
+    #[non_exhaustive]
+    pub struct PEPUKCodes {
+        #[rasn(identifier = "puk-Header")]
+        pub puk_header: PEHeader,
+        #[rasn(size("1..=16"), identifier = "pukCodes")]
+        pub puk_codes: SequenceOf<PUKConfiguration>,
+    }
+    impl PEPUKCodes {
+        pub fn new(puk_header: PEHeader, puk_codes: SequenceOf<PUKConfiguration>) -> Self {
+            Self {
+                puk_header,
+                puk_codes,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPERFMTarList(pub FixedOctetString<3usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct PERFMTarList(pub SequenceOf<AnonymousPERFMTarList>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "PE-RFM")]
+    #[non_exhaustive]
+    pub struct PERFM {
+        #[rasn(tag(context, 0), identifier = "rfm-header")]
+        pub rfm_header: PEHeader,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 0), identifier = "tarList")]
+        pub tar_list: Option<PERFMTarList>,
+        #[rasn(size("1"), tag(context, 1), identifier = "minimumSecurityLevel")]
+        pub minimum_security_level: OctetString,
+        #[rasn(identifier = "uiccAccessDomain")]
+        pub uicc_access_domain: OctetString,
+        #[rasn(identifier = "uiccAdminAccessDomain")]
+        pub uicc_admin_access_domain: OctetString,
+        #[rasn(identifier = "adfRFMAccess")]
+        pub adf_rfmaccess: Option<ADFRFMAccess>,
+    }
+    impl PERFM {
+        pub fn new(
+            rfm_header: PEHeader,
+            instance_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            tar_list: Option<PERFMTarList>,
+            minimum_security_level: OctetString,
+            uicc_access_domain: OctetString,
+            uicc_admin_access_domain: OctetString,
+            adf_rfmaccess: Option<ADFRFMAccess>,
+        ) -> Self {
+            Self {
+                rfm_header,
+                instance_aid,
+                security_domain_aid,
+                tar_list,
+                minimum_security_level,
+                uicc_access_domain,
+                uicc_admin_access_domain,
+                adf_rfmaccess,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SSIM")]
+    #[non_exhaustive]
+    pub struct PESSIM {
+        #[rasn(identifier = "ssim-header")]
+        pub ssim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-ssim")]
+        pub adf_ssim: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-eapId")]
+        pub ef_eap_id: File,
+        #[rasn(identifier = "ef-nssai")]
+        pub ef_nssai: File,
+        #[rasn(identifier = "ef-eapStatus")]
+        pub ef_eap_status: File,
+    }
+    impl PESSIM {
+        pub fn new(
+            ssim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_ssim: File,
+            ef_arr: File,
+            ef_eap_id: File,
+            ef_nssai: File,
+            ef_eap_status: File,
+        ) -> Self {
+            Self {
+                ssim_header,
+                template_id,
+                adf_ssim,
+                ef_arr,
+                ef_eap_id,
+                ef_nssai,
+                ef_eap_status,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SSIM-EAPTLSParameters")]
+    #[non_exhaustive]
+    pub struct PESSIMEAPTLSParameters {
+        #[rasn(identifier = "ssim-eaptls-header")]
+        pub ssim_eaptls_header: PEHeader,
+        #[rasn(identifier = "eapSSIMCertificate")]
+        pub eap_ssimcertificate: Certificate,
+        #[rasn(identifier = "eapSSIMCertificateChain")]
+        pub eap_ssimcertificate_chain: Option<SequenceOf<Certificate>>,
+        #[rasn(identifier = "eapCACertificate")]
+        pub eap_cacertificate: Certificate,
+        #[rasn(identifier = "privateKey")]
+        pub private_key: OctetString,
+    }
+    impl PESSIMEAPTLSParameters {
+        pub fn new(
+            ssim_eaptls_header: PEHeader,
+            eap_ssimcertificate: Certificate,
+            eap_ssimcertificate_chain: Option<SequenceOf<Certificate>>,
+            eap_cacertificate: Certificate,
+            private_key: OctetString,
+        ) -> Self {
+            Self {
+                ssim_eaptls_header,
+                eap_ssimcertificate,
+                eap_ssimcertificate_chain,
+                eap_cacertificate,
+                private_key,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainOpenPersoData {
+        #[rasn(size("1"), tag(private, 25), identifier = "restrictParameter")]
+        pub restrict_parameter: Option<OctetString>,
+        #[rasn(identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+    }
+    impl PESecurityDomainOpenPersoData {
+        pub fn new(
+            restrict_parameter: Option<OctetString>,
+            contactless_protocol_parameters: Option<OctetString>,
+        ) -> Self {
+            Self {
+                restrict_parameter,
+                contactless_protocol_parameters,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainCatTpParameters {
+        #[rasn(identifier = "catTpMaxSduSize")]
+        pub cat_tp_max_sdu_size: UInt16,
+        #[rasn(identifier = "catTpMaxPduSize")]
+        pub cat_tp_max_pdu_size: UInt16,
+    }
+    impl PESecurityDomainCatTpParameters {
+        pub fn new(cat_tp_max_sdu_size: UInt16, cat_tp_max_pdu_size: UInt16) -> Self {
+            Self {
+                cat_tp_max_sdu_size,
+                cat_tp_max_pdu_size,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SecurityDomain")]
+    #[non_exhaustive]
+    pub struct PESecurityDomain {
+        #[rasn(identifier = "sd-Header")]
+        pub sd_header: PEHeader,
+        pub instance: ApplicationInstance,
+        #[rasn(size("1.."), identifier = "keyList")]
+        pub key_list: Option<SequenceOf<KeyObject>>,
+        #[rasn(size("1.."), identifier = "sdPersoData")]
+        pub sd_perso_data: Option<SequenceOf<OctetString>>,
+        #[rasn(identifier = "openPersoData")]
+        pub open_perso_data: Option<PESecurityDomainOpenPersoData>,
+        #[rasn(identifier = "catTpParameters")]
+        pub cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+    }
+    impl PESecurityDomain {
+        pub fn new(
+            sd_header: PEHeader,
+            instance: ApplicationInstance,
+            key_list: Option<SequenceOf<KeyObject>>,
+            sd_perso_data: Option<SequenceOf<OctetString>>,
+            open_perso_data: Option<PESecurityDomainOpenPersoData>,
+            cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+        ) -> Self {
+            Self {
+                sd_header,
+                instance,
+                key_list,
+                sd_perso_data,
+                open_perso_data,
+                cat_tp_parameters,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-TELECOM")]
+    #[non_exhaustive]
+    pub struct PETELECOM {
+        #[rasn(identifier = "telecom-header")]
+        pub telecom_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-telecom")]
+        pub df_telecom: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: Option<File>,
+        #[rasn(identifier = "ef-rma")]
+        pub ef_rma: Option<File>,
+        #[rasn(identifier = "ef-sume")]
+        pub ef_sume: Option<File>,
+        #[rasn(identifier = "ef-ice-dn")]
+        pub ef_ice_dn: Option<File>,
+        #[rasn(identifier = "ef-ice-ff")]
+        pub ef_ice_ff: Option<File>,
+        #[rasn(identifier = "ef-psismsc")]
+        pub ef_psismsc: Option<File>,
+        #[rasn(identifier = "df-graphics")]
+        pub df_graphics: Option<File>,
+        #[rasn(identifier = "ef-img")]
+        pub ef_img: Option<File>,
+        #[rasn(identifier = "ef-iidf")]
+        pub ef_iidf: Option<File>,
+        #[rasn(identifier = "ef-ice-graphics")]
+        pub ef_ice_graphics: Option<File>,
+        #[rasn(identifier = "ef-launch-scws")]
+        pub ef_launch_scws: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: Option<File>,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+        #[rasn(identifier = "df-multimedia")]
+        pub df_multimedia: Option<File>,
+        #[rasn(identifier = "ef-mml")]
+        pub ef_mml: Option<File>,
+        #[rasn(identifier = "ef-mmdf")]
+        pub ef_mmdf: Option<File>,
+        #[rasn(identifier = "df-mmss")]
+        pub df_mmss: Option<File>,
+        #[rasn(identifier = "ef-mlpl")]
+        pub ef_mlpl: Option<File>,
+        #[rasn(identifier = "ef-mspl")]
+        pub ef_mspl: Option<File>,
+        #[rasn(identifier = "ef-mmssmode")]
+        pub ef_mmssmode: Option<File>,
+        #[rasn(identifier = "df-mcs")]
+        pub df_mcs: Option<File>,
+        #[rasn(identifier = "ef-mst")]
+        pub ef_mst: Option<File>,
+        #[rasn(identifier = "ef-mcs-config")]
+        pub ef_mcs_config: Option<File>,
+        #[rasn(identifier = "df-v2x")]
+        pub df_v2x: Option<File>,
+        #[rasn(identifier = "ef-vst")]
+        pub ef_vst: Option<File>,
+        #[rasn(identifier = "ef-v2x-config")]
+        pub ef_v2x_config: Option<File>,
+        #[rasn(identifier = "ef-v2xp-pc5")]
+        pub ef_v2xp_pc5: Option<File>,
+        #[rasn(identifier = "ef-v2xp-Uu")]
+        pub ef_v2xp_uu: Option<File>,
+        #[rasn(identifier = "df-a2x")]
+        pub df_a2x: Option<File>,
+        #[rasn(identifier = "ef-ast")]
+        pub ef_ast: Option<File>,
+        #[rasn(identifier = "ef-a2x-config")]
+        pub ef_a2x_config: Option<File>,
+        #[rasn(identifier = "ef-a2xp-pc5")]
+        pub ef_a2xp_pc5: Option<File>,
+        #[rasn(identifier = "ef-a2x-ddaap-pc5")]
+        pub ef_a2x_ddaap_pc5: Option<File>,
+        #[rasn(identifier = "ef-a2x-dc2p-pc5")]
+        pub ef_a2x_dc2p_pc5: Option<File>,
+        #[rasn(identifier = "ef-a2xp-Uu")]
+        pub ef_a2xp_uu: Option<File>,
+    }
+    impl PETELECOM {
+        pub fn new(
+            telecom_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_telecom: File,
+            ef_arr: Option<File>,
+            ef_rma: Option<File>,
+            ef_sume: Option<File>,
+            ef_ice_dn: Option<File>,
+            ef_ice_ff: Option<File>,
+            ef_psismsc: Option<File>,
+            df_graphics: Option<File>,
+            ef_img: Option<File>,
+            ef_iidf: Option<File>,
+            ef_ice_graphics: Option<File>,
+            ef_launch_scws: Option<File>,
+            ef_icon: Option<File>,
+            df_phonebook: Option<File>,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+            df_multimedia: Option<File>,
+            ef_mml: Option<File>,
+            ef_mmdf: Option<File>,
+            df_mmss: Option<File>,
+            ef_mlpl: Option<File>,
+            ef_mspl: Option<File>,
+            ef_mmssmode: Option<File>,
+            df_mcs: Option<File>,
+            ef_mst: Option<File>,
+            ef_mcs_config: Option<File>,
+            df_v2x: Option<File>,
+            ef_vst: Option<File>,
+            ef_v2x_config: Option<File>,
+            ef_v2xp_pc5: Option<File>,
+            ef_v2xp_uu: Option<File>,
+            df_a2x: Option<File>,
+            ef_ast: Option<File>,
+            ef_a2x_config: Option<File>,
+            ef_a2xp_pc5: Option<File>,
+            ef_a2x_ddaap_pc5: Option<File>,
+            ef_a2x_dc2p_pc5: Option<File>,
+            ef_a2xp_uu: Option<File>,
+        ) -> Self {
+            Self {
+                telecom_header,
+                template_id,
+                df_telecom,
+                ef_arr,
+                ef_rma,
+                ef_sume,
+                ef_ice_dn,
+                ef_ice_ff,
+                ef_psismsc,
+                df_graphics,
+                ef_img,
+                ef_iidf,
+                ef_ice_graphics,
+                ef_launch_scws,
+                ef_icon,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+                df_multimedia,
+                ef_mml,
+                ef_mmdf,
+                df_mmss,
+                ef_mlpl,
+                ef_mspl,
+                ef_mmssmode,
+                df_mcs,
+                ef_mst,
+                ef_mcs_config,
+                df_v2x,
+                ef_vst,
+                ef_v2x_config,
+                ef_v2xp_pc5,
+                ef_v2xp_uu,
+                df_a2x,
+                ef_ast,
+                ef_a2x_config,
+                ef_a2xp_pc5,
+                ef_a2x_ddaap_pc5,
+                ef_a2x_dc2p_pc5,
+                ef_a2xp_uu,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-USIM")]
+    #[non_exhaustive]
+    pub struct PEUSIM {
+        #[rasn(identifier = "usim-header")]
+        pub usim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-usim")]
+        pub adf_usim: File,
+        #[rasn(identifier = "ef-imsi")]
+        pub ef_imsi: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-keys")]
+        pub ef_keys: Option<File>,
+        #[rasn(identifier = "ef-keysPS")]
+        pub ef_keys_ps: Option<File>,
+        #[rasn(identifier = "ef-hpplmn")]
+        pub ef_hpplmn: Option<File>,
+        #[rasn(identifier = "ef-ust")]
+        pub ef_ust: File,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: File,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: File,
+        #[rasn(identifier = "ef-start-hfn")]
+        pub ef_start_hfn: Option<File>,
+        #[rasn(identifier = "ef-threshold")]
+        pub ef_threshold: Option<File>,
+        #[rasn(identifier = "ef-psloci")]
+        pub ef_psloci: Option<File>,
+        #[rasn(identifier = "ef-acc")]
+        pub ef_acc: File,
+        #[rasn(identifier = "ef-fplmn")]
+        pub ef_fplmn: Option<File>,
+        #[rasn(identifier = "ef-loci")]
+        pub ef_loci: Option<File>,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: File,
+        #[rasn(identifier = "ef-netpar")]
+        pub ef_netpar: Option<File>,
+        #[rasn(identifier = "ef-epsloci")]
+        pub ef_epsloci: Option<File>,
+        #[rasn(identifier = "ef-epsnsc")]
+        pub ef_epsnsc: Option<File>,
+    }
+    impl PEUSIM {
+        pub fn new(
+            usim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_usim: File,
+            ef_imsi: File,
+            ef_arr: File,
+            ef_keys: Option<File>,
+            ef_keys_ps: Option<File>,
+            ef_hpplmn: Option<File>,
+            ef_ust: File,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_spn: File,
+            ef_est: File,
+            ef_start_hfn: Option<File>,
+            ef_threshold: Option<File>,
+            ef_psloci: Option<File>,
+            ef_acc: File,
+            ef_fplmn: Option<File>,
+            ef_loci: Option<File>,
+            ef_ad: Option<File>,
+            ef_ecc: File,
+            ef_netpar: Option<File>,
+            ef_epsloci: Option<File>,
+            ef_epsnsc: Option<File>,
+        ) -> Self {
+            Self {
+                usim_header,
+                template_id,
+                adf_usim,
+                ef_imsi,
+                ef_arr,
+                ef_keys,
+                ef_keys_ps,
+                ef_hpplmn,
+                ef_ust,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_spn,
+                ef_est,
+                ef_start_hfn,
+                ef_threshold,
+                ef_psloci,
+                ef_acc,
+                ef_fplmn,
+                ef_loci,
+                ef_ad,
+                ef_ecc,
+                ef_netpar,
+                ef_epsloci,
+                ef_epsnsc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEHeader {
+        pub mandated: Option<()>,
+        pub identification: UInt15,
+    }
+    impl PEHeader {
+        pub fn new(mandated: Option<()>, identification: UInt15) -> Self {
+            Self {
+                mandated,
+                identification,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEStatus {
+        pub status: Integer,
+        pub identification: Option<UInt15>,
+        #[rasn(identifier = "additional-information")]
+        pub additional_information: Option<UInt8>,
+        pub offset: Option<UInt31>,
+    }
+    impl PEStatus {
+        pub fn new(
+            status: Integer,
+            identification: Option<UInt15>,
+            additional_information: Option<UInt8>,
+            offset: Option<UInt31>,
+        ) -> Self {
+            Self {
+                status,
+                identification,
+                additional_information,
+                offset,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PINConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PINKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pinValue")]
+        pub pin_value: OctetString,
+        #[rasn(identifier = "unblockingPINReference")]
+        pub unblocking_pinreference: Option<PUKKeyReferenceValue>,
+        #[rasn(
+            default = "pinconfiguration_pin_attributes_default",
+            identifier = "pinAttributes"
+        )]
+        pub pin_attributes: UInt8,
+        #[rasn(
+            default = "pinconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PINConfiguration {
+        pub fn new(
+            key_reference: PINKeyReferenceValue,
+            pin_value: OctetString,
+            unblocking_pinreference: Option<PUKKeyReferenceValue>,
+            pin_attributes: UInt8,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                pin_value,
+                unblocking_pinreference,
+                pin_attributes,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pinconfiguration_pin_attributes_default() -> UInt8 {
+        UInt8(7)
+    }
+    fn pinconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(51)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PINKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PUKConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PUKKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pukValue")]
+        pub puk_value: OctetString,
+        #[rasn(
+            default = "pukconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PUKConfiguration {
+        pub fn new(
+            key_reference: PUKKeyReferenceValue,
+            puk_value: OctetString,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                puk_value,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pukconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(170)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PUKKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ProfileElement {
+        header(ProfileHeader),
+        genericFileManagement(PEGenericFileManagement),
+        pinCodes(PEPINCodes),
+        pukCodes(PEPUKCodes),
+        akaParameter(PEAKAParameter),
+        cdmaParameter(PECDMAParameter),
+        securityDomain(PESecurityDomain),
+        rfm(PERFM),
+        application(PEApplication),
+        nonStandard(PENonStandard),
+        end(PEEnd),
+        ssimEapTLSParameters(PESSIMEAPTLSParameters),
+        rfu2(PEDummy),
+        rfu3(PEDummy),
+        rfu4(PEDummy),
+        rfu5(PEDummy),
+        mf(PEMF),
+        cd(PECD),
+        telecom(PETELECOM),
+        usim(PEUSIM),
+        #[rasn(identifier = "opt-usim")]
+        opt_usim(PEOPTUSIM),
+        isim(PEISIM),
+        #[rasn(identifier = "opt-isim")]
+        opt_isim(PEOPTISIM),
+        phonebook(PEPHONEBOOK),
+        #[rasn(identifier = "gsm-access")]
+        gsm_access(PEGSMACCESS),
+        csim(PECSIM),
+        #[rasn(identifier = "opt-csim")]
+        opt_csim(PEOPTCSIM),
+        eap(PEEAP),
+        #[rasn(identifier = "df-5gs")]
+        df_5gs(PEDF5GS),
+        #[rasn(identifier = "df-saip")]
+        df_saip(PEDFSAIP),
+        #[rasn(identifier = "df-snpn")]
+        df_snpn(PEDFSNPN),
+        #[rasn(identifier = "df-5gprose")]
+        df_5gprose(PEDF5GPROSE),
+        iot(PEIoT),
+        #[rasn(identifier = "opt-iot")]
+        opt_iot(PEOPTIoT),
+        ssim(PESSIM),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub aid: ApplicationIdentifier,
+        #[rasn(size("2"))]
+        pub version: OctetString,
+    }
+    impl AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub fn new(aid: ApplicationIdentifier, version: OctetString) -> Self {
+            Self { aid, version }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ProfileHeaderEUICCMandatoryAIDs(
+        pub SequenceOf<AnonymousProfileHeaderEUICCMandatoryAIDs>,
+    );
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ProfileHeader {
+        #[rasn(identifier = "major-version")]
+        pub major_version: UInt8,
+        #[rasn(identifier = "minor-version")]
+        pub minor_version: UInt8,
+        #[rasn(identifier = "profileType")]
+        pub profile_type: Option<Utf8String>,
+        #[rasn(size("10"))]
+        pub iccid: OctetString,
+        pub pol: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-services")]
+        pub e_uicc_mandatory_services: ServicesList,
+        #[rasn(identifier = "eUICC-Mandatory-GFSTEList")]
+        pub e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+        #[rasn(identifier = "connectivityParameters")]
+        pub connectivity_parameters: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-AIDs")]
+        pub e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+        #[rasn(identifier = "iotOptions")]
+        pub iot_options: Option<IotOptions>,
+    }
+    impl ProfileHeader {
+        pub fn new(
+            major_version: UInt8,
+            minor_version: UInt8,
+            profile_type: Option<Utf8String>,
+            iccid: OctetString,
+            pol: Option<OctetString>,
+            e_uicc_mandatory_services: ServicesList,
+            e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+            connectivity_parameters: Option<OctetString>,
+            e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+            iot_options: Option<IotOptions>,
+        ) -> Self {
+            Self {
+                major_version,
+                minor_version,
+                profile_type,
+                iccid,
+                pol,
+                e_uicc_mandatory_services,
+                e_uicc_mandatory_gfstelist,
+                connectivity_parameters,
+                e_uicc_mandatory_aids,
+                iot_options,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ProprietaryInfo {
+        #[rasn(
+            size("1"),
+            tag(private, 0),
+            default = "proprietary_info_special_file_information_default",
+            identifier = "specialFileInformation"
+        )]
+        pub special_file_information: OctetString,
+        #[rasn(size("1..=200"), tag(private, 1), identifier = "fillPattern")]
+        pub fill_pattern: Option<OctetString>,
+        #[rasn(size("1..=200"), tag(private, 2), identifier = "repeatPattern")]
+        pub repeat_pattern: Option<OctetString>,
+        #[rasn(tag(context, 6), identifier = "maximumFileSize")]
+        pub maximum_file_size: Option<OctetString>,
+        #[rasn(
+            size("1"),
+            tag(context, 4),
+            default = "proprietary_info_file_details_default",
+            identifier = "fileDetails"
+        )]
+        pub file_details: OctetString,
+    }
+    impl ProprietaryInfo {
+        pub fn new(
+            special_file_information: OctetString,
+            fill_pattern: Option<OctetString>,
+            repeat_pattern: Option<OctetString>,
+            maximum_file_size: Option<OctetString>,
+            file_details: OctetString,
+        ) -> Self {
+            Self {
+                special_file_information,
+                fill_pattern,
+                repeat_pattern,
+                maximum_file_size,
+                file_details,
+            }
+        }
+    }
+    fn proprietary_info_special_file_information_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    fn proprietary_info_file_details_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[1])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ServicesList {
+        pub contactless: Option<()>,
+        pub usim: Option<()>,
+        pub isim: Option<()>,
+        pub csim: Option<()>,
+        pub milenage: Option<()>,
+        pub tuak128: Option<()>,
+        pub cave: Option<()>,
+        #[rasn(identifier = "gba-usim")]
+        pub gba_usim: Option<()>,
+        #[rasn(identifier = "gba-isim")]
+        pub gba_isim: Option<()>,
+        pub mbms: Option<()>,
+        pub eap: Option<()>,
+        pub javacard: Option<()>,
+        pub multos: Option<()>,
+        #[rasn(identifier = "multiple-usim")]
+        pub multiple_usim: Option<()>,
+        #[rasn(identifier = "multiple-isim")]
+        pub multiple_isim: Option<()>,
+        #[rasn(identifier = "multiple-csim")]
+        pub multiple_csim: Option<()>,
+        pub tuak256: Option<()>,
+        #[rasn(identifier = "usim-test-algorithm")]
+        pub usim_test_algorithm: Option<()>,
+        #[rasn(identifier = "ber-tlv")]
+        pub ber_tlv: Option<()>,
+        #[rasn(identifier = "dfLink")]
+        pub df_link: Option<()>,
+        #[rasn(identifier = "cat-tp")]
+        pub cat_tp: Option<()>,
+        #[rasn(identifier = "get-identity")]
+        pub get_identity: Option<()>,
+        #[rasn(identifier = "profile-a-x25519")]
+        pub profile_a_x25519: Option<()>,
+        #[rasn(identifier = "profile-b-p256")]
+        pub profile_b_p256: Option<()>,
+        #[rasn(identifier = "suciCalculatorApi")]
+        pub suci_calculator_api: Option<()>,
+        #[rasn(identifier = "dns-resolution")]
+        pub dns_resolution: Option<()>,
+        pub scp11ac: Option<()>,
+        #[rasn(identifier = "scp11c-authorization-mechanism")]
+        pub scp11c_authorization_mechanism: Option<()>,
+        pub s16mode: Option<()>,
+        pub eaka: Option<()>,
+        #[rasn(identifier = "suci-nswo")]
+        pub suci_nswo: Option<()>,
+        #[rasn(identifier = "network-id")]
+        pub network_id: Option<()>,
+        pub coap: Option<()>,
+        #[rasn(identifier = "gbauApi")]
+        pub gbau_api: Option<()>,
+        #[rasn(identifier = "uir5GProSe")]
+        pub uir5_gpro_se: Option<()>,
+        #[rasn(identifier = "ssim-Eap-Tls")]
+        pub ssim_eap_tls: Option<()>,
+        #[rasn(identifier = "ssim-Eap-Aka-prime")]
+        pub ssim_eap_aka_prime: Option<()>,
+        #[rasn(identifier = "usatAppPairing")]
+        pub usat_app_pairing: Option<()>,
+    }
+    impl ServicesList {
+        pub fn new(
+            contactless: Option<()>,
+            usim: Option<()>,
+            isim: Option<()>,
+            csim: Option<()>,
+            milenage: Option<()>,
+            tuak128: Option<()>,
+            cave: Option<()>,
+            gba_usim: Option<()>,
+            gba_isim: Option<()>,
+            mbms: Option<()>,
+            eap: Option<()>,
+            javacard: Option<()>,
+            multos: Option<()>,
+            multiple_usim: Option<()>,
+            multiple_isim: Option<()>,
+            multiple_csim: Option<()>,
+            tuak256: Option<()>,
+            usim_test_algorithm: Option<()>,
+            ber_tlv: Option<()>,
+            df_link: Option<()>,
+            cat_tp: Option<()>,
+            get_identity: Option<()>,
+            profile_a_x25519: Option<()>,
+            profile_b_p256: Option<()>,
+            suci_calculator_api: Option<()>,
+            dns_resolution: Option<()>,
+            scp11ac: Option<()>,
+            scp11c_authorization_mechanism: Option<()>,
+            s16mode: Option<()>,
+            eaka: Option<()>,
+            suci_nswo: Option<()>,
+            network_id: Option<()>,
+            coap: Option<()>,
+            gbau_api: Option<()>,
+            uir5_gpro_se: Option<()>,
+            ssim_eap_tls: Option<()>,
+            ssim_eap_aka_prime: Option<()>,
+            usat_app_pairing: Option<()>,
+        ) -> Self {
+            Self {
+                contactless,
+                usim,
+                isim,
+                csim,
+                milenage,
+                tuak128,
+                cave,
+                gba_usim,
+                gba_isim,
+                mbms,
+                eap,
+                javacard,
+                multos,
+                multiple_usim,
+                multiple_isim,
+                multiple_csim,
+                tuak256,
+                usim_test_algorithm,
+                ber_tlv,
+                df_link,
+                cat_tp,
+                get_identity,
+                profile_a_x25519,
+                profile_b_p256,
+                suci_calculator_api,
+                dns_resolution,
+                scp11ac,
+                scp11c_authorization_mechanism,
+                s16mode,
+                eaka,
+                suci_nswo,
+                network_id,
+                coap,
+                gbau_api,
+                uir5_gpro_se,
+                ssim_eap_tls,
+                ssim_eap_aka_prime,
+                usat_app_pairing,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TS102226AdditionalContactlessParameters {
+        #[rasn(identifier = "protocolParameterData")]
+        pub protocol_parameter_data: OctetString,
+    }
+    impl TS102226AdditionalContactlessParameters {
+        pub fn new(protocol_parameter_data: OctetString) -> Self {
+            Self {
+                protocol_parameter_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct UICCApplicationParameters {
+        #[rasn(
+            tag(context, 0),
+            identifier = "uiccToolkitApplicationSpecificParametersField"
+        )]
+        pub uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 1),
+            identifier = "uiccAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_access_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 2),
+            identifier = "uiccAdministrativeAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+    }
+    impl UICCApplicationParameters {
+        pub fn new(
+            uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+            uicc_access_application_specific_parameters_field: Option<OctetString>,
+            uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+        ) -> Self {
+            Self {
+                uicc_toolkit_application_specific_parameters_field,
+                uicc_access_application_specific_parameters_field,
+                uicc_administrative_access_application_specific_parameters_field,
+            }
+        }
+    }
+    #[doc = " Definition of UICCCapability"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct UICCCapability(pub BitString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=32767"))]
+    pub struct UInt15(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct UInt16(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=2147483647"))]
+    pub struct UInt31(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct UInt8(pub u8);
+    pub static MAX_UINT15: LazyLock<Integer> = LazyLock::new(|| Integer::from(32767i128));
+    pub static MAX_UINT16: LazyLock<Integer> = LazyLock::new(|| Integer::from(65535i128));
+    pub static MAX_UINT31: LazyLock<Integer> = LazyLock::new(|| Integer::from(2147483647i128));
+    #[doc = " As defined in X.509 Public Key Infrastructure Certificate [RFC5280]"]
+    #[doc = " Basic integer types, for size constraints"]
+    pub static MAX_UINT8: LazyLock<Integer> = LazyLock::new(|| Integer::from(255i128));
+}

--- a/rasn-compiler-tests/tests/snapshots/structured_types__sequence_of_fixed_octet_with_default.snap
+++ b/rasn-compiler-tests/tests/snapshots/structured_types__sequence_of_fixed_octet_with_default.snap
@@ -1,0 +1,49 @@
+---
+source: rasn-compiler-tests/tests/structured_types.rs
+description: "\n        MySeq ::= SEQUENCE {\n            items SEQUENCE OF OCTET STRING (SIZE(3)) DEFAULT {'AABBCC'H}\n        }\n    "
+---
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod test_module {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousMySeqItems(pub FixedOctetString<3usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct MySeqItems(pub SequenceOf<AnonymousMySeqItems>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    pub struct MySeq {
+        #[rasn(default = "my_seq_items_default")]
+        pub items: MySeqItems,
+    }
+    impl MySeq {
+        pub fn new(items: MySeqItems) -> Self {
+            Self { items }
+        }
+    }
+    impl std::default::Default for MySeq {
+        fn default() -> Self {
+            Self {
+                items: my_seq_items_default(),
+            }
+        }
+    }
+    fn my_seq_items_default() -> MySeqItems {
+        MySeqItems(alloc::vec![AnonymousMySeqItems(FixedOctetString::new([
+            170u8, 187u8, 204u8
+        ]))])
+    }
+}

--- a/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v2_3_1_compiles.snap
+++ b/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v2_3_1_compiles.snap
@@ -423,7 +423,7 @@ pub mod pedefinitions {
         }
     }
     fn anonymous_key_object_key_compontents_mac_length_default() -> UInt8 {
-        8
+        UInt8(8)
     }
     #[doc = " Inner type "]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
@@ -562,41 +562,41 @@ pub mod pedefinitions {
     fn peakaparameter_sqn_age_limit_default() -> OctetString {
         <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
     }
-    fn peakaparameter_sqn_init_default() -> SequenceOf<OctetString> {
-        alloc::vec![
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0])
-        ]
+    fn peakaparameter_sqn_init_default() -> PEAKAParameterSqnInit {
+        PEAKAParameterSqnInit(alloc::vec![
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8]))
+        ])
     }
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "PE-Application")]

--- a/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v2_3_1_compiles.snap
+++ b/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v2_3_1_compiles.snap
@@ -1,0 +1,2822 @@
+---
+source: rasn-compiler-tests/tests/tca_tests.rs
+---
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod pedefinitions {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ADFRFMAccess {
+        #[rasn(identifier = "adfAID")]
+        pub adf_aid: ApplicationIdentifier,
+        #[rasn(identifier = "adfAccessDomain")]
+        pub adf_access_domain: OctetString,
+        #[rasn(identifier = "adfAdminAccessDomain")]
+        pub adf_admin_access_domain: OctetString,
+    }
+    impl ADFRFMAccess {
+        pub fn new(
+            adf_aid: ApplicationIdentifier,
+            adf_access_domain: OctetString,
+            adf_admin_access_domain: OctetString,
+        ) -> Self {
+            Self {
+                adf_aid,
+                adf_access_domain,
+                adf_admin_access_domain,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct AlgoParameter {
+        #[rasn(identifier = "algorithmID")]
+        pub algorithm_id: Integer,
+        #[rasn(size("1"), identifier = "algorithmOptions")]
+        pub algorithm_options: OctetString,
+        pub key: OctetString,
+        pub opc: OctetString,
+        #[rasn(
+            size("5"),
+            default = "algo_parameter_rotation_constants_default",
+            identifier = "rotationConstants"
+        )]
+        pub rotation_constants: OctetString,
+        #[rasn(
+            size("80"),
+            default = "algo_parameter_xoring_constants_default",
+            identifier = "xoringConstants"
+        )]
+        pub xoring_constants: OctetString,
+        #[rasn(size("3"), identifier = "authCounterMax")]
+        pub auth_counter_max: Option<OctetString>,
+        #[rasn(
+            default = "algo_parameter_number_of_keccak_default",
+            identifier = "numberOfKeccak"
+        )]
+        pub number_of_keccak: UInt8,
+    }
+    impl AlgoParameter {
+        pub fn new(
+            algorithm_id: Integer,
+            algorithm_options: OctetString,
+            key: OctetString,
+            opc: OctetString,
+            rotation_constants: OctetString,
+            xoring_constants: OctetString,
+            auth_counter_max: Option<OctetString>,
+            number_of_keccak: UInt8,
+        ) -> Self {
+            Self {
+                algorithm_id,
+                algorithm_options,
+                key,
+                opc,
+                rotation_constants,
+                xoring_constants,
+                auth_counter_max,
+                number_of_keccak,
+            }
+        }
+    }
+    fn algo_parameter_rotation_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[64, 0, 32, 64, 96])
+    }
+    fn algo_parameter_xoring_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8,
+        ])
+    }
+    fn algo_parameter_number_of_keccak_default() -> UInt8 {
+        UInt8(1)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("5..=16"))]
+    pub struct ApplicationIdentifier(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationInstance {
+        #[rasn(tag(application, 15), identifier = "applicationLoadPackageAID")]
+        pub application_load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "classAID")]
+        pub class_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "extraditeSecurityDomainAID")]
+        pub extradite_security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 2), identifier = "applicationPrivileges")]
+        pub application_privileges: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 3),
+            default = "application_instance_life_cycle_state_default",
+            identifier = "lifeCycleState"
+        )]
+        pub life_cycle_state: OctetString,
+        #[rasn(tag(private, 9), identifier = "applicationSpecificParametersC9")]
+        pub application_specific_parameters_c9: OctetString,
+        #[rasn(tag(private, 15), identifier = "systemSpecificParameters")]
+        pub system_specific_parameters: Option<ApplicationSystemParameters>,
+        #[rasn(tag(private, 10), identifier = "applicationParameters")]
+        pub application_parameters: Option<UICCApplicationParameters>,
+        #[rasn(size("1.."), identifier = "processData")]
+        pub process_data: Option<SequenceOf<OctetString>>,
+    }
+    impl ApplicationInstance {
+        pub fn new(
+            application_load_package_aid: ApplicationIdentifier,
+            class_aid: ApplicationIdentifier,
+            instance_aid: ApplicationIdentifier,
+            extradite_security_domain_aid: Option<ApplicationIdentifier>,
+            application_privileges: OctetString,
+            life_cycle_state: OctetString,
+            application_specific_parameters_c9: OctetString,
+            system_specific_parameters: Option<ApplicationSystemParameters>,
+            application_parameters: Option<UICCApplicationParameters>,
+            process_data: Option<SequenceOf<OctetString>>,
+        ) -> Self {
+            Self {
+                application_load_package_aid,
+                class_aid,
+                instance_aid,
+                extradite_security_domain_aid,
+                application_privileges,
+                life_cycle_state,
+                application_specific_parameters_c9,
+                system_specific_parameters,
+                application_parameters,
+                process_data,
+            }
+        }
+    }
+    fn application_instance_life_cycle_state_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[7])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationLoadPackage {
+        #[rasn(tag(application, 15), identifier = "loadPackageAID")]
+        pub load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(private, 6), identifier = "nonVolatileCodeLimitC6")]
+        pub non_volatile_code_limit_c6: Option<OctetString>,
+        #[rasn(tag(private, 7), identifier = "volatileDataLimitC7")]
+        pub volatile_data_limit_c7: Option<OctetString>,
+        #[rasn(tag(private, 8), identifier = "nonVolatileDataLimitC8")]
+        pub non_volatile_data_limit_c8: Option<OctetString>,
+        #[rasn(tag(private, 1), identifier = "hashValue")]
+        pub hash_value: Option<OctetString>,
+        #[rasn(tag(private, 4), identifier = "loadBlockObject")]
+        pub load_block_object: OctetString,
+    }
+    impl ApplicationLoadPackage {
+        pub fn new(
+            load_package_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            non_volatile_code_limit_c6: Option<OctetString>,
+            volatile_data_limit_c7: Option<OctetString>,
+            non_volatile_data_limit_c8: Option<OctetString>,
+            hash_value: Option<OctetString>,
+            load_block_object: OctetString,
+        ) -> Self {
+            Self {
+                load_package_aid,
+                security_domain_aid,
+                non_volatile_code_limit_c6,
+                volatile_data_limit_c7,
+                non_volatile_data_limit_c8,
+                hash_value,
+                load_block_object,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationSystemParameters {
+        #[rasn(size("2..=4"), tag(private, 7), identifier = "volatileMemoryQuotaC7")]
+        pub volatile_memory_quota_c7: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 8),
+            identifier = "nonVolatileMemoryQuotaC8"
+        )]
+        pub non_volatile_memory_quota_c8: Option<OctetString>,
+        #[rasn(tag(private, 11), identifier = "globalServiceParameters")]
+        pub global_service_parameters: Option<OctetString>,
+        #[rasn(tag(private, 15), identifier = "implicitSelectionParameter")]
+        pub implicit_selection_parameter: Option<OctetString>,
+        #[rasn(size("2..=4"), tag(private, 23), identifier = "volatileReservedMemory")]
+        pub volatile_reserved_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 24),
+            identifier = "nonVolatileReservedMemory"
+        )]
+        pub non_volatile_reserved_memory: Option<OctetString>,
+        #[rasn(tag(private, 10), identifier = "ts102226SIMFileAccessToolkitParameter")]
+        pub ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+        #[rasn(
+            tag(context, 0),
+            identifier = "ts102226AdditionalContactlessParameters"
+        )]
+        pub ts102226_additional_contactless_parameters:
+            Option<TS102226AdditionalContactlessParameters>,
+        #[rasn(tag(private, 25), identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+        #[rasn(tag(private, 26), identifier = "userInteractionContactlessParameters")]
+        pub user_interaction_contactless_parameters: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 2),
+            identifier = "cumulativeGrantedVolatileMemory"
+        )]
+        pub cumulative_granted_volatile_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 3),
+            identifier = "cumulativeGrantedNonVolatileMemory"
+        )]
+        pub cumulative_granted_non_volatile_memory: Option<OctetString>,
+    }
+    impl ApplicationSystemParameters {
+        pub fn new(
+            volatile_memory_quota_c7: Option<OctetString>,
+            non_volatile_memory_quota_c8: Option<OctetString>,
+            global_service_parameters: Option<OctetString>,
+            implicit_selection_parameter: Option<OctetString>,
+            volatile_reserved_memory: Option<OctetString>,
+            non_volatile_reserved_memory: Option<OctetString>,
+            ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+            ts102226_additional_contactless_parameters: Option<
+                TS102226AdditionalContactlessParameters,
+            >,
+            contactless_protocol_parameters: Option<OctetString>,
+            user_interaction_contactless_parameters: Option<OctetString>,
+            cumulative_granted_volatile_memory: Option<OctetString>,
+            cumulative_granted_non_volatile_memory: Option<OctetString>,
+        ) -> Self {
+            Self {
+                volatile_memory_quota_c7,
+                non_volatile_memory_quota_c8,
+                global_service_parameters,
+                implicit_selection_parameter,
+                volatile_reserved_memory,
+                non_volatile_reserved_memory,
+                ts102226_simfile_access_toolkit_parameter,
+                ts102226_additional_contactless_parameters,
+                contactless_protocol_parameters,
+                user_interaction_contactless_parameters,
+                cumulative_granted_volatile_memory,
+                cumulative_granted_non_volatile_memory,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct EUICCResponse {
+        #[rasn(identifier = "peStatus")]
+        pub pe_status: SequenceOf<PEStatus>,
+        #[rasn(identifier = "profileInstallationAborted")]
+        pub profile_installation_aborted: Option<()>,
+        #[rasn(identifier = "statusMessage")]
+        pub status_message: Option<Utf8String>,
+    }
+    impl EUICCResponse {
+        pub fn new(
+            pe_status: SequenceOf<PEStatus>,
+            profile_installation_aborted: Option<()>,
+            status_message: Option<Utf8String>,
+        ) -> Self {
+            Self {
+                pe_status,
+                profile_installation_aborted,
+                status_message,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct Fcp {
+        #[rasn(size("2..=4"), tag(context, 2), identifier = "fileDescriptor")]
+        pub file_descriptor: Option<OctetString>,
+        #[rasn(size("2"), tag(context, 3), identifier = "fileID")]
+        pub file_id: Option<OctetString>,
+        #[rasn(tag(context, 4), identifier = "dfName")]
+        pub df_name: Option<ApplicationIdentifier>,
+        #[rasn(size("1"), tag(context, 10), default = "fcp_lcsi_default")]
+        pub lcsi: OctetString,
+        #[rasn(
+            size("1..=3"),
+            tag(context, 11),
+            identifier = "securityAttributesReferenced"
+        )]
+        pub security_attributes_referenced: Option<OctetString>,
+        #[rasn(tag(context, 0), identifier = "efFileSize")]
+        pub ef_file_size: Option<OctetString>,
+        #[rasn(tag(private, 6), identifier = "pinStatusTemplateDO")]
+        pub pin_status_template_do: Option<OctetString>,
+        #[rasn(size("0..=1"), tag(context, 8), identifier = "shortEFID")]
+        pub short_efid: Option<OctetString>,
+        #[rasn(tag(context, 5), identifier = "proprietaryEFInfo")]
+        pub proprietary_efinfo: Option<ProprietaryInfo>,
+        #[rasn(tag(private, 7), identifier = "linkPath")]
+        pub link_path: Option<OctetString>,
+    }
+    impl Fcp {
+        pub fn new(
+            file_descriptor: Option<OctetString>,
+            file_id: Option<OctetString>,
+            df_name: Option<ApplicationIdentifier>,
+            lcsi: OctetString,
+            security_attributes_referenced: Option<OctetString>,
+            ef_file_size: Option<OctetString>,
+            pin_status_template_do: Option<OctetString>,
+            short_efid: Option<OctetString>,
+            proprietary_efinfo: Option<ProprietaryInfo>,
+            link_path: Option<OctetString>,
+        ) -> Self {
+            Self {
+                file_descriptor,
+                file_id,
+                df_name,
+                lcsi,
+                security_attributes_referenced,
+                ef_file_size,
+                pin_status_template_do,
+                short_efid,
+                proprietary_efinfo,
+                link_path,
+            }
+        }
+    }
+    fn fcp_lcsi_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[5])
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFile {
+        doNotCreate(()),
+        fileDescriptor(Fcp),
+        fillFileOffset(UInt16),
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct File(pub SequenceOf<AnonymousFile>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFileManagement {
+        #[rasn(size("0..=8"), tag(context, 0))]
+        filePath(OctetString),
+        #[rasn(tag(application, 2))]
+        createFCP(Fcp),
+        fillFileOffset(UInt16),
+        #[rasn(tag(context, 1))]
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct FileManagement(pub SequenceOf<AnonymousFileManagement>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousKeyObjectKeyCompontents {
+        #[rasn(tag(context, 0), identifier = "keyType")]
+        pub key_type: OctetString,
+        #[rasn(tag(context, 6), identifier = "keyData")]
+        pub key_data: OctetString,
+        #[rasn(
+            tag(context, 7),
+            default = "anonymous_key_object_key_compontents_mac_length_default",
+            identifier = "macLength"
+        )]
+        pub mac_length: UInt8,
+    }
+    impl AnonymousKeyObjectKeyCompontents {
+        pub fn new(key_type: OctetString, key_data: OctetString, mac_length: UInt8) -> Self {
+            Self {
+                key_type,
+                key_data,
+                mac_length,
+            }
+        }
+    }
+    fn anonymous_key_object_key_compontents_mac_length_default() -> UInt8 {
+        8
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct KeyObjectKeyCompontents(pub SequenceOf<AnonymousKeyObjectKeyCompontents>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct KeyObject {
+        #[rasn(size("1..=2"), tag(context, 21), identifier = "keyUsageQualifier")]
+        pub key_usage_qualifier: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 22),
+            default = "key_object_key_access_default",
+            identifier = "keyAccess"
+        )]
+        pub key_access: OctetString,
+        #[rasn(size("1"), tag(context, 2), identifier = "keyIdentifier")]
+        pub key_identifier: OctetString,
+        #[rasn(size("1"), tag(context, 3), identifier = "keyVersionNumber")]
+        pub key_version_number: OctetString,
+        #[rasn(tag(context, 5), identifier = "keyCounterValue")]
+        pub key_counter_value: Option<OctetString>,
+        #[rasn(identifier = "keyCompontents")]
+        pub key_compontents: KeyObjectKeyCompontents,
+    }
+    impl KeyObject {
+        pub fn new(
+            key_usage_qualifier: OctetString,
+            key_access: OctetString,
+            key_identifier: OctetString,
+            key_version_number: OctetString,
+            key_counter_value: Option<OctetString>,
+            key_compontents: KeyObjectKeyCompontents,
+        ) -> Self {
+            Self {
+                key_usage_qualifier,
+                key_access,
+                key_identifier,
+                key_version_number,
+                key_counter_value,
+                key_compontents,
+            }
+        }
+    }
+    fn key_object_key_access_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MappingParameter {
+        #[rasn(size("1"), identifier = "mappingOptions")]
+        pub mapping_options: OctetString,
+        #[rasn(identifier = "mappingSource")]
+        pub mapping_source: ApplicationIdentifier,
+    }
+    impl MappingParameter {
+        pub fn new(mapping_options: OctetString, mapping_source: ApplicationIdentifier) -> Self {
+            Self {
+                mapping_options,
+                mapping_source,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEAKAParameterAlgoConfiguration {
+        mappingParameter(MappingParameter),
+        algoParameter(AlgoParameter),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPEAKAParameterSqnInit(pub FixedOctetString<6usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("32"))]
+    pub struct PEAKAParameterSqnInit(pub SequenceOf<AnonymousPEAKAParameterSqnInit>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-AKAParameter")]
+    #[non_exhaustive]
+    pub struct PEAKAParameter {
+        #[rasn(identifier = "aka-header")]
+        pub aka_header: PEHeader,
+        #[rasn(identifier = "algoConfiguration")]
+        pub algo_configuration: PEAKAParameterAlgoConfiguration,
+        #[rasn(
+            size("1"),
+            default = "peakaparameter_sqn_options_default",
+            identifier = "sqnOptions"
+        )]
+        pub sqn_options: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_delta_default",
+            identifier = "sqnDelta"
+        )]
+        pub sqn_delta: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_age_limit_default",
+            identifier = "sqnAgeLimit"
+        )]
+        pub sqn_age_limit: OctetString,
+        #[rasn(default = "peakaparameter_sqn_init_default", identifier = "sqnInit")]
+        pub sqn_init: PEAKAParameterSqnInit,
+    }
+    impl PEAKAParameter {
+        pub fn new(
+            aka_header: PEHeader,
+            algo_configuration: PEAKAParameterAlgoConfiguration,
+            sqn_options: OctetString,
+            sqn_delta: OctetString,
+            sqn_age_limit: OctetString,
+            sqn_init: PEAKAParameterSqnInit,
+        ) -> Self {
+            Self {
+                aka_header,
+                algo_configuration,
+                sqn_options,
+                sqn_delta,
+                sqn_age_limit,
+                sqn_init,
+            }
+        }
+    }
+    fn peakaparameter_sqn_options_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[2])
+    }
+    fn peakaparameter_sqn_delta_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_age_limit_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_init_default() -> SequenceOf<OctetString> {
+        alloc::vec![
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0])
+        ]
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Application")]
+    #[non_exhaustive]
+    pub struct PEApplication {
+        #[rasn(identifier = "app-Header")]
+        pub app_header: PEHeader,
+        #[rasn(identifier = "loadBlock")]
+        pub load_block: Option<ApplicationLoadPackage>,
+        #[rasn(size("1.."), identifier = "instanceList")]
+        pub instance_list: Option<SequenceOf<ApplicationInstance>>,
+    }
+    impl PEApplication {
+        pub fn new(
+            app_header: PEHeader,
+            load_block: Option<ApplicationLoadPackage>,
+            instance_list: Option<SequenceOf<ApplicationInstance>>,
+        ) -> Self {
+            Self {
+                app_header,
+                load_block,
+                instance_list,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CD")]
+    #[non_exhaustive]
+    pub struct PECD {
+        #[rasn(identifier = "cd-header")]
+        pub cd_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-cd")]
+        pub df_cd: File,
+        #[rasn(identifier = "ef-launchpad")]
+        pub ef_launchpad: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+    }
+    impl PECD {
+        pub fn new(
+            cd_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_cd: File,
+            ef_launchpad: Option<File>,
+            ef_icon: Option<File>,
+        ) -> Self {
+            Self {
+                cd_header,
+                template_id,
+                df_cd,
+                ef_launchpad,
+                ef_icon,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CDMAParameter")]
+    #[non_exhaustive]
+    pub struct PECDMAParameter {
+        #[rasn(identifier = "cdma-header")]
+        pub cdma_header: PEHeader,
+        #[rasn(size("8"), identifier = "authenticationKey")]
+        pub authentication_key: OctetString,
+        #[rasn(size("16"))]
+        pub ssd: Option<OctetString>,
+        #[rasn(size("2..=32"), identifier = "hrpdAccessAuthenticationData")]
+        pub hrpd_access_authentication_data: Option<OctetString>,
+        #[rasn(size("3..=483"), identifier = "simpleIPAuthenticationData")]
+        pub simple_ipauthentication_data: Option<OctetString>,
+        #[rasn(size("5..=957"), identifier = "mobileIPAuthenticationData")]
+        pub mobile_ipauthentication_data: Option<OctetString>,
+    }
+    impl PECDMAParameter {
+        pub fn new(
+            cdma_header: PEHeader,
+            authentication_key: OctetString,
+            ssd: Option<OctetString>,
+            hrpd_access_authentication_data: Option<OctetString>,
+            simple_ipauthentication_data: Option<OctetString>,
+            mobile_ipauthentication_data: Option<OctetString>,
+        ) -> Self {
+            Self {
+                cdma_header,
+                authentication_key,
+                ssd,
+                hrpd_access_authentication_data,
+                simple_ipauthentication_data,
+                mobile_ipauthentication_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CSIM")]
+    #[non_exhaustive]
+    pub struct PECSIM {
+        #[rasn(identifier = "csim-header")]
+        pub csim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-csim")]
+        pub adf_csim: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-call-count")]
+        pub ef_call_count: File,
+        #[rasn(identifier = "ef-imsi-m")]
+        pub ef_imsi_m: File,
+        #[rasn(identifier = "ef-imsi-t")]
+        pub ef_imsi_t: File,
+        #[rasn(identifier = "ef-tmsi")]
+        pub ef_tmsi: File,
+        #[rasn(identifier = "ef-ah")]
+        pub ef_ah: File,
+        #[rasn(identifier = "ef-aop")]
+        pub ef_aop: File,
+        #[rasn(identifier = "ef-aloc")]
+        pub ef_aloc: File,
+        #[rasn(identifier = "ef-cdmahome")]
+        pub ef_cdmahome: File,
+        #[rasn(identifier = "ef-znregi")]
+        pub ef_znregi: File,
+        #[rasn(identifier = "ef-snregi")]
+        pub ef_snregi: File,
+        #[rasn(identifier = "ef-distregi")]
+        pub ef_distregi: File,
+        #[rasn(identifier = "ef-accolc")]
+        pub ef_accolc: File,
+        #[rasn(identifier = "ef-term")]
+        pub ef_term: File,
+        #[rasn(identifier = "ef-acp")]
+        pub ef_acp: File,
+        #[rasn(identifier = "ef-prl")]
+        pub ef_prl: File,
+        #[rasn(identifier = "ef-ruimid")]
+        pub ef_ruimid: File,
+        #[rasn(identifier = "ef-csim-st")]
+        pub ef_csim_st: File,
+        #[rasn(identifier = "ef-spc")]
+        pub ef_spc: File,
+        #[rasn(identifier = "ef-otapaspc")]
+        pub ef_otapaspc: File,
+        #[rasn(identifier = "ef-namlock")]
+        pub ef_namlock: File,
+        #[rasn(identifier = "ef-ota")]
+        pub ef_ota: File,
+        #[rasn(identifier = "ef-sp")]
+        pub ef_sp: File,
+        #[rasn(identifier = "ef-esn-meid-me")]
+        pub ef_esn_meid_me: File,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: File,
+        #[rasn(identifier = "ef-usgind")]
+        pub ef_usgind: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: File,
+        #[rasn(identifier = "ef-max-prl")]
+        pub ef_max_prl: File,
+        #[rasn(identifier = "ef-spcs")]
+        pub ef_spcs: File,
+        #[rasn(identifier = "ef-mecrp")]
+        pub ef_mecrp: File,
+        #[rasn(identifier = "ef-home-tag")]
+        pub ef_home_tag: File,
+        #[rasn(identifier = "ef-group-tag")]
+        pub ef_group_tag: File,
+        #[rasn(identifier = "ef-specific-tag")]
+        pub ef_specific_tag: File,
+        #[rasn(identifier = "ef-call-prompt")]
+        pub ef_call_prompt: File,
+    }
+    impl PECSIM {
+        pub fn new(
+            csim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_csim: File,
+            ef_arr: File,
+            ef_call_count: File,
+            ef_imsi_m: File,
+            ef_imsi_t: File,
+            ef_tmsi: File,
+            ef_ah: File,
+            ef_aop: File,
+            ef_aloc: File,
+            ef_cdmahome: File,
+            ef_znregi: File,
+            ef_snregi: File,
+            ef_distregi: File,
+            ef_accolc: File,
+            ef_term: File,
+            ef_acp: File,
+            ef_prl: File,
+            ef_ruimid: File,
+            ef_csim_st: File,
+            ef_spc: File,
+            ef_otapaspc: File,
+            ef_namlock: File,
+            ef_ota: File,
+            ef_sp: File,
+            ef_esn_meid_me: File,
+            ef_li: File,
+            ef_usgind: File,
+            ef_ad: File,
+            ef_max_prl: File,
+            ef_spcs: File,
+            ef_mecrp: File,
+            ef_home_tag: File,
+            ef_group_tag: File,
+            ef_specific_tag: File,
+            ef_call_prompt: File,
+        ) -> Self {
+            Self {
+                csim_header,
+                template_id,
+                adf_csim,
+                ef_arr,
+                ef_call_count,
+                ef_imsi_m,
+                ef_imsi_t,
+                ef_tmsi,
+                ef_ah,
+                ef_aop,
+                ef_aloc,
+                ef_cdmahome,
+                ef_znregi,
+                ef_snregi,
+                ef_distregi,
+                ef_accolc,
+                ef_term,
+                ef_acp,
+                ef_prl,
+                ef_ruimid,
+                ef_csim_st,
+                ef_spc,
+                ef_otapaspc,
+                ef_namlock,
+                ef_ota,
+                ef_sp,
+                ef_esn_meid_me,
+                ef_li,
+                ef_usgind,
+                ef_ad,
+                ef_max_prl,
+                ef_spcs,
+                ef_mecrp,
+                ef_home_tag,
+                ef_group_tag,
+                ef_specific_tag,
+                ef_call_prompt,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-5GS")]
+    #[non_exhaustive]
+    pub struct PEDF5GS {
+        #[rasn(identifier = "df-5gs-header")]
+        pub df_5gs_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-5gs")]
+        pub df_df_5gs: File,
+        #[rasn(identifier = "ef-5gs3gpploci")]
+        pub ef_5gs3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gpploci")]
+        pub ef_5gsn3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gs3gppnsc")]
+        pub ef_5gs3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gppnsc")]
+        pub ef_5gsn3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gauthkeys")]
+        pub ef_5gauthkeys: Option<File>,
+        #[rasn(identifier = "ef-uac-aic")]
+        pub ef_uac_aic: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info")]
+        pub ef_suci_calc_info: Option<File>,
+        #[rasn(identifier = "ef-opl5g")]
+        pub ef_opl5g: Option<File>,
+        #[rasn(identifier = "ef-nsi")]
+        pub ef_nsi: Option<File>,
+        #[rasn(identifier = "ef-routing-indicator")]
+        pub ef_routing_indicator: Option<File>,
+    }
+    impl PEDF5GS {
+        pub fn new(
+            df_5gs_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_5gs: File,
+            ef_5gs3gpploci: Option<File>,
+            ef_5gsn3gpploci: Option<File>,
+            ef_5gs3gppnsc: Option<File>,
+            ef_5gsn3gppnsc: Option<File>,
+            ef_5gauthkeys: Option<File>,
+            ef_uac_aic: Option<File>,
+            ef_suci_calc_info: Option<File>,
+            ef_opl5g: Option<File>,
+            ef_nsi: Option<File>,
+            ef_routing_indicator: Option<File>,
+        ) -> Self {
+            Self {
+                df_5gs_header,
+                template_id,
+                df_df_5gs,
+                ef_5gs3gpploci,
+                ef_5gsn3gpploci,
+                ef_5gs3gppnsc,
+                ef_5gsn3gppnsc,
+                ef_5gauthkeys,
+                ef_uac_aic,
+                ef_suci_calc_info,
+                ef_opl5g,
+                ef_nsi,
+                ef_routing_indicator,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-SAIP")]
+    #[non_exhaustive]
+    pub struct PEDFSAIP {
+        #[rasn(identifier = "df-saip-header")]
+        pub df_saip_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-saip")]
+        pub df_df_saip: File,
+        #[rasn(identifier = "ef-suci-calc-info-usim")]
+        pub ef_suci_calc_info_usim: Option<File>,
+    }
+    impl PEDFSAIP {
+        pub fn new(
+            df_saip_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_saip: File,
+            ef_suci_calc_info_usim: Option<File>,
+        ) -> Self {
+            Self {
+                df_saip_header,
+                template_id,
+                df_df_saip,
+                ef_suci_calc_info_usim,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Dummy")]
+    #[non_exhaustive]
+    pub struct PEDummy {}
+    impl PEDummy {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+    impl std::default::Default for PEDummy {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-EAP")]
+    #[non_exhaustive]
+    pub struct PEEAP {
+        #[rasn(identifier = "eap-header")]
+        pub eap_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-eap")]
+        pub df_eap: File,
+        #[rasn(identifier = "ef-eapkeys")]
+        pub ef_eapkeys: Option<File>,
+        #[rasn(identifier = "ef-eapstatus")]
+        pub ef_eapstatus: File,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-ps")]
+        pub ef_ps: Option<File>,
+        #[rasn(identifier = "ef-curid")]
+        pub ef_curid: Option<File>,
+        #[rasn(identifier = "ef-reid")]
+        pub ef_reid: Option<File>,
+        #[rasn(identifier = "ef-realm")]
+        pub ef_realm: Option<File>,
+    }
+    impl PEEAP {
+        pub fn new(
+            eap_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_eap: File,
+            ef_eapkeys: Option<File>,
+            ef_eapstatus: File,
+            ef_puid: Option<File>,
+            ef_ps: Option<File>,
+            ef_curid: Option<File>,
+            ef_reid: Option<File>,
+            ef_realm: Option<File>,
+        ) -> Self {
+            Self {
+                eap_header,
+                template_id,
+                df_eap,
+                ef_eapkeys,
+                ef_eapstatus,
+                ef_puid,
+                ef_ps,
+                ef_curid,
+                ef_reid,
+                ef_realm,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-End")]
+    #[non_exhaustive]
+    pub struct PEEnd {
+        #[rasn(identifier = "end-header")]
+        pub end_header: PEHeader,
+    }
+    impl PEEnd {
+        pub fn new(end_header: PEHeader) -> Self {
+            Self { end_header }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GSM-ACCESS")]
+    #[non_exhaustive]
+    pub struct PEGSMACCESS {
+        #[rasn(identifier = "gsm-access-header")]
+        pub gsm_access_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-gsm-access")]
+        pub df_gsm_access: File,
+        #[rasn(identifier = "ef-kc")]
+        pub ef_kc: Option<File>,
+        #[rasn(identifier = "ef-kcgprs")]
+        pub ef_kcgprs: Option<File>,
+        #[rasn(identifier = "ef-cpbcch")]
+        pub ef_cpbcch: Option<File>,
+        #[rasn(identifier = "ef-invscan")]
+        pub ef_invscan: Option<File>,
+    }
+    impl PEGSMACCESS {
+        pub fn new(
+            gsm_access_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_gsm_access: File,
+            ef_kc: Option<File>,
+            ef_kcgprs: Option<File>,
+            ef_cpbcch: Option<File>,
+            ef_invscan: Option<File>,
+        ) -> Self {
+            Self {
+                gsm_access_header,
+                template_id,
+                df_gsm_access,
+                ef_kc,
+                ef_kcgprs,
+                ef_cpbcch,
+                ef_invscan,
+            }
+        }
+    }
+    #[doc = " Create GenericFileManagement"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GenericFileManagement")]
+    #[non_exhaustive]
+    pub struct PEGenericFileManagement {
+        #[rasn(identifier = "gfm-header")]
+        pub gfm_header: PEHeader,
+        #[rasn(size("1.."), identifier = "fileManagementCMD")]
+        pub file_management_cmd: SequenceOf<FileManagement>,
+    }
+    impl PEGenericFileManagement {
+        pub fn new(gfm_header: PEHeader, file_management_cmd: SequenceOf<FileManagement>) -> Self {
+            Self {
+                gfm_header,
+                file_management_cmd,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-ISIM")]
+    #[non_exhaustive]
+    pub struct PEISIM {
+        #[rasn(identifier = "isim-header")]
+        pub isim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-isim")]
+        pub adf_isim: File,
+        #[rasn(identifier = "ef-impi")]
+        pub ef_impi: File,
+        #[rasn(identifier = "ef-impu")]
+        pub ef_impu: File,
+        #[rasn(identifier = "ef-domain")]
+        pub ef_domain: File,
+        #[rasn(identifier = "ef-ist")]
+        pub ef_ist: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+    }
+    impl PEISIM {
+        pub fn new(
+            isim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_isim: File,
+            ef_impi: File,
+            ef_impu: File,
+            ef_domain: File,
+            ef_ist: File,
+            ef_ad: Option<File>,
+            ef_arr: File,
+        ) -> Self {
+            Self {
+                isim_header,
+                template_id,
+                adf_isim,
+                ef_impi,
+                ef_impu,
+                ef_domain,
+                ef_ist,
+                ef_ad,
+                ef_arr,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-MF")]
+    #[non_exhaustive]
+    pub struct PEMF {
+        #[rasn(identifier = "mf-header")]
+        pub mf_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        pub mf: File,
+        #[rasn(identifier = "ef-pl")]
+        pub ef_pl: Option<File>,
+        #[rasn(identifier = "ef-iccid")]
+        pub ef_iccid: File,
+        #[rasn(identifier = "ef-dir")]
+        pub ef_dir: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-umpc")]
+        pub ef_umpc: Option<File>,
+    }
+    impl PEMF {
+        pub fn new(
+            mf_header: PEHeader,
+            template_id: ObjectIdentifier,
+            mf: File,
+            ef_pl: Option<File>,
+            ef_iccid: File,
+            ef_dir: File,
+            ef_arr: File,
+            ef_umpc: Option<File>,
+        ) -> Self {
+            Self {
+                mf_header,
+                template_id,
+                mf,
+                ef_pl,
+                ef_iccid,
+                ef_dir,
+                ef_arr,
+                ef_umpc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-NonStandard")]
+    #[non_exhaustive]
+    pub struct PENonStandard {
+        #[rasn(identifier = "nonStandard-header")]
+        pub non_standard_header: PEHeader,
+        #[rasn(identifier = "issuerID")]
+        pub issuer_id: ObjectIdentifier,
+        pub content: OctetString,
+    }
+    impl PENonStandard {
+        pub fn new(
+            non_standard_header: PEHeader,
+            issuer_id: ObjectIdentifier,
+            content: OctetString,
+        ) -> Self {
+            Self {
+                non_standard_header,
+                issuer_id,
+                content,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-CSIM")]
+    #[non_exhaustive]
+    pub struct PEOPTCSIM {
+        #[rasn(identifier = "optcsim-header")]
+        pub optcsim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-ssci")]
+        pub ef_ssci: Option<File>,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-ssfc")]
+        pub ef_ssfc: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: Option<File>,
+        #[rasn(identifier = "ef-mdn")]
+        pub ef_mdn: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: Option<File>,
+        #[rasn(identifier = "ef-me3gpdopc")]
+        pub ef_me3gpdopc: Option<File>,
+        #[rasn(identifier = "ef-3gpdopm")]
+        pub ef_3gpdopm: Option<File>,
+        #[rasn(identifier = "ef-sipcap")]
+        pub ef_sipcap: Option<File>,
+        #[rasn(identifier = "ef-mipcap")]
+        pub ef_mipcap: Option<File>,
+        #[rasn(identifier = "ef-sipupp")]
+        pub ef_sipupp: Option<File>,
+        #[rasn(identifier = "ef-mipupp")]
+        pub ef_mipupp: Option<File>,
+        #[rasn(identifier = "ef-sipsp")]
+        pub ef_sipsp: Option<File>,
+        #[rasn(identifier = "ef-mipsp")]
+        pub ef_mipsp: Option<File>,
+        #[rasn(identifier = "ef-sippapss")]
+        pub ef_sippapss: Option<File>,
+        #[rasn(identifier = "ef-puzl")]
+        pub ef_puzl: Option<File>,
+        #[rasn(identifier = "ef-maxpuzl")]
+        pub ef_maxpuzl: Option<File>,
+        #[rasn(identifier = "ef-hrpdcap")]
+        pub ef_hrpdcap: Option<File>,
+        #[rasn(identifier = "ef-hrpdupp")]
+        pub ef_hrpdupp: Option<File>,
+        #[rasn(identifier = "ef-csspr")]
+        pub ef_csspr: Option<File>,
+        #[rasn(identifier = "ef-atc")]
+        pub ef_atc: Option<File>,
+        #[rasn(identifier = "ef-eprl")]
+        pub ef_eprl: Option<File>,
+        #[rasn(identifier = "ef-bcsmscfg")]
+        pub ef_bcsmscfg: Option<File>,
+        #[rasn(identifier = "ef-bcsmspref")]
+        pub ef_bcsmspref: Option<File>,
+        #[rasn(identifier = "ef-bcsmstable")]
+        pub ef_bcsmstable: Option<File>,
+        #[rasn(identifier = "ef-bcsmsp")]
+        pub ef_bcsmsp: Option<File>,
+        #[rasn(identifier = "ef-bakpara")]
+        pub ef_bakpara: Option<File>,
+        #[rasn(identifier = "ef-upbakpara")]
+        pub ef_upbakpara: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-auth-capability")]
+        pub ef_auth_capability: Option<File>,
+        #[rasn(identifier = "ef-3gcik")]
+        pub ef_3gcik: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-cdmacnl")]
+        pub ef_cdmacnl: Option<File>,
+        #[rasn(identifier = "ef-sf-euimid")]
+        pub ef_sf_euimid: Option<File>,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: Option<File>,
+        #[rasn(identifier = "ef-hidden-key")]
+        pub ef_hidden_key: Option<File>,
+        #[rasn(identifier = "ef-lcsver")]
+        pub ef_lcsver: Option<File>,
+        #[rasn(identifier = "ef-lcscp")]
+        pub ef_lcscp: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-applabels")]
+        pub ef_applabels: Option<File>,
+        #[rasn(identifier = "ef-model")]
+        pub ef_model: Option<File>,
+        #[rasn(identifier = "ef-rc")]
+        pub ef_rc: Option<File>,
+        #[rasn(identifier = "ef-smscap")]
+        pub ef_smscap: Option<File>,
+        #[rasn(identifier = "ef-mipflags")]
+        pub ef_mipflags: Option<File>,
+        #[rasn(identifier = "ef-3gpduppext")]
+        pub ef_3gpduppext: Option<File>,
+        #[rasn(identifier = "ef-ipv6cap")]
+        pub ef_ipv6cap: Option<File>,
+        #[rasn(identifier = "ef-tcpconfig")]
+        pub ef_tcpconfig: Option<File>,
+        #[rasn(identifier = "ef-dgc")]
+        pub ef_dgc: Option<File>,
+        #[rasn(identifier = "ef-wapbrowsercp")]
+        pub ef_wapbrowsercp: Option<File>,
+        #[rasn(identifier = "ef-wapbrowserbm")]
+        pub ef_wapbrowserbm: Option<File>,
+        #[rasn(identifier = "ef-mmsconfig")]
+        pub ef_mmsconfig: Option<File>,
+        #[rasn(identifier = "ef-jdl")]
+        pub ef_jdl: Option<File>,
+    }
+    impl PEOPTCSIM {
+        pub fn new(
+            optcsim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_ssci: Option<File>,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_ssfc: Option<File>,
+            ef_spn: Option<File>,
+            ef_mdn: Option<File>,
+            ef_ecc: Option<File>,
+            ef_me3gpdopc: Option<File>,
+            ef_3gpdopm: Option<File>,
+            ef_sipcap: Option<File>,
+            ef_mipcap: Option<File>,
+            ef_sipupp: Option<File>,
+            ef_mipupp: Option<File>,
+            ef_sipsp: Option<File>,
+            ef_mipsp: Option<File>,
+            ef_sippapss: Option<File>,
+            ef_puzl: Option<File>,
+            ef_maxpuzl: Option<File>,
+            ef_hrpdcap: Option<File>,
+            ef_hrpdupp: Option<File>,
+            ef_csspr: Option<File>,
+            ef_atc: Option<File>,
+            ef_eprl: Option<File>,
+            ef_bcsmscfg: Option<File>,
+            ef_bcsmspref: Option<File>,
+            ef_bcsmstable: Option<File>,
+            ef_bcsmsp: Option<File>,
+            ef_bakpara: Option<File>,
+            ef_upbakpara: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_auth_capability: Option<File>,
+            ef_3gcik: Option<File>,
+            ef_dck: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_cdmacnl: Option<File>,
+            ef_sf_euimid: Option<File>,
+            ef_est: Option<File>,
+            ef_hidden_key: Option<File>,
+            ef_lcsver: Option<File>,
+            ef_lcscp: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_applabels: Option<File>,
+            ef_model: Option<File>,
+            ef_rc: Option<File>,
+            ef_smscap: Option<File>,
+            ef_mipflags: Option<File>,
+            ef_3gpduppext: Option<File>,
+            ef_ipv6cap: Option<File>,
+            ef_tcpconfig: Option<File>,
+            ef_dgc: Option<File>,
+            ef_wapbrowsercp: Option<File>,
+            ef_wapbrowserbm: Option<File>,
+            ef_mmsconfig: Option<File>,
+            ef_jdl: Option<File>,
+        ) -> Self {
+            Self {
+                optcsim_header,
+                template_id,
+                ef_ssci,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_ssfc,
+                ef_spn,
+                ef_mdn,
+                ef_ecc,
+                ef_me3gpdopc,
+                ef_3gpdopm,
+                ef_sipcap,
+                ef_mipcap,
+                ef_sipupp,
+                ef_mipupp,
+                ef_sipsp,
+                ef_mipsp,
+                ef_sippapss,
+                ef_puzl,
+                ef_maxpuzl,
+                ef_hrpdcap,
+                ef_hrpdupp,
+                ef_csspr,
+                ef_atc,
+                ef_eprl,
+                ef_bcsmscfg,
+                ef_bcsmspref,
+                ef_bcsmstable,
+                ef_bcsmsp,
+                ef_bakpara,
+                ef_upbakpara,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_auth_capability,
+                ef_3gcik,
+                ef_dck,
+                ef_gid1,
+                ef_gid2,
+                ef_cdmacnl,
+                ef_sf_euimid,
+                ef_est,
+                ef_hidden_key,
+                ef_lcsver,
+                ef_lcscp,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_ici,
+                ef_oci,
+                ef_ext5,
+                ef_ccp2,
+                ef_applabels,
+                ef_model,
+                ef_rc,
+                ef_smscap,
+                ef_mipflags,
+                ef_3gpduppext,
+                ef_ipv6cap,
+                ef_tcpconfig,
+                ef_dgc,
+                ef_wapbrowsercp,
+                ef_wapbrowserbm,
+                ef_mmsconfig,
+                ef_jdl,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-ISIM")]
+    #[non_exhaustive]
+    pub struct PEOPTISIM {
+        #[rasn(identifier = "optisim-header")]
+        pub optisim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-pcscf")]
+        pub ef_pcscf: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+    }
+    impl PEOPTISIM {
+        pub fn new(
+            optisim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_pcscf: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_smsr: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_uicciari: Option<File>,
+        ) -> Self {
+            Self {
+                optisim_header,
+                template_id,
+                ef_pcscf,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_smsr,
+                ef_gbabp,
+                ef_gbanl,
+                ef_nafkca,
+                ef_uicciari,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-USIM")]
+    #[non_exhaustive]
+    pub struct PEOPTUSIM {
+        #[rasn(identifier = "optusim-header")]
+        pub optusim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: Option<File>,
+        #[rasn(identifier = "ef-acmax")]
+        pub ef_acmax: Option<File>,
+        #[rasn(identifier = "ef-acm")]
+        pub ef_acm: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-msisdn")]
+        pub ef_msisdn: Option<File>,
+        #[rasn(identifier = "ef-puct")]
+        pub ef_puct: Option<File>,
+        #[rasn(identifier = "ef-cbmi")]
+        pub ef_cbmi: Option<File>,
+        #[rasn(identifier = "ef-cbmid")]
+        pub ef_cbmid: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-cbmir")]
+        pub ef_cbmir: Option<File>,
+        #[rasn(identifier = "ef-plmnwact")]
+        pub ef_plmnwact: Option<File>,
+        #[rasn(identifier = "ef-oplmnwact")]
+        pub ef_oplmnwact: Option<File>,
+        #[rasn(identifier = "ef-hplmnwact")]
+        pub ef_hplmnwact: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-cnl")]
+        pub ef_cnl: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-bdn")]
+        pub ef_bdn: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-ext4")]
+        pub ef_ext4: Option<File>,
+        #[rasn(identifier = "ef-acl")]
+        pub ef_acl: Option<File>,
+        #[rasn(identifier = "ef-cmi")]
+        pub ef_cmi: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ict")]
+        pub ef_ict: Option<File>,
+        #[rasn(identifier = "ef-oct")]
+        pub ef_oct: Option<File>,
+        #[rasn(identifier = "ef-vgcs")]
+        pub ef_vgcs: Option<File>,
+        #[rasn(identifier = "ef-vgcss")]
+        pub ef_vgcss: Option<File>,
+        #[rasn(identifier = "ef-vbs")]
+        pub ef_vbs: Option<File>,
+        #[rasn(identifier = "ef-vbss")]
+        pub ef_vbss: Option<File>,
+        #[rasn(identifier = "ef-emlpp")]
+        pub ef_emlpp: Option<File>,
+        #[rasn(identifier = "ef-aaem")]
+        pub ef_aaem: Option<File>,
+        #[rasn(identifier = "ef-hiddenkey")]
+        pub ef_hiddenkey: Option<File>,
+        #[rasn(identifier = "ef-pnn")]
+        pub ef_pnn: Option<File>,
+        #[rasn(identifier = "ef-opl")]
+        pub ef_opl: Option<File>,
+        #[rasn(identifier = "ef-mbdn")]
+        pub ef_mbdn: Option<File>,
+        #[rasn(identifier = "ef-ext6")]
+        pub ef_ext6: Option<File>,
+        #[rasn(identifier = "ef-mbi")]
+        pub ef_mbi: Option<File>,
+        #[rasn(identifier = "ef-mwis")]
+        pub ef_mwis: Option<File>,
+        #[rasn(identifier = "ef-cfis")]
+        pub ef_cfis: Option<File>,
+        #[rasn(identifier = "ef-ext7")]
+        pub ef_ext7: Option<File>,
+        #[rasn(identifier = "ef-spdi")]
+        pub ef_spdi: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-nia")]
+        pub ef_nia: Option<File>,
+        #[rasn(identifier = "ef-vgcsca")]
+        pub ef_vgcsca: Option<File>,
+        #[rasn(identifier = "ef-vbsca")]
+        pub ef_vbsca: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-msk")]
+        pub ef_msk: Option<File>,
+        #[rasn(identifier = "ef-muk")]
+        pub ef_muk: Option<File>,
+        #[rasn(identifier = "ef-ehplmn")]
+        pub ef_ehplmn: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-ehplmnpi")]
+        pub ef_ehplmnpi: Option<File>,
+        #[rasn(identifier = "ef-lrplmnsi")]
+        pub ef_lrplmnsi: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-spni")]
+        pub ef_spni: Option<File>,
+        #[rasn(identifier = "ef-pnni")]
+        pub ef_pnni: Option<File>,
+        #[rasn(identifier = "ef-ncp-ip")]
+        pub ef_ncp_ip: Option<File>,
+        #[rasn(identifier = "ef-ufc")]
+        pub ef_ufc: Option<File>,
+        #[rasn(identifier = "ef-nasconfig")]
+        pub ef_nasconfig: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+        #[rasn(identifier = "ef-pws")]
+        pub ef_pws: Option<File>,
+        #[rasn(identifier = "ef-fdnuri")]
+        pub ef_fdnuri: Option<File>,
+        #[rasn(identifier = "ef-bdnuri")]
+        pub ef_bdnuri: Option<File>,
+        #[rasn(identifier = "ef-sdnuri")]
+        pub ef_sdnuri: Option<File>,
+        #[rasn(identifier = "ef-iwl")]
+        pub ef_iwl: Option<File>,
+        #[rasn(identifier = "ef-ips")]
+        pub ef_ips: Option<File>,
+        #[rasn(identifier = "ef-ipd")]
+        pub ef_ipd: Option<File>,
+    }
+    impl PEOPTUSIM {
+        pub fn new(
+            optusim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_li: Option<File>,
+            ef_acmax: Option<File>,
+            ef_acm: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_msisdn: Option<File>,
+            ef_puct: Option<File>,
+            ef_cbmi: Option<File>,
+            ef_cbmid: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_cbmir: Option<File>,
+            ef_plmnwact: Option<File>,
+            ef_oplmnwact: Option<File>,
+            ef_hplmnwact: Option<File>,
+            ef_dck: Option<File>,
+            ef_cnl: Option<File>,
+            ef_smsr: Option<File>,
+            ef_bdn: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_ext4: Option<File>,
+            ef_acl: Option<File>,
+            ef_cmi: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ict: Option<File>,
+            ef_oct: Option<File>,
+            ef_vgcs: Option<File>,
+            ef_vgcss: Option<File>,
+            ef_vbs: Option<File>,
+            ef_vbss: Option<File>,
+            ef_emlpp: Option<File>,
+            ef_aaem: Option<File>,
+            ef_hiddenkey: Option<File>,
+            ef_pnn: Option<File>,
+            ef_opl: Option<File>,
+            ef_mbdn: Option<File>,
+            ef_ext6: Option<File>,
+            ef_mbi: Option<File>,
+            ef_mwis: Option<File>,
+            ef_cfis: Option<File>,
+            ef_ext7: Option<File>,
+            ef_spdi: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_nia: Option<File>,
+            ef_vgcsca: Option<File>,
+            ef_vbsca: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_msk: Option<File>,
+            ef_muk: Option<File>,
+            ef_ehplmn: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_ehplmnpi: Option<File>,
+            ef_lrplmnsi: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_spni: Option<File>,
+            ef_pnni: Option<File>,
+            ef_ncp_ip: Option<File>,
+            ef_ufc: Option<File>,
+            ef_nasconfig: Option<File>,
+            ef_uicciari: Option<File>,
+            ef_pws: Option<File>,
+            ef_fdnuri: Option<File>,
+            ef_bdnuri: Option<File>,
+            ef_sdnuri: Option<File>,
+            ef_iwl: Option<File>,
+            ef_ips: Option<File>,
+            ef_ipd: Option<File>,
+        ) -> Self {
+            Self {
+                optusim_header,
+                template_id,
+                ef_li,
+                ef_acmax,
+                ef_acm,
+                ef_gid1,
+                ef_gid2,
+                ef_msisdn,
+                ef_puct,
+                ef_cbmi,
+                ef_cbmid,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_cbmir,
+                ef_plmnwact,
+                ef_oplmnwact,
+                ef_hplmnwact,
+                ef_dck,
+                ef_cnl,
+                ef_smsr,
+                ef_bdn,
+                ef_ext5,
+                ef_ccp2,
+                ef_ext4,
+                ef_acl,
+                ef_cmi,
+                ef_ici,
+                ef_oci,
+                ef_ict,
+                ef_oct,
+                ef_vgcs,
+                ef_vgcss,
+                ef_vbs,
+                ef_vbss,
+                ef_emlpp,
+                ef_aaem,
+                ef_hiddenkey,
+                ef_pnn,
+                ef_opl,
+                ef_mbdn,
+                ef_ext6,
+                ef_mbi,
+                ef_mwis,
+                ef_cfis,
+                ef_ext7,
+                ef_spdi,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_nia,
+                ef_vgcsca,
+                ef_vbsca,
+                ef_gbabp,
+                ef_msk,
+                ef_muk,
+                ef_ehplmn,
+                ef_gbanl,
+                ef_ehplmnpi,
+                ef_lrplmnsi,
+                ef_nafkca,
+                ef_spni,
+                ef_pnni,
+                ef_ncp_ip,
+                ef_ufc,
+                ef_nasconfig,
+                ef_uicciari,
+                ef_pws,
+                ef_fdnuri,
+                ef_bdnuri,
+                ef_sdnuri,
+                ef_iwl,
+                ef_ips,
+                ef_ipd,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PHONEBOOK")]
+    #[non_exhaustive]
+    pub struct PEPHONEBOOK {
+        #[rasn(identifier = "phonebook-header")]
+        pub phonebook_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: File,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+    }
+    impl PEPHONEBOOK {
+        pub fn new(
+            phonebook_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_phonebook: File,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+        ) -> Self {
+            Self {
+                phonebook_header,
+                template_id,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEPINCodesPinCodes {
+        #[rasn(size("1..=26"))]
+        pinconfig(SequenceOf<PINConfiguration>),
+        #[rasn(size("0..=8"))]
+        filePath(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PINCodes")]
+    #[non_exhaustive]
+    pub struct PEPINCodes {
+        #[rasn(identifier = "pin-Header")]
+        pub pin_header: PEHeader,
+        #[rasn(identifier = "pinCodes")]
+        pub pin_codes: PEPINCodesPinCodes,
+    }
+    impl PEPINCodes {
+        pub fn new(pin_header: PEHeader, pin_codes: PEPINCodesPinCodes) -> Self {
+            Self {
+                pin_header,
+                pin_codes,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PUKCodes")]
+    #[non_exhaustive]
+    pub struct PEPUKCodes {
+        #[rasn(identifier = "puk-Header")]
+        pub puk_header: PEHeader,
+        #[rasn(size("1..=16"), identifier = "pukCodes")]
+        pub puk_codes: SequenceOf<PUKConfiguration>,
+    }
+    impl PEPUKCodes {
+        pub fn new(puk_header: PEHeader, puk_codes: SequenceOf<PUKConfiguration>) -> Self {
+            Self {
+                puk_header,
+                puk_codes,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPERFMTarList(pub FixedOctetString<3usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct PERFMTarList(pub SequenceOf<AnonymousPERFMTarList>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "PE-RFM")]
+    #[non_exhaustive]
+    pub struct PERFM {
+        #[rasn(tag(context, 0), identifier = "rfm-header")]
+        pub rfm_header: PEHeader,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 0), identifier = "tarList")]
+        pub tar_list: Option<PERFMTarList>,
+        #[rasn(size("1"), tag(context, 1), identifier = "minimumSecurityLevel")]
+        pub minimum_security_level: OctetString,
+        #[rasn(identifier = "uiccAccessDomain")]
+        pub uicc_access_domain: OctetString,
+        #[rasn(identifier = "uiccAdminAccessDomain")]
+        pub uicc_admin_access_domain: OctetString,
+        #[rasn(identifier = "adfRFMAccess")]
+        pub adf_rfmaccess: Option<ADFRFMAccess>,
+    }
+    impl PERFM {
+        pub fn new(
+            rfm_header: PEHeader,
+            instance_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            tar_list: Option<PERFMTarList>,
+            minimum_security_level: OctetString,
+            uicc_access_domain: OctetString,
+            uicc_admin_access_domain: OctetString,
+            adf_rfmaccess: Option<ADFRFMAccess>,
+        ) -> Self {
+            Self {
+                rfm_header,
+                instance_aid,
+                security_domain_aid,
+                tar_list,
+                minimum_security_level,
+                uicc_access_domain,
+                uicc_admin_access_domain,
+                adf_rfmaccess,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainOpenPersoData {
+        #[rasn(tag(private, 25), identifier = "restrictParameter")]
+        pub restrict_parameter: Option<OctetString>,
+        #[rasn(identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+    }
+    impl PESecurityDomainOpenPersoData {
+        pub fn new(
+            restrict_parameter: Option<OctetString>,
+            contactless_protocol_parameters: Option<OctetString>,
+        ) -> Self {
+            Self {
+                restrict_parameter,
+                contactless_protocol_parameters,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainCatTpParameters {
+        #[rasn(identifier = "catTpMaxSduSize")]
+        pub cat_tp_max_sdu_size: UInt16,
+        #[rasn(identifier = "catTpMaxPduSize")]
+        pub cat_tp_max_pdu_size: UInt16,
+    }
+    impl PESecurityDomainCatTpParameters {
+        pub fn new(cat_tp_max_sdu_size: UInt16, cat_tp_max_pdu_size: UInt16) -> Self {
+            Self {
+                cat_tp_max_sdu_size,
+                cat_tp_max_pdu_size,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SecurityDomain")]
+    #[non_exhaustive]
+    pub struct PESecurityDomain {
+        #[rasn(identifier = "sd-Header")]
+        pub sd_header: PEHeader,
+        pub instance: ApplicationInstance,
+        #[rasn(size("1.."), identifier = "keyList")]
+        pub key_list: Option<SequenceOf<KeyObject>>,
+        #[rasn(size("1.."), identifier = "sdPersoData")]
+        pub sd_perso_data: Option<SequenceOf<OctetString>>,
+        #[rasn(identifier = "openPersoData")]
+        pub open_perso_data: Option<PESecurityDomainOpenPersoData>,
+        #[rasn(identifier = "catTpParameters")]
+        pub cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+    }
+    impl PESecurityDomain {
+        pub fn new(
+            sd_header: PEHeader,
+            instance: ApplicationInstance,
+            key_list: Option<SequenceOf<KeyObject>>,
+            sd_perso_data: Option<SequenceOf<OctetString>>,
+            open_perso_data: Option<PESecurityDomainOpenPersoData>,
+            cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+        ) -> Self {
+            Self {
+                sd_header,
+                instance,
+                key_list,
+                sd_perso_data,
+                open_perso_data,
+                cat_tp_parameters,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-TELECOM")]
+    #[non_exhaustive]
+    pub struct PETELECOM {
+        #[rasn(identifier = "telecom-header")]
+        pub telecom_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-telecom")]
+        pub df_telecom: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: Option<File>,
+        #[rasn(identifier = "ef-rma")]
+        pub ef_rma: Option<File>,
+        #[rasn(identifier = "ef-sume")]
+        pub ef_sume: Option<File>,
+        #[rasn(identifier = "ef-ice-dn")]
+        pub ef_ice_dn: Option<File>,
+        #[rasn(identifier = "ef-ice-ff")]
+        pub ef_ice_ff: Option<File>,
+        #[rasn(identifier = "ef-psismsc")]
+        pub ef_psismsc: Option<File>,
+        #[rasn(identifier = "df-graphics")]
+        pub df_graphics: Option<File>,
+        #[rasn(identifier = "ef-img")]
+        pub ef_img: Option<File>,
+        #[rasn(identifier = "ef-iidf")]
+        pub ef_iidf: Option<File>,
+        #[rasn(identifier = "ef-ice-graphics")]
+        pub ef_ice_graphics: Option<File>,
+        #[rasn(identifier = "ef-launch-scws")]
+        pub ef_launch_scws: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: Option<File>,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+        #[rasn(identifier = "df-multimedia")]
+        pub df_multimedia: Option<File>,
+        #[rasn(identifier = "ef-mml")]
+        pub ef_mml: Option<File>,
+        #[rasn(identifier = "ef-mmdf")]
+        pub ef_mmdf: Option<File>,
+        #[rasn(identifier = "df-mmss")]
+        pub df_mmss: Option<File>,
+        #[rasn(identifier = "ef-mlpl")]
+        pub ef_mlpl: Option<File>,
+        #[rasn(identifier = "ef-mspl")]
+        pub ef_mspl: Option<File>,
+        #[rasn(identifier = "ef-mmssmode")]
+        pub ef_mmssmode: Option<File>,
+    }
+    impl PETELECOM {
+        pub fn new(
+            telecom_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_telecom: File,
+            ef_arr: Option<File>,
+            ef_rma: Option<File>,
+            ef_sume: Option<File>,
+            ef_ice_dn: Option<File>,
+            ef_ice_ff: Option<File>,
+            ef_psismsc: Option<File>,
+            df_graphics: Option<File>,
+            ef_img: Option<File>,
+            ef_iidf: Option<File>,
+            ef_ice_graphics: Option<File>,
+            ef_launch_scws: Option<File>,
+            ef_icon: Option<File>,
+            df_phonebook: Option<File>,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+            df_multimedia: Option<File>,
+            ef_mml: Option<File>,
+            ef_mmdf: Option<File>,
+            df_mmss: Option<File>,
+            ef_mlpl: Option<File>,
+            ef_mspl: Option<File>,
+            ef_mmssmode: Option<File>,
+        ) -> Self {
+            Self {
+                telecom_header,
+                template_id,
+                df_telecom,
+                ef_arr,
+                ef_rma,
+                ef_sume,
+                ef_ice_dn,
+                ef_ice_ff,
+                ef_psismsc,
+                df_graphics,
+                ef_img,
+                ef_iidf,
+                ef_ice_graphics,
+                ef_launch_scws,
+                ef_icon,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+                df_multimedia,
+                ef_mml,
+                ef_mmdf,
+                df_mmss,
+                ef_mlpl,
+                ef_mspl,
+                ef_mmssmode,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-USIM")]
+    #[non_exhaustive]
+    pub struct PEUSIM {
+        #[rasn(identifier = "usim-header")]
+        pub usim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-usim")]
+        pub adf_usim: File,
+        #[rasn(identifier = "ef-imsi")]
+        pub ef_imsi: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-keys")]
+        pub ef_keys: Option<File>,
+        #[rasn(identifier = "ef-keysPS")]
+        pub ef_keys_ps: Option<File>,
+        #[rasn(identifier = "ef-hpplmn")]
+        pub ef_hpplmn: Option<File>,
+        #[rasn(identifier = "ef-ust")]
+        pub ef_ust: File,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: File,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: File,
+        #[rasn(identifier = "ef-start-hfn")]
+        pub ef_start_hfn: Option<File>,
+        #[rasn(identifier = "ef-threshold")]
+        pub ef_threshold: Option<File>,
+        #[rasn(identifier = "ef-psloci")]
+        pub ef_psloci: Option<File>,
+        #[rasn(identifier = "ef-acc")]
+        pub ef_acc: File,
+        #[rasn(identifier = "ef-fplmn")]
+        pub ef_fplmn: Option<File>,
+        #[rasn(identifier = "ef-loci")]
+        pub ef_loci: Option<File>,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: File,
+        #[rasn(identifier = "ef-netpar")]
+        pub ef_netpar: Option<File>,
+        #[rasn(identifier = "ef-epsloci")]
+        pub ef_epsloci: Option<File>,
+        #[rasn(identifier = "ef-epsnsc")]
+        pub ef_epsnsc: Option<File>,
+    }
+    impl PEUSIM {
+        pub fn new(
+            usim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_usim: File,
+            ef_imsi: File,
+            ef_arr: File,
+            ef_keys: Option<File>,
+            ef_keys_ps: Option<File>,
+            ef_hpplmn: Option<File>,
+            ef_ust: File,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_spn: File,
+            ef_est: File,
+            ef_start_hfn: Option<File>,
+            ef_threshold: Option<File>,
+            ef_psloci: Option<File>,
+            ef_acc: File,
+            ef_fplmn: Option<File>,
+            ef_loci: Option<File>,
+            ef_ad: Option<File>,
+            ef_ecc: File,
+            ef_netpar: Option<File>,
+            ef_epsloci: Option<File>,
+            ef_epsnsc: Option<File>,
+        ) -> Self {
+            Self {
+                usim_header,
+                template_id,
+                adf_usim,
+                ef_imsi,
+                ef_arr,
+                ef_keys,
+                ef_keys_ps,
+                ef_hpplmn,
+                ef_ust,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_spn,
+                ef_est,
+                ef_start_hfn,
+                ef_threshold,
+                ef_psloci,
+                ef_acc,
+                ef_fplmn,
+                ef_loci,
+                ef_ad,
+                ef_ecc,
+                ef_netpar,
+                ef_epsloci,
+                ef_epsnsc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEHeader {
+        pub mandated: Option<()>,
+        pub identification: UInt15,
+    }
+    impl PEHeader {
+        pub fn new(mandated: Option<()>, identification: UInt15) -> Self {
+            Self {
+                mandated,
+                identification,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEStatus {
+        pub status: Integer,
+        pub identification: Option<UInt15>,
+        #[rasn(identifier = "additional-information")]
+        pub additional_information: Option<UInt8>,
+        pub offset: Option<UInt31>,
+    }
+    impl PEStatus {
+        pub fn new(
+            status: Integer,
+            identification: Option<UInt15>,
+            additional_information: Option<UInt8>,
+            offset: Option<UInt31>,
+        ) -> Self {
+            Self {
+                status,
+                identification,
+                additional_information,
+                offset,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PINConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PINKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pinValue")]
+        pub pin_value: OctetString,
+        #[rasn(identifier = "unblockingPINReference")]
+        pub unblocking_pinreference: Option<PUKKeyReferenceValue>,
+        #[rasn(
+            default = "pinconfiguration_pin_attributes_default",
+            identifier = "pinAttributes"
+        )]
+        pub pin_attributes: UInt8,
+        #[rasn(
+            default = "pinconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PINConfiguration {
+        pub fn new(
+            key_reference: PINKeyReferenceValue,
+            pin_value: OctetString,
+            unblocking_pinreference: Option<PUKKeyReferenceValue>,
+            pin_attributes: UInt8,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                pin_value,
+                unblocking_pinreference,
+                pin_attributes,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pinconfiguration_pin_attributes_default() -> UInt8 {
+        UInt8(7)
+    }
+    fn pinconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(51)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PINKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PUKConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PUKKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pukValue")]
+        pub puk_value: OctetString,
+        #[rasn(
+            default = "pukconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PUKConfiguration {
+        pub fn new(
+            key_reference: PUKKeyReferenceValue,
+            puk_value: OctetString,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                puk_value,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pukconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(170)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PUKKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ProfileElement {
+        header(ProfileHeader),
+        genericFileManagement(PEGenericFileManagement),
+        pinCodes(PEPINCodes),
+        pukCodes(PEPUKCodes),
+        akaParameter(PEAKAParameter),
+        cdmaParameter(PECDMAParameter),
+        securityDomain(PESecurityDomain),
+        rfm(PERFM),
+        application(PEApplication),
+        nonStandard(PENonStandard),
+        end(PEEnd),
+        rfu1(PEDummy),
+        rfu2(PEDummy),
+        rfu3(PEDummy),
+        rfu4(PEDummy),
+        rfu5(PEDummy),
+        mf(PEMF),
+        cd(PECD),
+        telecom(PETELECOM),
+        usim(PEUSIM),
+        #[rasn(identifier = "opt-usim")]
+        opt_usim(PEOPTUSIM),
+        isim(PEISIM),
+        #[rasn(identifier = "opt-isim")]
+        opt_isim(PEOPTISIM),
+        phonebook(PEPHONEBOOK),
+        #[rasn(identifier = "gsm-access")]
+        gsm_access(PEGSMACCESS),
+        csim(PECSIM),
+        #[rasn(identifier = "opt-csim")]
+        opt_csim(PEOPTCSIM),
+        eap(PEEAP),
+        #[rasn(identifier = "df-5gs")]
+        df_5gs(PEDF5GS),
+        #[rasn(identifier = "df-saip")]
+        df_saip(PEDFSAIP),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub aid: ApplicationIdentifier,
+        #[rasn(size("2"))]
+        pub version: OctetString,
+    }
+    impl AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub fn new(aid: ApplicationIdentifier, version: OctetString) -> Self {
+            Self { aid, version }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ProfileHeaderEUICCMandatoryAIDs(
+        pub SequenceOf<AnonymousProfileHeaderEUICCMandatoryAIDs>,
+    );
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ProfileHeader {
+        #[rasn(identifier = "major-version")]
+        pub major_version: UInt8,
+        #[rasn(identifier = "minor-version")]
+        pub minor_version: UInt8,
+        #[rasn(identifier = "profileType")]
+        pub profile_type: Option<Utf8String>,
+        #[rasn(size("10"))]
+        pub iccid: OctetString,
+        pub pol: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-services")]
+        pub e_uicc_mandatory_services: ServicesList,
+        #[rasn(identifier = "eUICC-Mandatory-GFSTEList")]
+        pub e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+        #[rasn(identifier = "connectivityParameters")]
+        pub connectivity_parameters: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-AIDs")]
+        pub e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+    }
+    impl ProfileHeader {
+        pub fn new(
+            major_version: UInt8,
+            minor_version: UInt8,
+            profile_type: Option<Utf8String>,
+            iccid: OctetString,
+            pol: Option<OctetString>,
+            e_uicc_mandatory_services: ServicesList,
+            e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+            connectivity_parameters: Option<OctetString>,
+            e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+        ) -> Self {
+            Self {
+                major_version,
+                minor_version,
+                profile_type,
+                iccid,
+                pol,
+                e_uicc_mandatory_services,
+                e_uicc_mandatory_gfstelist,
+                connectivity_parameters,
+                e_uicc_mandatory_aids,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ProprietaryInfo {
+        #[rasn(
+            size("1"),
+            tag(private, 0),
+            default = "proprietary_info_special_file_information_default",
+            identifier = "specialFileInformation"
+        )]
+        pub special_file_information: OctetString,
+        #[rasn(size("1..=200"), tag(private, 1), identifier = "fillPattern")]
+        pub fill_pattern: Option<OctetString>,
+        #[rasn(size("1..=200"), tag(private, 2), identifier = "repeatPattern")]
+        pub repeat_pattern: Option<OctetString>,
+    }
+    impl ProprietaryInfo {
+        pub fn new(
+            special_file_information: OctetString,
+            fill_pattern: Option<OctetString>,
+            repeat_pattern: Option<OctetString>,
+        ) -> Self {
+            Self {
+                special_file_information,
+                fill_pattern,
+                repeat_pattern,
+            }
+        }
+    }
+    fn proprietary_info_special_file_information_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ServicesList {
+        pub contactless: Option<()>,
+        pub usim: Option<()>,
+        pub isim: Option<()>,
+        pub csim: Option<()>,
+        pub milenage: Option<()>,
+        pub tuak128: Option<()>,
+        pub cave: Option<()>,
+        #[rasn(identifier = "gba-usim")]
+        pub gba_usim: Option<()>,
+        #[rasn(identifier = "gba-isim")]
+        pub gba_isim: Option<()>,
+        pub mbms: Option<()>,
+        pub eap: Option<()>,
+        pub javacard: Option<()>,
+        pub multos: Option<()>,
+        #[rasn(identifier = "multiple-usim")]
+        pub multiple_usim: Option<()>,
+        #[rasn(identifier = "multiple-isim")]
+        pub multiple_isim: Option<()>,
+        #[rasn(identifier = "multiple-csim")]
+        pub multiple_csim: Option<()>,
+        pub tuak256: Option<()>,
+        #[rasn(identifier = "usim-test-algorithm")]
+        pub usim_test_algorithm: Option<()>,
+        #[rasn(identifier = "ber-tlv")]
+        pub ber_tlv: Option<()>,
+        #[rasn(identifier = "dfLink")]
+        pub df_link: Option<()>,
+        #[rasn(identifier = "cat-tp")]
+        pub cat_tp: Option<()>,
+        #[rasn(identifier = "get-identity")]
+        pub get_identity: Option<()>,
+        #[rasn(identifier = "profile-a-x25519")]
+        pub profile_a_x25519: Option<()>,
+        #[rasn(identifier = "profile-b-p256")]
+        pub profile_b_p256: Option<()>,
+    }
+    impl ServicesList {
+        pub fn new(
+            contactless: Option<()>,
+            usim: Option<()>,
+            isim: Option<()>,
+            csim: Option<()>,
+            milenage: Option<()>,
+            tuak128: Option<()>,
+            cave: Option<()>,
+            gba_usim: Option<()>,
+            gba_isim: Option<()>,
+            mbms: Option<()>,
+            eap: Option<()>,
+            javacard: Option<()>,
+            multos: Option<()>,
+            multiple_usim: Option<()>,
+            multiple_isim: Option<()>,
+            multiple_csim: Option<()>,
+            tuak256: Option<()>,
+            usim_test_algorithm: Option<()>,
+            ber_tlv: Option<()>,
+            df_link: Option<()>,
+            cat_tp: Option<()>,
+            get_identity: Option<()>,
+            profile_a_x25519: Option<()>,
+            profile_b_p256: Option<()>,
+        ) -> Self {
+            Self {
+                contactless,
+                usim,
+                isim,
+                csim,
+                milenage,
+                tuak128,
+                cave,
+                gba_usim,
+                gba_isim,
+                mbms,
+                eap,
+                javacard,
+                multos,
+                multiple_usim,
+                multiple_isim,
+                multiple_csim,
+                tuak256,
+                usim_test_algorithm,
+                ber_tlv,
+                df_link,
+                cat_tp,
+                get_identity,
+                profile_a_x25519,
+                profile_b_p256,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TS102226AdditionalContactlessParameters {
+        #[rasn(identifier = "protocolParameterData")]
+        pub protocol_parameter_data: OctetString,
+    }
+    impl TS102226AdditionalContactlessParameters {
+        pub fn new(protocol_parameter_data: OctetString) -> Self {
+            Self {
+                protocol_parameter_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct UICCApplicationParameters {
+        #[rasn(
+            tag(context, 0),
+            identifier = "uiccToolkitApplicationSpecificParametersField"
+        )]
+        pub uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 1),
+            identifier = "uiccAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_access_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 2),
+            identifier = "uiccAdministrativeAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+    }
+    impl UICCApplicationParameters {
+        pub fn new(
+            uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+            uicc_access_application_specific_parameters_field: Option<OctetString>,
+            uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+        ) -> Self {
+            Self {
+                uicc_toolkit_application_specific_parameters_field,
+                uicc_access_application_specific_parameters_field,
+                uicc_administrative_access_application_specific_parameters_field,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=32767"))]
+    pub struct UInt15(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct UInt16(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=2147483647"))]
+    pub struct UInt31(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct UInt8(pub u8);
+    pub static MAX_UINT15: LazyLock<Integer> = LazyLock::new(|| Integer::from(32767i128));
+    pub static MAX_UINT16: LazyLock<Integer> = LazyLock::new(|| Integer::from(65535i128));
+    pub static MAX_UINT31: LazyLock<Integer> = LazyLock::new(|| Integer::from(2147483647i128));
+    #[doc = " Basic integer types, for size constraints"]
+    pub static MAX_UINT8: LazyLock<Integer> = LazyLock::new(|| Integer::from(255i128));
+}

--- a/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v3_4_1_compiles.snap
+++ b/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v3_4_1_compiles.snap
@@ -453,7 +453,7 @@ pub mod pedefinitions {
         }
     }
     fn anonymous_key_object_key_compontents_mac_length_default() -> UInt8 {
-        8
+        UInt8(8)
     }
     #[doc = " Inner type "]
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
@@ -571,9 +571,13 @@ pub mod pedefinitions {
             }
         }
     }
-    fn peakaparameter_ssim_parameters_key_derivation_functions_default() -> SequenceOf<OctetString>
-    {
-        alloc::vec![<OctetString as From<&'static [u8]>>::from(&[1])]
+    fn peakaparameter_ssim_parameters_key_derivation_functions_default(
+    ) -> PEAKAParameterSsimParametersKeyDerivationFunctions {
+        PEAKAParameterSsimParametersKeyDerivationFunctions(alloc::vec![
+            AnonymousPEAKAParameterSsimParametersKeyDerivationFunctions(FixedOctetString::new([
+                1u8
+            ]))
+        ])
     }
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "PE-AKAParameter")]
@@ -636,41 +640,41 @@ pub mod pedefinitions {
     fn peakaparameter_sqn_age_limit_default() -> OctetString {
         <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
     }
-    fn peakaparameter_sqn_init_default() -> SequenceOf<OctetString> {
-        alloc::vec![
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
-            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0])
-        ]
+    fn peakaparameter_sqn_init_default() -> PEAKAParameterSqnInit {
+        PEAKAParameterSqnInit(alloc::vec![
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8])),
+            AnonymousPEAKAParameterSqnInit(FixedOctetString::new([0u8, 0u8, 0u8, 0u8, 0u8, 0u8]))
+        ])
     }
     #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
     #[rasn(automatic_tags, identifier = "PE-Application")]

--- a/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v3_4_1_compiles.snap
+++ b/rasn-compiler-tests/tests/snapshots/tca_tests__tca_v3_4_1_compiles.snap
@@ -1,0 +1,4648 @@
+---
+source: rasn-compiler-tests/tests/tca_tests.rs
+---
+Generated:
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod pedefinitions {
+    extern crate alloc;
+    use super::pkix1_explicit88::Certificate;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ADFRFMAccess {
+        #[rasn(identifier = "adfAID")]
+        pub adf_aid: ApplicationIdentifier,
+        #[rasn(identifier = "adfAccessDomain")]
+        pub adf_access_domain: OctetString,
+        #[rasn(identifier = "adfAdminAccessDomain")]
+        pub adf_admin_access_domain: OctetString,
+    }
+    impl ADFRFMAccess {
+        pub fn new(
+            adf_aid: ApplicationIdentifier,
+            adf_access_domain: OctetString,
+            adf_admin_access_domain: OctetString,
+        ) -> Self {
+            Self {
+                adf_aid,
+                adf_access_domain,
+                adf_admin_access_domain,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct AlgoParameter {
+        #[rasn(identifier = "algorithmID")]
+        pub algorithm_id: Integer,
+        #[rasn(size("1"), identifier = "algorithmOptions")]
+        pub algorithm_options: OctetString,
+        pub key: OctetString,
+        pub opc: OctetString,
+        #[rasn(
+            size("5"),
+            default = "algo_parameter_rotation_constants_default",
+            identifier = "rotationConstants"
+        )]
+        pub rotation_constants: OctetString,
+        #[rasn(
+            size("80"),
+            default = "algo_parameter_xoring_constants_default",
+            identifier = "xoringConstants"
+        )]
+        pub xoring_constants: OctetString,
+        #[rasn(size("3"), identifier = "authCounterMax")]
+        pub auth_counter_max: Option<OctetString>,
+        #[rasn(
+            default = "algo_parameter_number_of_keccak_default",
+            identifier = "numberOfKeccak"
+        )]
+        pub number_of_keccak: UInt8,
+    }
+    impl AlgoParameter {
+        pub fn new(
+            algorithm_id: Integer,
+            algorithm_options: OctetString,
+            key: OctetString,
+            opc: OctetString,
+            rotation_constants: OctetString,
+            xoring_constants: OctetString,
+            auth_counter_max: Option<OctetString>,
+            number_of_keccak: UInt8,
+        ) -> Self {
+            Self {
+                algorithm_id,
+                algorithm_options,
+                key,
+                opc,
+                rotation_constants,
+                xoring_constants,
+                auth_counter_max,
+                number_of_keccak,
+            }
+        }
+    }
+    fn algo_parameter_rotation_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[64, 0, 32, 64, 96])
+    }
+    fn algo_parameter_xoring_constants_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8,
+        ])
+    }
+    fn algo_parameter_number_of_keccak_default() -> UInt8 {
+        UInt8(1)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("5..=16"))]
+    pub struct ApplicationIdentifier(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationInstance {
+        #[rasn(tag(application, 15), identifier = "applicationLoadPackageAID")]
+        pub application_load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "classAID")]
+        pub class_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "extraditeSecurityDomainAID")]
+        pub extradite_security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 2), identifier = "applicationPrivileges")]
+        pub application_privileges: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 3),
+            default = "application_instance_life_cycle_state_default",
+            identifier = "lifeCycleState"
+        )]
+        pub life_cycle_state: OctetString,
+        #[rasn(tag(private, 9), identifier = "applicationSpecificParametersC9")]
+        pub application_specific_parameters_c9: OctetString,
+        #[rasn(tag(private, 15), identifier = "systemSpecificParameters")]
+        pub system_specific_parameters: Option<ApplicationSystemParameters>,
+        #[rasn(tag(private, 10), identifier = "applicationParameters")]
+        pub application_parameters: Option<UICCApplicationParameters>,
+        #[rasn(size("1.."), identifier = "processData")]
+        pub process_data: Option<SequenceOf<OctetString>>,
+        #[rasn(tag(context, 16), identifier = "controlReferenceTemplate")]
+        pub control_reference_template: Option<ControlReferenceTemplate>,
+    }
+    impl ApplicationInstance {
+        pub fn new(
+            application_load_package_aid: ApplicationIdentifier,
+            class_aid: ApplicationIdentifier,
+            instance_aid: ApplicationIdentifier,
+            extradite_security_domain_aid: Option<ApplicationIdentifier>,
+            application_privileges: OctetString,
+            life_cycle_state: OctetString,
+            application_specific_parameters_c9: OctetString,
+            system_specific_parameters: Option<ApplicationSystemParameters>,
+            application_parameters: Option<UICCApplicationParameters>,
+            process_data: Option<SequenceOf<OctetString>>,
+            control_reference_template: Option<ControlReferenceTemplate>,
+        ) -> Self {
+            Self {
+                application_load_package_aid,
+                class_aid,
+                instance_aid,
+                extradite_security_domain_aid,
+                application_privileges,
+                life_cycle_state,
+                application_specific_parameters_c9,
+                system_specific_parameters,
+                application_parameters,
+                process_data,
+                control_reference_template,
+            }
+        }
+    }
+    fn application_instance_life_cycle_state_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[7])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationLoadPackage {
+        #[rasn(tag(application, 15), identifier = "loadPackageAID")]
+        pub load_package_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(private, 6), identifier = "nonVolatileCodeLimitC6")]
+        pub non_volatile_code_limit_c6: Option<OctetString>,
+        #[rasn(tag(private, 7), identifier = "volatileDataLimitC7")]
+        pub volatile_data_limit_c7: Option<OctetString>,
+        #[rasn(tag(private, 8), identifier = "nonVolatileDataLimitC8")]
+        pub non_volatile_data_limit_c8: Option<OctetString>,
+        #[rasn(tag(private, 1), identifier = "hashValue")]
+        pub hash_value: Option<OctetString>,
+        #[rasn(tag(private, 4), identifier = "loadBlockObject")]
+        pub load_block_object: OctetString,
+    }
+    impl ApplicationLoadPackage {
+        pub fn new(
+            load_package_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            non_volatile_code_limit_c6: Option<OctetString>,
+            volatile_data_limit_c7: Option<OctetString>,
+            non_volatile_data_limit_c8: Option<OctetString>,
+            hash_value: Option<OctetString>,
+            load_block_object: OctetString,
+        ) -> Self {
+            Self {
+                load_package_aid,
+                security_domain_aid,
+                non_volatile_code_limit_c6,
+                volatile_data_limit_c7,
+                non_volatile_data_limit_c8,
+                hash_value,
+                load_block_object,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ApplicationSystemParameters {
+        #[rasn(size("2..=4"), tag(private, 7), identifier = "volatileMemoryQuotaC7")]
+        pub volatile_memory_quota_c7: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 8),
+            identifier = "nonVolatileMemoryQuotaC8"
+        )]
+        pub non_volatile_memory_quota_c8: Option<OctetString>,
+        #[rasn(tag(private, 11), identifier = "globalServiceParameters")]
+        pub global_service_parameters: Option<OctetString>,
+        #[rasn(tag(private, 15), identifier = "implicitSelectionParameter")]
+        pub implicit_selection_parameter: Option<OctetString>,
+        #[rasn(size("2..=4"), tag(private, 23), identifier = "volatileReservedMemory")]
+        pub volatile_reserved_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(private, 24),
+            identifier = "nonVolatileReservedMemory"
+        )]
+        pub non_volatile_reserved_memory: Option<OctetString>,
+        #[rasn(tag(private, 10), identifier = "ts102226SIMFileAccessToolkitParameter")]
+        pub ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+        #[rasn(
+            tag(context, 0),
+            identifier = "ts102226AdditionalContactlessParameters"
+        )]
+        pub ts102226_additional_contactless_parameters:
+            Option<TS102226AdditionalContactlessParameters>,
+        #[rasn(tag(private, 25), identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+        #[rasn(tag(private, 26), identifier = "userInteractionContactlessParameters")]
+        pub user_interaction_contactless_parameters: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 2),
+            identifier = "cumulativeGrantedVolatileMemory"
+        )]
+        pub cumulative_granted_volatile_memory: Option<OctetString>,
+        #[rasn(
+            size("2..=4"),
+            tag(context, 3),
+            identifier = "cumulativeGrantedNonVolatileMemory"
+        )]
+        pub cumulative_granted_non_volatile_memory: Option<OctetString>,
+    }
+    impl ApplicationSystemParameters {
+        pub fn new(
+            volatile_memory_quota_c7: Option<OctetString>,
+            non_volatile_memory_quota_c8: Option<OctetString>,
+            global_service_parameters: Option<OctetString>,
+            implicit_selection_parameter: Option<OctetString>,
+            volatile_reserved_memory: Option<OctetString>,
+            non_volatile_reserved_memory: Option<OctetString>,
+            ts102226_simfile_access_toolkit_parameter: Option<OctetString>,
+            ts102226_additional_contactless_parameters: Option<
+                TS102226AdditionalContactlessParameters,
+            >,
+            contactless_protocol_parameters: Option<OctetString>,
+            user_interaction_contactless_parameters: Option<OctetString>,
+            cumulative_granted_volatile_memory: Option<OctetString>,
+            cumulative_granted_non_volatile_memory: Option<OctetString>,
+        ) -> Self {
+            Self {
+                volatile_memory_quota_c7,
+                non_volatile_memory_quota_c8,
+                global_service_parameters,
+                implicit_selection_parameter,
+                volatile_reserved_memory,
+                non_volatile_reserved_memory,
+                ts102226_simfile_access_toolkit_parameter,
+                ts102226_additional_contactless_parameters,
+                contactless_protocol_parameters,
+                user_interaction_contactless_parameters,
+                cumulative_granted_volatile_memory,
+                cumulative_granted_non_volatile_memory,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ControlReferenceTemplate {
+        #[rasn(tag(application, 32), identifier = "applicationProviderIdentifier")]
+        pub application_provider_identifier: OctetString,
+    }
+    impl ControlReferenceTemplate {
+        pub fn new(application_provider_identifier: OctetString) -> Self {
+            Self {
+                application_provider_identifier,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct EUICCResponse {
+        #[rasn(identifier = "peStatus")]
+        pub pe_status: SequenceOf<PEStatus>,
+        #[rasn(identifier = "profileInstallationAborted")]
+        pub profile_installation_aborted: Option<()>,
+        #[rasn(identifier = "statusMessage")]
+        pub status_message: Option<Utf8String>,
+    }
+    impl EUICCResponse {
+        pub fn new(
+            pe_status: SequenceOf<PEStatus>,
+            profile_installation_aborted: Option<()>,
+            status_message: Option<Utf8String>,
+        ) -> Self {
+            Self {
+                pe_status,
+                profile_installation_aborted,
+                status_message,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct Fcp {
+        #[rasn(size("2..=4"), tag(context, 2), identifier = "fileDescriptor")]
+        pub file_descriptor: Option<OctetString>,
+        #[rasn(size("2"), tag(context, 3), identifier = "fileID")]
+        pub file_id: Option<OctetString>,
+        #[rasn(tag(context, 4), identifier = "dfName")]
+        pub df_name: Option<ApplicationIdentifier>,
+        #[rasn(size("1"), tag(context, 10), default = "fcp_lcsi_default")]
+        pub lcsi: OctetString,
+        #[rasn(
+            size("1..=3"),
+            tag(context, 11),
+            identifier = "securityAttributesReferenced"
+        )]
+        pub security_attributes_referenced: Option<OctetString>,
+        #[rasn(tag(context, 0), identifier = "efFileSize")]
+        pub ef_file_size: Option<OctetString>,
+        #[rasn(tag(private, 6), identifier = "pinStatusTemplateDO")]
+        pub pin_status_template_do: Option<OctetString>,
+        #[rasn(size("0..=1"), tag(context, 8), identifier = "shortEFID")]
+        pub short_efid: Option<OctetString>,
+        #[rasn(tag(context, 5), identifier = "proprietaryEFInfo")]
+        pub proprietary_efinfo: Option<ProprietaryInfo>,
+        #[rasn(size("0..=8"), tag(private, 7), identifier = "linkPath")]
+        pub link_path: Option<OctetString>,
+    }
+    impl Fcp {
+        pub fn new(
+            file_descriptor: Option<OctetString>,
+            file_id: Option<OctetString>,
+            df_name: Option<ApplicationIdentifier>,
+            lcsi: OctetString,
+            security_attributes_referenced: Option<OctetString>,
+            ef_file_size: Option<OctetString>,
+            pin_status_template_do: Option<OctetString>,
+            short_efid: Option<OctetString>,
+            proprietary_efinfo: Option<ProprietaryInfo>,
+            link_path: Option<OctetString>,
+        ) -> Self {
+            Self {
+                file_descriptor,
+                file_id,
+                df_name,
+                lcsi,
+                security_attributes_referenced,
+                ef_file_size,
+                pin_status_template_do,
+                short_efid,
+                proprietary_efinfo,
+                link_path,
+            }
+        }
+    }
+    fn fcp_lcsi_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[5])
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFile {
+        doNotCreate(()),
+        fileDescriptor(Fcp),
+        fillFileOffset(UInt16),
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct File(pub SequenceOf<AnonymousFile>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, identifier = "CHOICE")]
+    #[non_exhaustive]
+    pub enum AnonymousFileManagement {
+        #[rasn(size("0..=8"), tag(context, 0))]
+        filePath(OctetString),
+        #[rasn(tag(application, 2))]
+        createFCP(Fcp),
+        fillFileOffset(UInt16),
+        #[rasn(tag(context, 1))]
+        fillFileContent(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct FileManagement(pub SequenceOf<AnonymousFileManagement>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct IotOptions {
+        #[rasn(size("7..=11"))]
+        pub pix: OctetString,
+    }
+    impl IotOptions {
+        pub fn new(pix: OctetString) -> Self {
+            Self { pix }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousKeyObjectKeyCompontents {
+        #[rasn(tag(context, 0), identifier = "keyType")]
+        pub key_type: OctetString,
+        #[rasn(tag(context, 6), identifier = "keyData")]
+        pub key_data: OctetString,
+        #[rasn(
+            tag(context, 7),
+            default = "anonymous_key_object_key_compontents_mac_length_default",
+            identifier = "macLength"
+        )]
+        pub mac_length: UInt8,
+    }
+    impl AnonymousKeyObjectKeyCompontents {
+        pub fn new(key_type: OctetString, key_data: OctetString, mac_length: UInt8) -> Self {
+            Self {
+                key_type,
+                key_data,
+                mac_length,
+            }
+        }
+    }
+    fn anonymous_key_object_key_compontents_mac_length_default() -> UInt8 {
+        8
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct KeyObjectKeyCompontents(pub SequenceOf<AnonymousKeyObjectKeyCompontents>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct KeyObject {
+        #[rasn(size("1..=2"), tag(context, 21), identifier = "keyUsageQualifier")]
+        pub key_usage_qualifier: OctetString,
+        #[rasn(
+            size("1"),
+            tag(context, 22),
+            default = "key_object_key_access_default",
+            identifier = "keyAccess"
+        )]
+        pub key_access: OctetString,
+        #[rasn(size("1"), tag(context, 2), identifier = "keyIdentifier")]
+        pub key_identifier: OctetString,
+        #[rasn(size("1"), tag(context, 3), identifier = "keyVersionNumber")]
+        pub key_version_number: OctetString,
+        #[rasn(tag(context, 5), identifier = "keyCounterValue")]
+        pub key_counter_value: Option<OctetString>,
+        #[rasn(identifier = "keyCompontents")]
+        pub key_compontents: KeyObjectKeyCompontents,
+    }
+    impl KeyObject {
+        pub fn new(
+            key_usage_qualifier: OctetString,
+            key_access: OctetString,
+            key_identifier: OctetString,
+            key_version_number: OctetString,
+            key_counter_value: Option<OctetString>,
+            key_compontents: KeyObjectKeyCompontents,
+        ) -> Self {
+            Self {
+                key_usage_qualifier,
+                key_access,
+                key_identifier,
+                key_version_number,
+                key_counter_value,
+                key_compontents,
+            }
+        }
+    }
+    fn key_object_key_access_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct MappingParameter {
+        #[rasn(size("1"), identifier = "mappingOptions")]
+        pub mapping_options: OctetString,
+        #[rasn(identifier = "mappingSource")]
+        pub mapping_source: ApplicationIdentifier,
+    }
+    impl MappingParameter {
+        pub fn new(mapping_options: OctetString, mapping_source: ApplicationIdentifier) -> Self {
+            Self {
+                mapping_options,
+                mapping_source,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEAKAParameterAlgoConfiguration {
+        mappingParameter(MappingParameter),
+        algoParameter(AlgoParameter),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPEAKAParameterSqnInit(pub FixedOctetString<6usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("32"))]
+    pub struct PEAKAParameterSqnInit(pub SequenceOf<AnonymousPEAKAParameterSqnInit>);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPEAKAParameterSsimParametersKeyDerivationFunctions(
+        pub FixedOctetString<1usize>,
+    );
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PEAKAParameterSsimParametersKeyDerivationFunctions(
+        pub SequenceOf<AnonymousPEAKAParameterSsimParametersKeyDerivationFunctions>,
+    );
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEAKAParameterSsimParameters {
+        #[rasn(identifier = "networkName")]
+        pub network_name: Option<Utf8String>,
+        #[rasn(
+            default = "peakaparameter_ssim_parameters_key_derivation_functions_default",
+            identifier = "keyDerivationFunctions"
+        )]
+        pub key_derivation_functions: PEAKAParameterSsimParametersKeyDerivationFunctions,
+    }
+    impl PEAKAParameterSsimParameters {
+        pub fn new(
+            network_name: Option<Utf8String>,
+            key_derivation_functions: PEAKAParameterSsimParametersKeyDerivationFunctions,
+        ) -> Self {
+            Self {
+                network_name,
+                key_derivation_functions,
+            }
+        }
+    }
+    fn peakaparameter_ssim_parameters_key_derivation_functions_default() -> SequenceOf<OctetString>
+    {
+        alloc::vec![<OctetString as From<&'static [u8]>>::from(&[1])]
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-AKAParameter")]
+    #[non_exhaustive]
+    pub struct PEAKAParameter {
+        #[rasn(identifier = "aka-header")]
+        pub aka_header: PEHeader,
+        #[rasn(identifier = "algoConfiguration")]
+        pub algo_configuration: PEAKAParameterAlgoConfiguration,
+        #[rasn(
+            size("1"),
+            default = "peakaparameter_sqn_options_default",
+            identifier = "sqnOptions"
+        )]
+        pub sqn_options: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_delta_default",
+            identifier = "sqnDelta"
+        )]
+        pub sqn_delta: OctetString,
+        #[rasn(
+            size("6"),
+            default = "peakaparameter_sqn_age_limit_default",
+            identifier = "sqnAgeLimit"
+        )]
+        pub sqn_age_limit: OctetString,
+        #[rasn(default = "peakaparameter_sqn_init_default", identifier = "sqnInit")]
+        pub sqn_init: PEAKAParameterSqnInit,
+        #[rasn(identifier = "ssimParameters")]
+        pub ssim_parameters: Option<PEAKAParameterSsimParameters>,
+    }
+    impl PEAKAParameter {
+        pub fn new(
+            aka_header: PEHeader,
+            algo_configuration: PEAKAParameterAlgoConfiguration,
+            sqn_options: OctetString,
+            sqn_delta: OctetString,
+            sqn_age_limit: OctetString,
+            sqn_init: PEAKAParameterSqnInit,
+            ssim_parameters: Option<PEAKAParameterSsimParameters>,
+        ) -> Self {
+            Self {
+                aka_header,
+                algo_configuration,
+                sqn_options,
+                sqn_delta,
+                sqn_age_limit,
+                sqn_init,
+                ssim_parameters,
+            }
+        }
+    }
+    fn peakaparameter_sqn_options_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[2])
+    }
+    fn peakaparameter_sqn_delta_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_age_limit_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0, 0, 16, 0, 0, 0])
+    }
+    fn peakaparameter_sqn_init_default() -> SequenceOf<OctetString> {
+        alloc::vec![
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0]),
+            <OctetString as From<&'static [u8]>>::from(&[0, 0, 0, 0, 0, 0])
+        ]
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Application")]
+    #[non_exhaustive]
+    pub struct PEApplication {
+        #[rasn(identifier = "app-Header")]
+        pub app_header: PEHeader,
+        #[rasn(identifier = "loadBlock")]
+        pub load_block: Option<ApplicationLoadPackage>,
+        #[rasn(size("1.."), identifier = "instanceList")]
+        pub instance_list: Option<SequenceOf<ApplicationInstance>>,
+    }
+    impl PEApplication {
+        pub fn new(
+            app_header: PEHeader,
+            load_block: Option<ApplicationLoadPackage>,
+            instance_list: Option<SequenceOf<ApplicationInstance>>,
+        ) -> Self {
+            Self {
+                app_header,
+                load_block,
+                instance_list,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CD")]
+    #[non_exhaustive]
+    pub struct PECD {
+        #[rasn(identifier = "cd-header")]
+        pub cd_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-cd")]
+        pub df_cd: File,
+        #[rasn(identifier = "ef-launchpad")]
+        pub ef_launchpad: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+    }
+    impl PECD {
+        pub fn new(
+            cd_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_cd: File,
+            ef_launchpad: Option<File>,
+            ef_icon: Option<File>,
+        ) -> Self {
+            Self {
+                cd_header,
+                template_id,
+                df_cd,
+                ef_launchpad,
+                ef_icon,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CDMAParameter")]
+    #[non_exhaustive]
+    pub struct PECDMAParameter {
+        #[rasn(identifier = "cdma-header")]
+        pub cdma_header: PEHeader,
+        #[rasn(size("8"), identifier = "authenticationKey")]
+        pub authentication_key: OctetString,
+        #[rasn(size("16"))]
+        pub ssd: Option<OctetString>,
+        #[rasn(size("2..=32"), identifier = "hrpdAccessAuthenticationData")]
+        pub hrpd_access_authentication_data: Option<OctetString>,
+        #[rasn(size("3..=483"), identifier = "simpleIPAuthenticationData")]
+        pub simple_ipauthentication_data: Option<OctetString>,
+        #[rasn(size("5..=957"), identifier = "mobileIPAuthenticationData")]
+        pub mobile_ipauthentication_data: Option<OctetString>,
+    }
+    impl PECDMAParameter {
+        pub fn new(
+            cdma_header: PEHeader,
+            authentication_key: OctetString,
+            ssd: Option<OctetString>,
+            hrpd_access_authentication_data: Option<OctetString>,
+            simple_ipauthentication_data: Option<OctetString>,
+            mobile_ipauthentication_data: Option<OctetString>,
+        ) -> Self {
+            Self {
+                cdma_header,
+                authentication_key,
+                ssd,
+                hrpd_access_authentication_data,
+                simple_ipauthentication_data,
+                mobile_ipauthentication_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-CSIM")]
+    #[non_exhaustive]
+    pub struct PECSIM {
+        #[rasn(identifier = "csim-header")]
+        pub csim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-csim")]
+        pub adf_csim: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-call-count")]
+        pub ef_call_count: File,
+        #[rasn(identifier = "ef-imsi-m")]
+        pub ef_imsi_m: File,
+        #[rasn(identifier = "ef-imsi-t")]
+        pub ef_imsi_t: File,
+        #[rasn(identifier = "ef-tmsi")]
+        pub ef_tmsi: File,
+        #[rasn(identifier = "ef-ah")]
+        pub ef_ah: File,
+        #[rasn(identifier = "ef-aop")]
+        pub ef_aop: File,
+        #[rasn(identifier = "ef-aloc")]
+        pub ef_aloc: File,
+        #[rasn(identifier = "ef-cdmahome")]
+        pub ef_cdmahome: File,
+        #[rasn(identifier = "ef-znregi")]
+        pub ef_znregi: File,
+        #[rasn(identifier = "ef-snregi")]
+        pub ef_snregi: File,
+        #[rasn(identifier = "ef-distregi")]
+        pub ef_distregi: File,
+        #[rasn(identifier = "ef-accolc")]
+        pub ef_accolc: File,
+        #[rasn(identifier = "ef-term")]
+        pub ef_term: File,
+        #[rasn(identifier = "ef-acp")]
+        pub ef_acp: File,
+        #[rasn(identifier = "ef-prl")]
+        pub ef_prl: File,
+        #[rasn(identifier = "ef-ruimid")]
+        pub ef_ruimid: File,
+        #[rasn(identifier = "ef-csim-st")]
+        pub ef_csim_st: File,
+        #[rasn(identifier = "ef-spc")]
+        pub ef_spc: File,
+        #[rasn(identifier = "ef-otapaspc")]
+        pub ef_otapaspc: File,
+        #[rasn(identifier = "ef-namlock")]
+        pub ef_namlock: File,
+        #[rasn(identifier = "ef-ota")]
+        pub ef_ota: File,
+        #[rasn(identifier = "ef-sp")]
+        pub ef_sp: File,
+        #[rasn(identifier = "ef-esn-meid-me")]
+        pub ef_esn_meid_me: File,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: File,
+        #[rasn(identifier = "ef-usgind")]
+        pub ef_usgind: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: File,
+        #[rasn(identifier = "ef-max-prl")]
+        pub ef_max_prl: File,
+        #[rasn(identifier = "ef-spcs")]
+        pub ef_spcs: File,
+        #[rasn(identifier = "ef-mecrp")]
+        pub ef_mecrp: File,
+        #[rasn(identifier = "ef-home-tag")]
+        pub ef_home_tag: File,
+        #[rasn(identifier = "ef-group-tag")]
+        pub ef_group_tag: File,
+        #[rasn(identifier = "ef-specific-tag")]
+        pub ef_specific_tag: File,
+        #[rasn(identifier = "ef-call-prompt")]
+        pub ef_call_prompt: File,
+    }
+    impl PECSIM {
+        pub fn new(
+            csim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_csim: File,
+            ef_arr: File,
+            ef_call_count: File,
+            ef_imsi_m: File,
+            ef_imsi_t: File,
+            ef_tmsi: File,
+            ef_ah: File,
+            ef_aop: File,
+            ef_aloc: File,
+            ef_cdmahome: File,
+            ef_znregi: File,
+            ef_snregi: File,
+            ef_distregi: File,
+            ef_accolc: File,
+            ef_term: File,
+            ef_acp: File,
+            ef_prl: File,
+            ef_ruimid: File,
+            ef_csim_st: File,
+            ef_spc: File,
+            ef_otapaspc: File,
+            ef_namlock: File,
+            ef_ota: File,
+            ef_sp: File,
+            ef_esn_meid_me: File,
+            ef_li: File,
+            ef_usgind: File,
+            ef_ad: File,
+            ef_max_prl: File,
+            ef_spcs: File,
+            ef_mecrp: File,
+            ef_home_tag: File,
+            ef_group_tag: File,
+            ef_specific_tag: File,
+            ef_call_prompt: File,
+        ) -> Self {
+            Self {
+                csim_header,
+                template_id,
+                adf_csim,
+                ef_arr,
+                ef_call_count,
+                ef_imsi_m,
+                ef_imsi_t,
+                ef_tmsi,
+                ef_ah,
+                ef_aop,
+                ef_aloc,
+                ef_cdmahome,
+                ef_znregi,
+                ef_snregi,
+                ef_distregi,
+                ef_accolc,
+                ef_term,
+                ef_acp,
+                ef_prl,
+                ef_ruimid,
+                ef_csim_st,
+                ef_spc,
+                ef_otapaspc,
+                ef_namlock,
+                ef_ota,
+                ef_sp,
+                ef_esn_meid_me,
+                ef_li,
+                ef_usgind,
+                ef_ad,
+                ef_max_prl,
+                ef_spcs,
+                ef_mecrp,
+                ef_home_tag,
+                ef_group_tag,
+                ef_specific_tag,
+                ef_call_prompt,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-5GPROSE")]
+    #[non_exhaustive]
+    pub struct PEDF5GPROSE {
+        #[rasn(identifier = "df-5g-prose-header")]
+        pub df_5g_prose_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-5g-prose")]
+        pub df_df_5g_prose: File,
+        #[rasn(identifier = "ef-5g-prose-st")]
+        pub ef_5g_prose_st: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-dd")]
+        pub ef_5g_prose_dd: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-dc")]
+        pub ef_5g_prose_dc: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-u2nru")]
+        pub ef_5g_prose_u2nru: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-ru")]
+        pub ef_5g_prose_ru: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-uir")]
+        pub ef_5g_prose_uir: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-u2uru")]
+        pub ef_5g_prose_u2uru: Option<File>,
+        #[rasn(identifier = "ef-5g-prose-eu")]
+        pub ef_5g_prose_eu: Option<File>,
+    }
+    impl PEDF5GPROSE {
+        pub fn new(
+            df_5g_prose_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_5g_prose: File,
+            ef_5g_prose_st: Option<File>,
+            ef_5g_prose_dd: Option<File>,
+            ef_5g_prose_dc: Option<File>,
+            ef_5g_prose_u2nru: Option<File>,
+            ef_5g_prose_ru: Option<File>,
+            ef_5g_prose_uir: Option<File>,
+            ef_5g_prose_u2uru: Option<File>,
+            ef_5g_prose_eu: Option<File>,
+        ) -> Self {
+            Self {
+                df_5g_prose_header,
+                template_id,
+                df_df_5g_prose,
+                ef_5g_prose_st,
+                ef_5g_prose_dd,
+                ef_5g_prose_dc,
+                ef_5g_prose_u2nru,
+                ef_5g_prose_ru,
+                ef_5g_prose_uir,
+                ef_5g_prose_u2uru,
+                ef_5g_prose_eu,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-5GS")]
+    #[non_exhaustive]
+    pub struct PEDF5GS {
+        #[rasn(identifier = "df-5gs-header")]
+        pub df_5gs_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-5gs")]
+        pub df_df_5gs: File,
+        #[rasn(identifier = "ef-5gs3gpploci")]
+        pub ef_5gs3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gpploci")]
+        pub ef_5gsn3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gs3gppnsc")]
+        pub ef_5gs3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gppnsc")]
+        pub ef_5gsn3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gauthkeys")]
+        pub ef_5gauthkeys: Option<File>,
+        #[rasn(identifier = "ef-uac-aic")]
+        pub ef_uac_aic: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info")]
+        pub ef_suci_calc_info: Option<File>,
+        #[rasn(identifier = "ef-opl5g")]
+        pub ef_opl5g: Option<File>,
+        #[rasn(identifier = "ef-supinai")]
+        pub ef_supinai: Option<File>,
+        #[rasn(identifier = "ef-routing-indicator")]
+        pub ef_routing_indicator: Option<File>,
+        #[rasn(identifier = "ef-ursp")]
+        pub ef_ursp: Option<File>,
+        #[rasn(identifier = "ef-tn3gppsnn")]
+        pub ef_tn3gppsnn: Option<File>,
+        #[rasn(identifier = "ef-cag")]
+        pub ef_cag: Option<File>,
+        #[rasn(identifier = "ef-sor-cmci")]
+        pub ef_sor_cmci: Option<File>,
+        #[rasn(identifier = "ef-dri")]
+        pub ef_dri: Option<File>,
+        #[rasn(identifier = "ef-5gsedrx")]
+        pub ef_5gsedrx: Option<File>,
+        #[rasn(identifier = "ef-5gnswo-conf")]
+        pub ef_5gnswo_conf: Option<File>,
+        #[rasn(identifier = "ef-mchpplmn")]
+        pub ef_mchpplmn: Option<File>,
+        #[rasn(identifier = "ef-kausf-derivation")]
+        pub ef_kausf_derivation: Option<File>,
+    }
+    impl PEDF5GS {
+        pub fn new(
+            df_5gs_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_5gs: File,
+            ef_5gs3gpploci: Option<File>,
+            ef_5gsn3gpploci: Option<File>,
+            ef_5gs3gppnsc: Option<File>,
+            ef_5gsn3gppnsc: Option<File>,
+            ef_5gauthkeys: Option<File>,
+            ef_uac_aic: Option<File>,
+            ef_suci_calc_info: Option<File>,
+            ef_opl5g: Option<File>,
+            ef_supinai: Option<File>,
+            ef_routing_indicator: Option<File>,
+            ef_ursp: Option<File>,
+            ef_tn3gppsnn: Option<File>,
+            ef_cag: Option<File>,
+            ef_sor_cmci: Option<File>,
+            ef_dri: Option<File>,
+            ef_5gsedrx: Option<File>,
+            ef_5gnswo_conf: Option<File>,
+            ef_mchpplmn: Option<File>,
+            ef_kausf_derivation: Option<File>,
+        ) -> Self {
+            Self {
+                df_5gs_header,
+                template_id,
+                df_df_5gs,
+                ef_5gs3gpploci,
+                ef_5gsn3gpploci,
+                ef_5gs3gppnsc,
+                ef_5gsn3gppnsc,
+                ef_5gauthkeys,
+                ef_uac_aic,
+                ef_suci_calc_info,
+                ef_opl5g,
+                ef_supinai,
+                ef_routing_indicator,
+                ef_ursp,
+                ef_tn3gppsnn,
+                ef_cag,
+                ef_sor_cmci,
+                ef_dri,
+                ef_5gsedrx,
+                ef_5gnswo_conf,
+                ef_mchpplmn,
+                ef_kausf_derivation,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-SAIP")]
+    #[non_exhaustive]
+    pub struct PEDFSAIP {
+        #[rasn(identifier = "df-saip-header")]
+        pub df_saip_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-saip")]
+        pub df_df_saip: File,
+        #[rasn(identifier = "ef-suci-calc-info-usim")]
+        pub ef_suci_calc_info_usim: Option<File>,
+    }
+    impl PEDFSAIP {
+        pub fn new(
+            df_saip_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_saip: File,
+            ef_suci_calc_info_usim: Option<File>,
+        ) -> Self {
+            Self {
+                df_saip_header,
+                template_id,
+                df_df_saip,
+                ef_suci_calc_info_usim,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-DF-SNPN")]
+    #[non_exhaustive]
+    pub struct PEDFSNPN {
+        #[rasn(identifier = "df-snpn-header")]
+        pub df_snpn_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-df-snpn")]
+        pub df_df_snpn: File,
+        #[rasn(identifier = "ef-pws-snpn")]
+        pub ef_pws_snpn: Option<File>,
+        #[rasn(identifier = "ef-nid")]
+        pub ef_nid: Option<File>,
+    }
+    impl PEDFSNPN {
+        pub fn new(
+            df_snpn_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_df_snpn: File,
+            ef_pws_snpn: Option<File>,
+            ef_nid: Option<File>,
+        ) -> Self {
+            Self {
+                df_snpn_header,
+                template_id,
+                df_df_snpn,
+                ef_pws_snpn,
+                ef_nid,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-Dummy")]
+    #[non_exhaustive]
+    pub struct PEDummy {}
+    impl PEDummy {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+    impl std::default::Default for PEDummy {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-EAP")]
+    #[non_exhaustive]
+    pub struct PEEAP {
+        #[rasn(identifier = "eap-header")]
+        pub eap_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-eap")]
+        pub df_eap: File,
+        #[rasn(identifier = "ef-eapkeys")]
+        pub ef_eapkeys: Option<File>,
+        #[rasn(identifier = "ef-eapstatus")]
+        pub ef_eapstatus: File,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-ps")]
+        pub ef_ps: Option<File>,
+        #[rasn(identifier = "ef-curid")]
+        pub ef_curid: Option<File>,
+        #[rasn(identifier = "ef-reid")]
+        pub ef_reid: Option<File>,
+        #[rasn(identifier = "ef-realm")]
+        pub ef_realm: Option<File>,
+    }
+    impl PEEAP {
+        pub fn new(
+            eap_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_eap: File,
+            ef_eapkeys: Option<File>,
+            ef_eapstatus: File,
+            ef_puid: Option<File>,
+            ef_ps: Option<File>,
+            ef_curid: Option<File>,
+            ef_reid: Option<File>,
+            ef_realm: Option<File>,
+        ) -> Self {
+            Self {
+                eap_header,
+                template_id,
+                df_eap,
+                ef_eapkeys,
+                ef_eapstatus,
+                ef_puid,
+                ef_ps,
+                ef_curid,
+                ef_reid,
+                ef_realm,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-End")]
+    #[non_exhaustive]
+    pub struct PEEnd {
+        #[rasn(identifier = "end-header")]
+        pub end_header: PEHeader,
+    }
+    impl PEEnd {
+        pub fn new(end_header: PEHeader) -> Self {
+            Self { end_header }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GSM-ACCESS")]
+    #[non_exhaustive]
+    pub struct PEGSMACCESS {
+        #[rasn(identifier = "gsm-access-header")]
+        pub gsm_access_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-gsm-access")]
+        pub df_gsm_access: File,
+        #[rasn(identifier = "ef-kc")]
+        pub ef_kc: Option<File>,
+        #[rasn(identifier = "ef-kcgprs")]
+        pub ef_kcgprs: Option<File>,
+        #[rasn(identifier = "ef-cpbcch")]
+        pub ef_cpbcch: Option<File>,
+        #[rasn(identifier = "ef-invscan")]
+        pub ef_invscan: Option<File>,
+    }
+    impl PEGSMACCESS {
+        pub fn new(
+            gsm_access_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_gsm_access: File,
+            ef_kc: Option<File>,
+            ef_kcgprs: Option<File>,
+            ef_cpbcch: Option<File>,
+            ef_invscan: Option<File>,
+        ) -> Self {
+            Self {
+                gsm_access_header,
+                template_id,
+                df_gsm_access,
+                ef_kc,
+                ef_kcgprs,
+                ef_cpbcch,
+                ef_invscan,
+            }
+        }
+    }
+    #[doc = " Create GenericFileManagement"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-GenericFileManagement")]
+    #[non_exhaustive]
+    pub struct PEGenericFileManagement {
+        #[rasn(identifier = "gfm-header")]
+        pub gfm_header: PEHeader,
+        #[rasn(size("1.."), identifier = "fileManagementCMD")]
+        pub file_management_cmd: SequenceOf<FileManagement>,
+    }
+    impl PEGenericFileManagement {
+        pub fn new(gfm_header: PEHeader, file_management_cmd: SequenceOf<FileManagement>) -> Self {
+            Self {
+                gfm_header,
+                file_management_cmd,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-ISIM")]
+    #[non_exhaustive]
+    pub struct PEISIM {
+        #[rasn(identifier = "isim-header")]
+        pub isim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-isim")]
+        pub adf_isim: File,
+        #[rasn(identifier = "ef-impi")]
+        pub ef_impi: File,
+        #[rasn(identifier = "ef-impu")]
+        pub ef_impu: File,
+        #[rasn(identifier = "ef-domain")]
+        pub ef_domain: File,
+        #[rasn(identifier = "ef-ist")]
+        pub ef_ist: File,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+    }
+    impl PEISIM {
+        pub fn new(
+            isim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_isim: File,
+            ef_impi: File,
+            ef_impu: File,
+            ef_domain: File,
+            ef_ist: File,
+            ef_ad: Option<File>,
+            ef_arr: File,
+        ) -> Self {
+            Self {
+                isim_header,
+                template_id,
+                adf_isim,
+                ef_impi,
+                ef_impu,
+                ef_domain,
+                ef_ist,
+                ef_ad,
+                ef_arr,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-IoT")]
+    #[non_exhaustive]
+    pub struct PEIoT {
+        #[rasn(identifier = "iot-header")]
+        pub iot_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        pub mf: Option<File>,
+        #[rasn(identifier = "ef-pl")]
+        pub ef_pl: Option<File>,
+        #[rasn(identifier = "ef-iccid")]
+        pub ef_iccid: Option<File>,
+        #[rasn(identifier = "ef-dir")]
+        pub ef_dir: Option<File>,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: Option<File>,
+        #[rasn(identifier = "ef-umpc")]
+        pub ef_umpc: Option<File>,
+        #[rasn(identifier = "adf-usim")]
+        pub adf_usim: Option<File>,
+        #[rasn(identifier = "ef-imsi")]
+        pub ef_imsi: File,
+        #[rasn(identifier = "ef-arr-usim")]
+        pub ef_arr_usim: Option<File>,
+        #[rasn(identifier = "ef-keys")]
+        pub ef_keys: Option<File>,
+        #[rasn(identifier = "ef-keysPS")]
+        pub ef_keys_ps: Option<File>,
+        #[rasn(identifier = "ef-hpplmn")]
+        pub ef_hpplmn: Option<File>,
+        #[rasn(identifier = "ef-ust")]
+        pub ef_ust: Option<File>,
+        #[rasn(identifier = "ef-start-hfn")]
+        pub ef_start_hfn: Option<File>,
+        #[rasn(identifier = "ef-threshold")]
+        pub ef_threshold: Option<File>,
+        #[rasn(identifier = "ef-psloci")]
+        pub ef_psloci: Option<File>,
+        #[rasn(identifier = "ef-acc")]
+        pub ef_acc: File,
+        #[rasn(identifier = "ef-fplmn")]
+        pub ef_fplmn: Option<File>,
+        #[rasn(identifier = "ef-loci")]
+        pub ef_loci: Option<File>,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: Option<File>,
+        #[rasn(identifier = "ef-netpar")]
+        pub ef_netpar: Option<File>,
+    }
+    impl PEIoT {
+        pub fn new(
+            iot_header: PEHeader,
+            template_id: ObjectIdentifier,
+            mf: Option<File>,
+            ef_pl: Option<File>,
+            ef_iccid: Option<File>,
+            ef_dir: Option<File>,
+            ef_arr: Option<File>,
+            ef_umpc: Option<File>,
+            adf_usim: Option<File>,
+            ef_imsi: File,
+            ef_arr_usim: Option<File>,
+            ef_keys: Option<File>,
+            ef_keys_ps: Option<File>,
+            ef_hpplmn: Option<File>,
+            ef_ust: Option<File>,
+            ef_start_hfn: Option<File>,
+            ef_threshold: Option<File>,
+            ef_psloci: Option<File>,
+            ef_acc: File,
+            ef_fplmn: Option<File>,
+            ef_loci: Option<File>,
+            ef_ad: Option<File>,
+            ef_ecc: Option<File>,
+            ef_netpar: Option<File>,
+        ) -> Self {
+            Self {
+                iot_header,
+                template_id,
+                mf,
+                ef_pl,
+                ef_iccid,
+                ef_dir,
+                ef_arr,
+                ef_umpc,
+                adf_usim,
+                ef_imsi,
+                ef_arr_usim,
+                ef_keys,
+                ef_keys_ps,
+                ef_hpplmn,
+                ef_ust,
+                ef_start_hfn,
+                ef_threshold,
+                ef_psloci,
+                ef_acc,
+                ef_fplmn,
+                ef_loci,
+                ef_ad,
+                ef_ecc,
+                ef_netpar,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-MF")]
+    #[non_exhaustive]
+    pub struct PEMF {
+        #[rasn(identifier = "mf-header")]
+        pub mf_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        pub mf: File,
+        #[rasn(identifier = "ef-pl")]
+        pub ef_pl: Option<File>,
+        #[rasn(identifier = "ef-iccid")]
+        pub ef_iccid: File,
+        #[rasn(identifier = "ef-dir")]
+        pub ef_dir: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-umpc")]
+        pub ef_umpc: Option<File>,
+    }
+    impl PEMF {
+        pub fn new(
+            mf_header: PEHeader,
+            template_id: ObjectIdentifier,
+            mf: File,
+            ef_pl: Option<File>,
+            ef_iccid: File,
+            ef_dir: File,
+            ef_arr: File,
+            ef_umpc: Option<File>,
+        ) -> Self {
+            Self {
+                mf_header,
+                template_id,
+                mf,
+                ef_pl,
+                ef_iccid,
+                ef_dir,
+                ef_arr,
+                ef_umpc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-NonStandard")]
+    #[non_exhaustive]
+    pub struct PENonStandard {
+        #[rasn(identifier = "nonStandard-header")]
+        pub non_standard_header: PEHeader,
+        #[rasn(identifier = "issuerID")]
+        pub issuer_id: ObjectIdentifier,
+        pub content: OctetString,
+    }
+    impl PENonStandard {
+        pub fn new(
+            non_standard_header: PEHeader,
+            issuer_id: ObjectIdentifier,
+            content: OctetString,
+        ) -> Self {
+            Self {
+                non_standard_header,
+                issuer_id,
+                content,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-CSIM")]
+    #[non_exhaustive]
+    pub struct PEOPTCSIM {
+        #[rasn(identifier = "optcsim-header")]
+        pub optcsim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-ssci")]
+        pub ef_ssci: Option<File>,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-ssfc")]
+        pub ef_ssfc: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: Option<File>,
+        #[rasn(identifier = "ef-mdn")]
+        pub ef_mdn: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: Option<File>,
+        #[rasn(identifier = "ef-me3gpdopc")]
+        pub ef_me3gpdopc: Option<File>,
+        #[rasn(identifier = "ef-3gpdopm")]
+        pub ef_3gpdopm: Option<File>,
+        #[rasn(identifier = "ef-sipcap")]
+        pub ef_sipcap: Option<File>,
+        #[rasn(identifier = "ef-mipcap")]
+        pub ef_mipcap: Option<File>,
+        #[rasn(identifier = "ef-sipupp")]
+        pub ef_sipupp: Option<File>,
+        #[rasn(identifier = "ef-mipupp")]
+        pub ef_mipupp: Option<File>,
+        #[rasn(identifier = "ef-sipsp")]
+        pub ef_sipsp: Option<File>,
+        #[rasn(identifier = "ef-mipsp")]
+        pub ef_mipsp: Option<File>,
+        #[rasn(identifier = "ef-sippapss")]
+        pub ef_sippapss: Option<File>,
+        #[rasn(identifier = "ef-puzl")]
+        pub ef_puzl: Option<File>,
+        #[rasn(identifier = "ef-maxpuzl")]
+        pub ef_maxpuzl: Option<File>,
+        #[rasn(identifier = "ef-hrpdcap")]
+        pub ef_hrpdcap: Option<File>,
+        #[rasn(identifier = "ef-hrpdupp")]
+        pub ef_hrpdupp: Option<File>,
+        #[rasn(identifier = "ef-csspr")]
+        pub ef_csspr: Option<File>,
+        #[rasn(identifier = "ef-atc")]
+        pub ef_atc: Option<File>,
+        #[rasn(identifier = "ef-eprl")]
+        pub ef_eprl: Option<File>,
+        #[rasn(identifier = "ef-bcsmscfg")]
+        pub ef_bcsmscfg: Option<File>,
+        #[rasn(identifier = "ef-bcsmspref")]
+        pub ef_bcsmspref: Option<File>,
+        #[rasn(identifier = "ef-bcsmstable")]
+        pub ef_bcsmstable: Option<File>,
+        #[rasn(identifier = "ef-bcsmsp")]
+        pub ef_bcsmsp: Option<File>,
+        #[rasn(identifier = "ef-bakpara")]
+        pub ef_bakpara: Option<File>,
+        #[rasn(identifier = "ef-upbakpara")]
+        pub ef_upbakpara: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-auth-capability")]
+        pub ef_auth_capability: Option<File>,
+        #[rasn(identifier = "ef-3gcik")]
+        pub ef_3gcik: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-cdmacnl")]
+        pub ef_cdmacnl: Option<File>,
+        #[rasn(identifier = "ef-sf-euimid")]
+        pub ef_sf_euimid: Option<File>,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: Option<File>,
+        #[rasn(identifier = "ef-hidden-key")]
+        pub ef_hidden_key: Option<File>,
+        #[rasn(identifier = "ef-lcsver")]
+        pub ef_lcsver: Option<File>,
+        #[rasn(identifier = "ef-lcscp")]
+        pub ef_lcscp: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-applabels")]
+        pub ef_applabels: Option<File>,
+        #[rasn(identifier = "ef-model")]
+        pub ef_model: Option<File>,
+        #[rasn(identifier = "ef-rc")]
+        pub ef_rc: Option<File>,
+        #[rasn(identifier = "ef-smscap")]
+        pub ef_smscap: Option<File>,
+        #[rasn(identifier = "ef-mipflags")]
+        pub ef_mipflags: Option<File>,
+        #[rasn(identifier = "ef-3gpduppext")]
+        pub ef_3gpduppext: Option<File>,
+        #[rasn(identifier = "ef-ipv6cap")]
+        pub ef_ipv6cap: Option<File>,
+        #[rasn(identifier = "ef-tcpconfig")]
+        pub ef_tcpconfig: Option<File>,
+        #[rasn(identifier = "ef-dgc")]
+        pub ef_dgc: Option<File>,
+        #[rasn(identifier = "ef-wapbrowsercp")]
+        pub ef_wapbrowsercp: Option<File>,
+        #[rasn(identifier = "ef-wapbrowserbm")]
+        pub ef_wapbrowserbm: Option<File>,
+        #[rasn(identifier = "ef-mmsconfig")]
+        pub ef_mmsconfig: Option<File>,
+        #[rasn(identifier = "ef-jdl")]
+        pub ef_jdl: Option<File>,
+    }
+    impl PEOPTCSIM {
+        pub fn new(
+            optcsim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_ssci: Option<File>,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_ssfc: Option<File>,
+            ef_spn: Option<File>,
+            ef_mdn: Option<File>,
+            ef_ecc: Option<File>,
+            ef_me3gpdopc: Option<File>,
+            ef_3gpdopm: Option<File>,
+            ef_sipcap: Option<File>,
+            ef_mipcap: Option<File>,
+            ef_sipupp: Option<File>,
+            ef_mipupp: Option<File>,
+            ef_sipsp: Option<File>,
+            ef_mipsp: Option<File>,
+            ef_sippapss: Option<File>,
+            ef_puzl: Option<File>,
+            ef_maxpuzl: Option<File>,
+            ef_hrpdcap: Option<File>,
+            ef_hrpdupp: Option<File>,
+            ef_csspr: Option<File>,
+            ef_atc: Option<File>,
+            ef_eprl: Option<File>,
+            ef_bcsmscfg: Option<File>,
+            ef_bcsmspref: Option<File>,
+            ef_bcsmstable: Option<File>,
+            ef_bcsmsp: Option<File>,
+            ef_bakpara: Option<File>,
+            ef_upbakpara: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_auth_capability: Option<File>,
+            ef_3gcik: Option<File>,
+            ef_dck: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_cdmacnl: Option<File>,
+            ef_sf_euimid: Option<File>,
+            ef_est: Option<File>,
+            ef_hidden_key: Option<File>,
+            ef_lcsver: Option<File>,
+            ef_lcscp: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_applabels: Option<File>,
+            ef_model: Option<File>,
+            ef_rc: Option<File>,
+            ef_smscap: Option<File>,
+            ef_mipflags: Option<File>,
+            ef_3gpduppext: Option<File>,
+            ef_ipv6cap: Option<File>,
+            ef_tcpconfig: Option<File>,
+            ef_dgc: Option<File>,
+            ef_wapbrowsercp: Option<File>,
+            ef_wapbrowserbm: Option<File>,
+            ef_mmsconfig: Option<File>,
+            ef_jdl: Option<File>,
+        ) -> Self {
+            Self {
+                optcsim_header,
+                template_id,
+                ef_ssci,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_ssfc,
+                ef_spn,
+                ef_mdn,
+                ef_ecc,
+                ef_me3gpdopc,
+                ef_3gpdopm,
+                ef_sipcap,
+                ef_mipcap,
+                ef_sipupp,
+                ef_mipupp,
+                ef_sipsp,
+                ef_mipsp,
+                ef_sippapss,
+                ef_puzl,
+                ef_maxpuzl,
+                ef_hrpdcap,
+                ef_hrpdupp,
+                ef_csspr,
+                ef_atc,
+                ef_eprl,
+                ef_bcsmscfg,
+                ef_bcsmspref,
+                ef_bcsmstable,
+                ef_bcsmsp,
+                ef_bakpara,
+                ef_upbakpara,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_auth_capability,
+                ef_3gcik,
+                ef_dck,
+                ef_gid1,
+                ef_gid2,
+                ef_cdmacnl,
+                ef_sf_euimid,
+                ef_est,
+                ef_hidden_key,
+                ef_lcsver,
+                ef_lcscp,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_ici,
+                ef_oci,
+                ef_ext5,
+                ef_ccp2,
+                ef_applabels,
+                ef_model,
+                ef_rc,
+                ef_smscap,
+                ef_mipflags,
+                ef_3gpduppext,
+                ef_ipv6cap,
+                ef_tcpconfig,
+                ef_dgc,
+                ef_wapbrowsercp,
+                ef_wapbrowserbm,
+                ef_mmsconfig,
+                ef_jdl,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-ISIM")]
+    #[non_exhaustive]
+    pub struct PEOPTISIM {
+        #[rasn(identifier = "optisim-header")]
+        pub optisim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-pcscf")]
+        pub ef_pcscf: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+        #[rasn(identifier = "ef-frompreferred")]
+        pub ef_frompreferred: Option<File>,
+        #[rasn(identifier = "ef-imsconfigdata")]
+        pub ef_imsconfigdata: Option<File>,
+        #[rasn(identifier = "ef-xcapconfigdata")]
+        pub ef_xcapconfigdata: Option<File>,
+        #[rasn(identifier = "ef-webrtcuri")]
+        pub ef_webrtcuri: Option<File>,
+        #[rasn(identifier = "ef-mudmidconfigdata")]
+        pub ef_mudmidconfigdata: Option<File>,
+        #[rasn(identifier = "ef-ac-gbauapi")]
+        pub ef_ac_gbauapi: Option<File>,
+        #[rasn(identifier = "ef-imsdci")]
+        pub ef_imsdci: Option<File>,
+    }
+    impl PEOPTISIM {
+        pub fn new(
+            optisim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_pcscf: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_smsr: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_uicciari: Option<File>,
+            ef_frompreferred: Option<File>,
+            ef_imsconfigdata: Option<File>,
+            ef_xcapconfigdata: Option<File>,
+            ef_webrtcuri: Option<File>,
+            ef_mudmidconfigdata: Option<File>,
+            ef_ac_gbauapi: Option<File>,
+            ef_imsdci: Option<File>,
+        ) -> Self {
+            Self {
+                optisim_header,
+                template_id,
+                ef_pcscf,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_smsr,
+                ef_gbabp,
+                ef_gbanl,
+                ef_nafkca,
+                ef_uicciari,
+                ef_frompreferred,
+                ef_imsconfigdata,
+                ef_xcapconfigdata,
+                ef_webrtcuri,
+                ef_mudmidconfigdata,
+                ef_ac_gbauapi,
+                ef_imsdci,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-IoT")]
+    #[non_exhaustive]
+    pub struct PEOPTIoT {
+        #[rasn(identifier = "optiot-header")]
+        pub optiot_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: Option<File>,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: Option<File>,
+        #[rasn(identifier = "ef-oplmnwact")]
+        pub ef_oplmnwact: Option<File>,
+        #[rasn(identifier = "ef-hplmnwact")]
+        pub ef_hplmnwact: Option<File>,
+        #[rasn(identifier = "ef-ehplmn")]
+        pub ef_ehplmn: Option<File>,
+        #[rasn(identifier = "ef-epsloci")]
+        pub ef_epsloci: Option<File>,
+        #[rasn(identifier = "ef-epsnsc")]
+        pub ef_epsnsc: Option<File>,
+        #[rasn(identifier = "df-df-5gs")]
+        pub df_df_5gs: Option<File>,
+        #[rasn(identifier = "ef-5gs3gpploci")]
+        pub ef_5gs3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gpploci")]
+        pub ef_5gsn3gpploci: Option<File>,
+        #[rasn(identifier = "ef-5gs3gppnsc")]
+        pub ef_5gs3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gsn3gppnsc")]
+        pub ef_5gsn3gppnsc: Option<File>,
+        #[rasn(identifier = "ef-5gauthkeys")]
+        pub ef_5gauthkeys: Option<File>,
+        #[rasn(identifier = "ef-uac-aic")]
+        pub ef_uac_aic: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info")]
+        pub ef_suci_calc_info: Option<File>,
+        #[rasn(identifier = "ef-opl5g")]
+        pub ef_opl5g: Option<File>,
+        #[rasn(identifier = "ef-supi-nai")]
+        pub ef_supi_nai: Option<File>,
+        #[rasn(identifier = "ef-routing-indicator")]
+        pub ef_routing_indicator: Option<File>,
+        #[rasn(identifier = "ef-ursp")]
+        pub ef_ursp: Option<File>,
+        #[rasn(identifier = "ef-tn3gppsnn")]
+        pub ef_tn3gppsnn: Option<File>,
+        #[rasn(identifier = "df-df-saip")]
+        pub df_df_saip: Option<File>,
+        #[rasn(identifier = "ef-suci-calc-info-usim")]
+        pub ef_suci_calc_info_usim: Option<File>,
+    }
+    impl PEOPTIoT {
+        pub fn new(
+            optiot_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_spn: Option<File>,
+            ef_est: Option<File>,
+            ef_oplmnwact: Option<File>,
+            ef_hplmnwact: Option<File>,
+            ef_ehplmn: Option<File>,
+            ef_epsloci: Option<File>,
+            ef_epsnsc: Option<File>,
+            df_df_5gs: Option<File>,
+            ef_5gs3gpploci: Option<File>,
+            ef_5gsn3gpploci: Option<File>,
+            ef_5gs3gppnsc: Option<File>,
+            ef_5gsn3gppnsc: Option<File>,
+            ef_5gauthkeys: Option<File>,
+            ef_uac_aic: Option<File>,
+            ef_suci_calc_info: Option<File>,
+            ef_opl5g: Option<File>,
+            ef_supi_nai: Option<File>,
+            ef_routing_indicator: Option<File>,
+            ef_ursp: Option<File>,
+            ef_tn3gppsnn: Option<File>,
+            df_df_saip: Option<File>,
+            ef_suci_calc_info_usim: Option<File>,
+        ) -> Self {
+            Self {
+                optiot_header,
+                template_id,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_spn,
+                ef_est,
+                ef_oplmnwact,
+                ef_hplmnwact,
+                ef_ehplmn,
+                ef_epsloci,
+                ef_epsnsc,
+                df_df_5gs,
+                ef_5gs3gpploci,
+                ef_5gsn3gpploci,
+                ef_5gs3gppnsc,
+                ef_5gsn3gppnsc,
+                ef_5gauthkeys,
+                ef_uac_aic,
+                ef_suci_calc_info,
+                ef_opl5g,
+                ef_supi_nai,
+                ef_routing_indicator,
+                ef_ursp,
+                ef_tn3gppsnn,
+                df_df_saip,
+                ef_suci_calc_info_usim,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-OPT-USIM")]
+    #[non_exhaustive]
+    pub struct PEOPTUSIM {
+        #[rasn(identifier = "optusim-header")]
+        pub optusim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "ef-li")]
+        pub ef_li: Option<File>,
+        #[rasn(identifier = "ef-acmax")]
+        pub ef_acmax: Option<File>,
+        #[rasn(identifier = "ef-acm")]
+        pub ef_acm: Option<File>,
+        #[rasn(identifier = "ef-gid1")]
+        pub ef_gid1: Option<File>,
+        #[rasn(identifier = "ef-gid2")]
+        pub ef_gid2: Option<File>,
+        #[rasn(identifier = "ef-msisdn")]
+        pub ef_msisdn: Option<File>,
+        #[rasn(identifier = "ef-puct")]
+        pub ef_puct: Option<File>,
+        #[rasn(identifier = "ef-cbmi")]
+        pub ef_cbmi: Option<File>,
+        #[rasn(identifier = "ef-cbmid")]
+        pub ef_cbmid: Option<File>,
+        #[rasn(identifier = "ef-sdn")]
+        pub ef_sdn: Option<File>,
+        #[rasn(identifier = "ef-ext2")]
+        pub ef_ext2: Option<File>,
+        #[rasn(identifier = "ef-ext3")]
+        pub ef_ext3: Option<File>,
+        #[rasn(identifier = "ef-cbmir")]
+        pub ef_cbmir: Option<File>,
+        #[rasn(identifier = "ef-plmnwact")]
+        pub ef_plmnwact: Option<File>,
+        #[rasn(identifier = "ef-oplmnwact")]
+        pub ef_oplmnwact: Option<File>,
+        #[rasn(identifier = "ef-hplmnwact")]
+        pub ef_hplmnwact: Option<File>,
+        #[rasn(identifier = "ef-dck")]
+        pub ef_dck: Option<File>,
+        #[rasn(identifier = "ef-cnl")]
+        pub ef_cnl: Option<File>,
+        #[rasn(identifier = "ef-smsr")]
+        pub ef_smsr: Option<File>,
+        #[rasn(identifier = "ef-bdn")]
+        pub ef_bdn: Option<File>,
+        #[rasn(identifier = "ef-ext5")]
+        pub ef_ext5: Option<File>,
+        #[rasn(identifier = "ef-ccp2")]
+        pub ef_ccp2: Option<File>,
+        #[rasn(identifier = "ef-ext4")]
+        pub ef_ext4: Option<File>,
+        #[rasn(identifier = "ef-acl")]
+        pub ef_acl: Option<File>,
+        #[rasn(identifier = "ef-cmi")]
+        pub ef_cmi: Option<File>,
+        #[rasn(identifier = "ef-ici")]
+        pub ef_ici: Option<File>,
+        #[rasn(identifier = "ef-oci")]
+        pub ef_oci: Option<File>,
+        #[rasn(identifier = "ef-ict")]
+        pub ef_ict: Option<File>,
+        #[rasn(identifier = "ef-oct")]
+        pub ef_oct: Option<File>,
+        #[rasn(identifier = "ef-vgcs")]
+        pub ef_vgcs: Option<File>,
+        #[rasn(identifier = "ef-vgcss")]
+        pub ef_vgcss: Option<File>,
+        #[rasn(identifier = "ef-vbs")]
+        pub ef_vbs: Option<File>,
+        #[rasn(identifier = "ef-vbss")]
+        pub ef_vbss: Option<File>,
+        #[rasn(identifier = "ef-emlpp")]
+        pub ef_emlpp: Option<File>,
+        #[rasn(identifier = "ef-aaem")]
+        pub ef_aaem: Option<File>,
+        #[rasn(identifier = "ef-hiddenkey")]
+        pub ef_hiddenkey: Option<File>,
+        #[rasn(identifier = "ef-pnn")]
+        pub ef_pnn: Option<File>,
+        #[rasn(identifier = "ef-opl")]
+        pub ef_opl: Option<File>,
+        #[rasn(identifier = "ef-mbdn")]
+        pub ef_mbdn: Option<File>,
+        #[rasn(identifier = "ef-ext6")]
+        pub ef_ext6: Option<File>,
+        #[rasn(identifier = "ef-mbi")]
+        pub ef_mbi: Option<File>,
+        #[rasn(identifier = "ef-mwis")]
+        pub ef_mwis: Option<File>,
+        #[rasn(identifier = "ef-cfis")]
+        pub ef_cfis: Option<File>,
+        #[rasn(identifier = "ef-ext7")]
+        pub ef_ext7: Option<File>,
+        #[rasn(identifier = "ef-spdi")]
+        pub ef_spdi: Option<File>,
+        #[rasn(identifier = "ef-mmsn")]
+        pub ef_mmsn: Option<File>,
+        #[rasn(identifier = "ef-ext8")]
+        pub ef_ext8: Option<File>,
+        #[rasn(identifier = "ef-mmsicp")]
+        pub ef_mmsicp: Option<File>,
+        #[rasn(identifier = "ef-mmsup")]
+        pub ef_mmsup: Option<File>,
+        #[rasn(identifier = "ef-mmsucp")]
+        pub ef_mmsucp: Option<File>,
+        #[rasn(identifier = "ef-nia")]
+        pub ef_nia: Option<File>,
+        #[rasn(identifier = "ef-vgcsca")]
+        pub ef_vgcsca: Option<File>,
+        #[rasn(identifier = "ef-vbsca")]
+        pub ef_vbsca: Option<File>,
+        #[rasn(identifier = "ef-gbabp")]
+        pub ef_gbabp: Option<File>,
+        #[rasn(identifier = "ef-msk")]
+        pub ef_msk: Option<File>,
+        #[rasn(identifier = "ef-muk")]
+        pub ef_muk: Option<File>,
+        #[rasn(identifier = "ef-ehplmn")]
+        pub ef_ehplmn: Option<File>,
+        #[rasn(identifier = "ef-gbanl")]
+        pub ef_gbanl: Option<File>,
+        #[rasn(identifier = "ef-ehplmnpi")]
+        pub ef_ehplmnpi: Option<File>,
+        #[rasn(identifier = "ef-lrplmnsi")]
+        pub ef_lrplmnsi: Option<File>,
+        #[rasn(identifier = "ef-nafkca")]
+        pub ef_nafkca: Option<File>,
+        #[rasn(identifier = "ef-spni")]
+        pub ef_spni: Option<File>,
+        #[rasn(identifier = "ef-pnni")]
+        pub ef_pnni: Option<File>,
+        #[rasn(identifier = "ef-ncp-ip")]
+        pub ef_ncp_ip: Option<File>,
+        #[rasn(identifier = "ef-ufc")]
+        pub ef_ufc: Option<File>,
+        #[rasn(identifier = "ef-nasconfig")]
+        pub ef_nasconfig: Option<File>,
+        #[rasn(identifier = "ef-uicciari")]
+        pub ef_uicciari: Option<File>,
+        #[rasn(identifier = "ef-pws")]
+        pub ef_pws: Option<File>,
+        #[rasn(identifier = "ef-fdnuri")]
+        pub ef_fdnuri: Option<File>,
+        #[rasn(identifier = "ef-bdnuri")]
+        pub ef_bdnuri: Option<File>,
+        #[rasn(identifier = "ef-sdnuri")]
+        pub ef_sdnuri: Option<File>,
+        #[rasn(identifier = "ef-ial")]
+        pub ef_ial: Option<File>,
+        #[rasn(identifier = "ef-ips")]
+        pub ef_ips: Option<File>,
+        #[rasn(identifier = "ef-ipd")]
+        pub ef_ipd: Option<File>,
+        #[rasn(identifier = "ef-epdgid")]
+        pub ef_epdgid: Option<File>,
+        #[rasn(identifier = "ef-epdgselection")]
+        pub ef_epdgselection: Option<File>,
+        #[rasn(identifier = "ef-epdgidem")]
+        pub ef_epdgidem: Option<File>,
+        #[rasn(identifier = "ef-epdgselectionem")]
+        pub ef_epdgselectionem: Option<File>,
+        #[rasn(identifier = "ef-frompreferred")]
+        pub ef_frompreferred: Option<File>,
+        #[rasn(identifier = "ef-imsconfigdata")]
+        pub ef_imsconfigdata: Option<File>,
+        #[rasn(identifier = "ef-3gpppsdataoff")]
+        pub ef_3gpppsdataoff: Option<File>,
+        #[rasn(identifier = "ef-3gpppsdataoffservicelist")]
+        pub ef_3gpppsdataoffservicelist: Option<File>,
+        #[rasn(identifier = "ef-xcapconfigdata")]
+        pub ef_xcapconfigdata: Option<File>,
+        #[rasn(identifier = "ef-earfcnlist")]
+        pub ef_earfcnlist: Option<File>,
+        #[rasn(identifier = "ef-mudmidconfigdata")]
+        pub ef_mudmidconfigdata: Option<File>,
+        #[rasn(identifier = "ef-eaka")]
+        pub ef_eaka: Option<File>,
+        #[rasn(identifier = "ef-ocst")]
+        pub ef_ocst: Option<File>,
+        #[rasn(identifier = "ef-ac-gbauapi")]
+        pub ef_ac_gbauapi: Option<File>,
+        #[rasn(identifier = "ef-imsdci")]
+        pub ef_imsdci: Option<File>,
+    }
+    impl PEOPTUSIM {
+        pub fn new(
+            optusim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            ef_li: Option<File>,
+            ef_acmax: Option<File>,
+            ef_acm: Option<File>,
+            ef_gid1: Option<File>,
+            ef_gid2: Option<File>,
+            ef_msisdn: Option<File>,
+            ef_puct: Option<File>,
+            ef_cbmi: Option<File>,
+            ef_cbmid: Option<File>,
+            ef_sdn: Option<File>,
+            ef_ext2: Option<File>,
+            ef_ext3: Option<File>,
+            ef_cbmir: Option<File>,
+            ef_plmnwact: Option<File>,
+            ef_oplmnwact: Option<File>,
+            ef_hplmnwact: Option<File>,
+            ef_dck: Option<File>,
+            ef_cnl: Option<File>,
+            ef_smsr: Option<File>,
+            ef_bdn: Option<File>,
+            ef_ext5: Option<File>,
+            ef_ccp2: Option<File>,
+            ef_ext4: Option<File>,
+            ef_acl: Option<File>,
+            ef_cmi: Option<File>,
+            ef_ici: Option<File>,
+            ef_oci: Option<File>,
+            ef_ict: Option<File>,
+            ef_oct: Option<File>,
+            ef_vgcs: Option<File>,
+            ef_vgcss: Option<File>,
+            ef_vbs: Option<File>,
+            ef_vbss: Option<File>,
+            ef_emlpp: Option<File>,
+            ef_aaem: Option<File>,
+            ef_hiddenkey: Option<File>,
+            ef_pnn: Option<File>,
+            ef_opl: Option<File>,
+            ef_mbdn: Option<File>,
+            ef_ext6: Option<File>,
+            ef_mbi: Option<File>,
+            ef_mwis: Option<File>,
+            ef_cfis: Option<File>,
+            ef_ext7: Option<File>,
+            ef_spdi: Option<File>,
+            ef_mmsn: Option<File>,
+            ef_ext8: Option<File>,
+            ef_mmsicp: Option<File>,
+            ef_mmsup: Option<File>,
+            ef_mmsucp: Option<File>,
+            ef_nia: Option<File>,
+            ef_vgcsca: Option<File>,
+            ef_vbsca: Option<File>,
+            ef_gbabp: Option<File>,
+            ef_msk: Option<File>,
+            ef_muk: Option<File>,
+            ef_ehplmn: Option<File>,
+            ef_gbanl: Option<File>,
+            ef_ehplmnpi: Option<File>,
+            ef_lrplmnsi: Option<File>,
+            ef_nafkca: Option<File>,
+            ef_spni: Option<File>,
+            ef_pnni: Option<File>,
+            ef_ncp_ip: Option<File>,
+            ef_ufc: Option<File>,
+            ef_nasconfig: Option<File>,
+            ef_uicciari: Option<File>,
+            ef_pws: Option<File>,
+            ef_fdnuri: Option<File>,
+            ef_bdnuri: Option<File>,
+            ef_sdnuri: Option<File>,
+            ef_ial: Option<File>,
+            ef_ips: Option<File>,
+            ef_ipd: Option<File>,
+            ef_epdgid: Option<File>,
+            ef_epdgselection: Option<File>,
+            ef_epdgidem: Option<File>,
+            ef_epdgselectionem: Option<File>,
+            ef_frompreferred: Option<File>,
+            ef_imsconfigdata: Option<File>,
+            ef_3gpppsdataoff: Option<File>,
+            ef_3gpppsdataoffservicelist: Option<File>,
+            ef_xcapconfigdata: Option<File>,
+            ef_earfcnlist: Option<File>,
+            ef_mudmidconfigdata: Option<File>,
+            ef_eaka: Option<File>,
+            ef_ocst: Option<File>,
+            ef_ac_gbauapi: Option<File>,
+            ef_imsdci: Option<File>,
+        ) -> Self {
+            Self {
+                optusim_header,
+                template_id,
+                ef_li,
+                ef_acmax,
+                ef_acm,
+                ef_gid1,
+                ef_gid2,
+                ef_msisdn,
+                ef_puct,
+                ef_cbmi,
+                ef_cbmid,
+                ef_sdn,
+                ef_ext2,
+                ef_ext3,
+                ef_cbmir,
+                ef_plmnwact,
+                ef_oplmnwact,
+                ef_hplmnwact,
+                ef_dck,
+                ef_cnl,
+                ef_smsr,
+                ef_bdn,
+                ef_ext5,
+                ef_ccp2,
+                ef_ext4,
+                ef_acl,
+                ef_cmi,
+                ef_ici,
+                ef_oci,
+                ef_ict,
+                ef_oct,
+                ef_vgcs,
+                ef_vgcss,
+                ef_vbs,
+                ef_vbss,
+                ef_emlpp,
+                ef_aaem,
+                ef_hiddenkey,
+                ef_pnn,
+                ef_opl,
+                ef_mbdn,
+                ef_ext6,
+                ef_mbi,
+                ef_mwis,
+                ef_cfis,
+                ef_ext7,
+                ef_spdi,
+                ef_mmsn,
+                ef_ext8,
+                ef_mmsicp,
+                ef_mmsup,
+                ef_mmsucp,
+                ef_nia,
+                ef_vgcsca,
+                ef_vbsca,
+                ef_gbabp,
+                ef_msk,
+                ef_muk,
+                ef_ehplmn,
+                ef_gbanl,
+                ef_ehplmnpi,
+                ef_lrplmnsi,
+                ef_nafkca,
+                ef_spni,
+                ef_pnni,
+                ef_ncp_ip,
+                ef_ufc,
+                ef_nasconfig,
+                ef_uicciari,
+                ef_pws,
+                ef_fdnuri,
+                ef_bdnuri,
+                ef_sdnuri,
+                ef_ial,
+                ef_ips,
+                ef_ipd,
+                ef_epdgid,
+                ef_epdgselection,
+                ef_epdgidem,
+                ef_epdgselectionem,
+                ef_frompreferred,
+                ef_imsconfigdata,
+                ef_3gpppsdataoff,
+                ef_3gpppsdataoffservicelist,
+                ef_xcapconfigdata,
+                ef_earfcnlist,
+                ef_mudmidconfigdata,
+                ef_eaka,
+                ef_ocst,
+                ef_ac_gbauapi,
+                ef_imsdci,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PHONEBOOK")]
+    #[non_exhaustive]
+    pub struct PEPHONEBOOK {
+        #[rasn(identifier = "phonebook-header")]
+        pub phonebook_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: File,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+    }
+    impl PEPHONEBOOK {
+        pub fn new(
+            phonebook_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_phonebook: File,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+        ) -> Self {
+            Self {
+                phonebook_header,
+                template_id,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum PEPINCodesPinCodes {
+        #[rasn(size("1..=26"))]
+        pinconfig(SequenceOf<PINConfiguration>),
+        #[rasn(size("0..=8"))]
+        filePath(OctetString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PINCodes")]
+    #[non_exhaustive]
+    pub struct PEPINCodes {
+        #[rasn(identifier = "pin-Header")]
+        pub pin_header: PEHeader,
+        #[rasn(identifier = "pinCodes")]
+        pub pin_codes: PEPINCodesPinCodes,
+    }
+    impl PEPINCodes {
+        pub fn new(pin_header: PEHeader, pin_codes: PEPINCodesPinCodes) -> Self {
+            Self {
+                pin_header,
+                pin_codes,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-PUKCodes")]
+    #[non_exhaustive]
+    pub struct PEPUKCodes {
+        #[rasn(identifier = "puk-Header")]
+        pub puk_header: PEHeader,
+        #[rasn(size("1..=16"), identifier = "pukCodes")]
+        pub puk_codes: SequenceOf<PUKConfiguration>,
+    }
+    impl PEPUKCodes {
+        pub fn new(puk_header: PEHeader, puk_codes: SequenceOf<PUKConfiguration>) -> Self {
+            Self {
+                puk_header,
+                puk_codes,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "OCTET_STRING")]
+    pub struct AnonymousPERFMTarList(pub FixedOctetString<3usize>);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct PERFMTarList(pub SequenceOf<AnonymousPERFMTarList>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "PE-RFM")]
+    #[non_exhaustive]
+    pub struct PERFM {
+        #[rasn(tag(context, 0), identifier = "rfm-header")]
+        pub rfm_header: PEHeader,
+        #[rasn(tag(application, 15), identifier = "instanceAID")]
+        pub instance_aid: ApplicationIdentifier,
+        #[rasn(tag(application, 15), identifier = "securityDomainAID")]
+        pub security_domain_aid: Option<ApplicationIdentifier>,
+        #[rasn(tag(context, 0), identifier = "tarList")]
+        pub tar_list: Option<PERFMTarList>,
+        #[rasn(size("1"), tag(context, 1), identifier = "minimumSecurityLevel")]
+        pub minimum_security_level: OctetString,
+        #[rasn(identifier = "uiccAccessDomain")]
+        pub uicc_access_domain: OctetString,
+        #[rasn(identifier = "uiccAdminAccessDomain")]
+        pub uicc_admin_access_domain: OctetString,
+        #[rasn(identifier = "adfRFMAccess")]
+        pub adf_rfmaccess: Option<ADFRFMAccess>,
+    }
+    impl PERFM {
+        pub fn new(
+            rfm_header: PEHeader,
+            instance_aid: ApplicationIdentifier,
+            security_domain_aid: Option<ApplicationIdentifier>,
+            tar_list: Option<PERFMTarList>,
+            minimum_security_level: OctetString,
+            uicc_access_domain: OctetString,
+            uicc_admin_access_domain: OctetString,
+            adf_rfmaccess: Option<ADFRFMAccess>,
+        ) -> Self {
+            Self {
+                rfm_header,
+                instance_aid,
+                security_domain_aid,
+                tar_list,
+                minimum_security_level,
+                uicc_access_domain,
+                uicc_admin_access_domain,
+                adf_rfmaccess,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SSIM")]
+    #[non_exhaustive]
+    pub struct PESSIM {
+        #[rasn(identifier = "ssim-header")]
+        pub ssim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-ssim")]
+        pub adf_ssim: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-eapId")]
+        pub ef_eap_id: File,
+        #[rasn(identifier = "ef-nssai")]
+        pub ef_nssai: File,
+        #[rasn(identifier = "ef-eapStatus")]
+        pub ef_eap_status: File,
+    }
+    impl PESSIM {
+        pub fn new(
+            ssim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_ssim: File,
+            ef_arr: File,
+            ef_eap_id: File,
+            ef_nssai: File,
+            ef_eap_status: File,
+        ) -> Self {
+            Self {
+                ssim_header,
+                template_id,
+                adf_ssim,
+                ef_arr,
+                ef_eap_id,
+                ef_nssai,
+                ef_eap_status,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SSIM-EAPTLSParameters")]
+    #[non_exhaustive]
+    pub struct PESSIMEAPTLSParameters {
+        #[rasn(identifier = "ssim-eaptls-header")]
+        pub ssim_eaptls_header: PEHeader,
+        #[rasn(identifier = "eapSSIMCertificate")]
+        pub eap_ssimcertificate: Certificate,
+        #[rasn(identifier = "eapSSIMCertificateChain")]
+        pub eap_ssimcertificate_chain: Option<SequenceOf<Certificate>>,
+        #[rasn(identifier = "eapCACertificate")]
+        pub eap_cacertificate: Certificate,
+        #[rasn(identifier = "privateKey")]
+        pub private_key: OctetString,
+    }
+    impl PESSIMEAPTLSParameters {
+        pub fn new(
+            ssim_eaptls_header: PEHeader,
+            eap_ssimcertificate: Certificate,
+            eap_ssimcertificate_chain: Option<SequenceOf<Certificate>>,
+            eap_cacertificate: Certificate,
+            private_key: OctetString,
+        ) -> Self {
+            Self {
+                ssim_eaptls_header,
+                eap_ssimcertificate,
+                eap_ssimcertificate_chain,
+                eap_cacertificate,
+                private_key,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainOpenPersoData {
+        #[rasn(size("1"), tag(private, 25), identifier = "restrictParameter")]
+        pub restrict_parameter: Option<OctetString>,
+        #[rasn(identifier = "contactlessProtocolParameters")]
+        pub contactless_protocol_parameters: Option<OctetString>,
+    }
+    impl PESecurityDomainOpenPersoData {
+        pub fn new(
+            restrict_parameter: Option<OctetString>,
+            contactless_protocol_parameters: Option<OctetString>,
+        ) -> Self {
+            Self {
+                restrict_parameter,
+                contactless_protocol_parameters,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PESecurityDomainCatTpParameters {
+        #[rasn(identifier = "catTpMaxSduSize")]
+        pub cat_tp_max_sdu_size: UInt16,
+        #[rasn(identifier = "catTpMaxPduSize")]
+        pub cat_tp_max_pdu_size: UInt16,
+    }
+    impl PESecurityDomainCatTpParameters {
+        pub fn new(cat_tp_max_sdu_size: UInt16, cat_tp_max_pdu_size: UInt16) -> Self {
+            Self {
+                cat_tp_max_sdu_size,
+                cat_tp_max_pdu_size,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-SecurityDomain")]
+    #[non_exhaustive]
+    pub struct PESecurityDomain {
+        #[rasn(identifier = "sd-Header")]
+        pub sd_header: PEHeader,
+        pub instance: ApplicationInstance,
+        #[rasn(size("1.."), identifier = "keyList")]
+        pub key_list: Option<SequenceOf<KeyObject>>,
+        #[rasn(size("1.."), identifier = "sdPersoData")]
+        pub sd_perso_data: Option<SequenceOf<OctetString>>,
+        #[rasn(identifier = "openPersoData")]
+        pub open_perso_data: Option<PESecurityDomainOpenPersoData>,
+        #[rasn(identifier = "catTpParameters")]
+        pub cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+    }
+    impl PESecurityDomain {
+        pub fn new(
+            sd_header: PEHeader,
+            instance: ApplicationInstance,
+            key_list: Option<SequenceOf<KeyObject>>,
+            sd_perso_data: Option<SequenceOf<OctetString>>,
+            open_perso_data: Option<PESecurityDomainOpenPersoData>,
+            cat_tp_parameters: Option<PESecurityDomainCatTpParameters>,
+        ) -> Self {
+            Self {
+                sd_header,
+                instance,
+                key_list,
+                sd_perso_data,
+                open_perso_data,
+                cat_tp_parameters,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-TELECOM")]
+    #[non_exhaustive]
+    pub struct PETELECOM {
+        #[rasn(identifier = "telecom-header")]
+        pub telecom_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "df-telecom")]
+        pub df_telecom: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: Option<File>,
+        #[rasn(identifier = "ef-rma")]
+        pub ef_rma: Option<File>,
+        #[rasn(identifier = "ef-sume")]
+        pub ef_sume: Option<File>,
+        #[rasn(identifier = "ef-ice-dn")]
+        pub ef_ice_dn: Option<File>,
+        #[rasn(identifier = "ef-ice-ff")]
+        pub ef_ice_ff: Option<File>,
+        #[rasn(identifier = "ef-psismsc")]
+        pub ef_psismsc: Option<File>,
+        #[rasn(identifier = "df-graphics")]
+        pub df_graphics: Option<File>,
+        #[rasn(identifier = "ef-img")]
+        pub ef_img: Option<File>,
+        #[rasn(identifier = "ef-iidf")]
+        pub ef_iidf: Option<File>,
+        #[rasn(identifier = "ef-ice-graphics")]
+        pub ef_ice_graphics: Option<File>,
+        #[rasn(identifier = "ef-launch-scws")]
+        pub ef_launch_scws: Option<File>,
+        #[rasn(identifier = "ef-icon")]
+        pub ef_icon: Option<File>,
+        #[rasn(identifier = "df-phonebook")]
+        pub df_phonebook: Option<File>,
+        #[rasn(identifier = "ef-pbr")]
+        pub ef_pbr: Option<File>,
+        #[rasn(identifier = "ef-ext1")]
+        pub ef_ext1: Option<File>,
+        #[rasn(identifier = "ef-aas")]
+        pub ef_aas: Option<File>,
+        #[rasn(identifier = "ef-gas")]
+        pub ef_gas: Option<File>,
+        #[rasn(identifier = "ef-psc")]
+        pub ef_psc: Option<File>,
+        #[rasn(identifier = "ef-cc")]
+        pub ef_cc: Option<File>,
+        #[rasn(identifier = "ef-puid")]
+        pub ef_puid: Option<File>,
+        #[rasn(identifier = "ef-iap")]
+        pub ef_iap: Option<File>,
+        #[rasn(identifier = "ef-adn")]
+        pub ef_adn: Option<File>,
+        #[rasn(identifier = "ef-pbc")]
+        pub ef_pbc: Option<File>,
+        #[rasn(identifier = "ef-anr")]
+        pub ef_anr: Option<File>,
+        #[rasn(identifier = "ef-puri")]
+        pub ef_puri: Option<File>,
+        #[rasn(identifier = "ef-email")]
+        pub ef_email: Option<File>,
+        #[rasn(identifier = "ef-sne")]
+        pub ef_sne: Option<File>,
+        #[rasn(identifier = "ef-uid")]
+        pub ef_uid: Option<File>,
+        #[rasn(identifier = "ef-grp")]
+        pub ef_grp: Option<File>,
+        #[rasn(identifier = "ef-ccp1")]
+        pub ef_ccp1: Option<File>,
+        #[rasn(identifier = "df-multimedia")]
+        pub df_multimedia: Option<File>,
+        #[rasn(identifier = "ef-mml")]
+        pub ef_mml: Option<File>,
+        #[rasn(identifier = "ef-mmdf")]
+        pub ef_mmdf: Option<File>,
+        #[rasn(identifier = "df-mmss")]
+        pub df_mmss: Option<File>,
+        #[rasn(identifier = "ef-mlpl")]
+        pub ef_mlpl: Option<File>,
+        #[rasn(identifier = "ef-mspl")]
+        pub ef_mspl: Option<File>,
+        #[rasn(identifier = "ef-mmssmode")]
+        pub ef_mmssmode: Option<File>,
+        #[rasn(identifier = "df-mcs")]
+        pub df_mcs: Option<File>,
+        #[rasn(identifier = "ef-mst")]
+        pub ef_mst: Option<File>,
+        #[rasn(identifier = "ef-mcs-config")]
+        pub ef_mcs_config: Option<File>,
+        #[rasn(identifier = "df-v2x")]
+        pub df_v2x: Option<File>,
+        #[rasn(identifier = "ef-vst")]
+        pub ef_vst: Option<File>,
+        #[rasn(identifier = "ef-v2x-config")]
+        pub ef_v2x_config: Option<File>,
+        #[rasn(identifier = "ef-v2xp-pc5")]
+        pub ef_v2xp_pc5: Option<File>,
+        #[rasn(identifier = "ef-v2xp-Uu")]
+        pub ef_v2xp_uu: Option<File>,
+        #[rasn(identifier = "df-a2x")]
+        pub df_a2x: Option<File>,
+        #[rasn(identifier = "ef-ast")]
+        pub ef_ast: Option<File>,
+        #[rasn(identifier = "ef-a2x-config")]
+        pub ef_a2x_config: Option<File>,
+        #[rasn(identifier = "ef-a2xp-pc5")]
+        pub ef_a2xp_pc5: Option<File>,
+        #[rasn(identifier = "ef-a2x-ddaap-pc5")]
+        pub ef_a2x_ddaap_pc5: Option<File>,
+        #[rasn(identifier = "ef-a2x-dc2p-pc5")]
+        pub ef_a2x_dc2p_pc5: Option<File>,
+        #[rasn(identifier = "ef-a2xp-Uu")]
+        pub ef_a2xp_uu: Option<File>,
+    }
+    impl PETELECOM {
+        pub fn new(
+            telecom_header: PEHeader,
+            template_id: ObjectIdentifier,
+            df_telecom: File,
+            ef_arr: Option<File>,
+            ef_rma: Option<File>,
+            ef_sume: Option<File>,
+            ef_ice_dn: Option<File>,
+            ef_ice_ff: Option<File>,
+            ef_psismsc: Option<File>,
+            df_graphics: Option<File>,
+            ef_img: Option<File>,
+            ef_iidf: Option<File>,
+            ef_ice_graphics: Option<File>,
+            ef_launch_scws: Option<File>,
+            ef_icon: Option<File>,
+            df_phonebook: Option<File>,
+            ef_pbr: Option<File>,
+            ef_ext1: Option<File>,
+            ef_aas: Option<File>,
+            ef_gas: Option<File>,
+            ef_psc: Option<File>,
+            ef_cc: Option<File>,
+            ef_puid: Option<File>,
+            ef_iap: Option<File>,
+            ef_adn: Option<File>,
+            ef_pbc: Option<File>,
+            ef_anr: Option<File>,
+            ef_puri: Option<File>,
+            ef_email: Option<File>,
+            ef_sne: Option<File>,
+            ef_uid: Option<File>,
+            ef_grp: Option<File>,
+            ef_ccp1: Option<File>,
+            df_multimedia: Option<File>,
+            ef_mml: Option<File>,
+            ef_mmdf: Option<File>,
+            df_mmss: Option<File>,
+            ef_mlpl: Option<File>,
+            ef_mspl: Option<File>,
+            ef_mmssmode: Option<File>,
+            df_mcs: Option<File>,
+            ef_mst: Option<File>,
+            ef_mcs_config: Option<File>,
+            df_v2x: Option<File>,
+            ef_vst: Option<File>,
+            ef_v2x_config: Option<File>,
+            ef_v2xp_pc5: Option<File>,
+            ef_v2xp_uu: Option<File>,
+            df_a2x: Option<File>,
+            ef_ast: Option<File>,
+            ef_a2x_config: Option<File>,
+            ef_a2xp_pc5: Option<File>,
+            ef_a2x_ddaap_pc5: Option<File>,
+            ef_a2x_dc2p_pc5: Option<File>,
+            ef_a2xp_uu: Option<File>,
+        ) -> Self {
+            Self {
+                telecom_header,
+                template_id,
+                df_telecom,
+                ef_arr,
+                ef_rma,
+                ef_sume,
+                ef_ice_dn,
+                ef_ice_ff,
+                ef_psismsc,
+                df_graphics,
+                ef_img,
+                ef_iidf,
+                ef_ice_graphics,
+                ef_launch_scws,
+                ef_icon,
+                df_phonebook,
+                ef_pbr,
+                ef_ext1,
+                ef_aas,
+                ef_gas,
+                ef_psc,
+                ef_cc,
+                ef_puid,
+                ef_iap,
+                ef_adn,
+                ef_pbc,
+                ef_anr,
+                ef_puri,
+                ef_email,
+                ef_sne,
+                ef_uid,
+                ef_grp,
+                ef_ccp1,
+                df_multimedia,
+                ef_mml,
+                ef_mmdf,
+                df_mmss,
+                ef_mlpl,
+                ef_mspl,
+                ef_mmssmode,
+                df_mcs,
+                ef_mst,
+                ef_mcs_config,
+                df_v2x,
+                ef_vst,
+                ef_v2x_config,
+                ef_v2xp_pc5,
+                ef_v2xp_uu,
+                df_a2x,
+                ef_ast,
+                ef_a2x_config,
+                ef_a2xp_pc5,
+                ef_a2x_ddaap_pc5,
+                ef_a2x_dc2p_pc5,
+                ef_a2xp_uu,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "PE-USIM")]
+    #[non_exhaustive]
+    pub struct PEUSIM {
+        #[rasn(identifier = "usim-header")]
+        pub usim_header: PEHeader,
+        #[rasn(identifier = "templateID")]
+        pub template_id: ObjectIdentifier,
+        #[rasn(identifier = "adf-usim")]
+        pub adf_usim: File,
+        #[rasn(identifier = "ef-imsi")]
+        pub ef_imsi: File,
+        #[rasn(identifier = "ef-arr")]
+        pub ef_arr: File,
+        #[rasn(identifier = "ef-keys")]
+        pub ef_keys: Option<File>,
+        #[rasn(identifier = "ef-keysPS")]
+        pub ef_keys_ps: Option<File>,
+        #[rasn(identifier = "ef-hpplmn")]
+        pub ef_hpplmn: Option<File>,
+        #[rasn(identifier = "ef-ust")]
+        pub ef_ust: File,
+        #[rasn(identifier = "ef-fdn")]
+        pub ef_fdn: Option<File>,
+        #[rasn(identifier = "ef-sms")]
+        pub ef_sms: Option<File>,
+        #[rasn(identifier = "ef-smsp")]
+        pub ef_smsp: Option<File>,
+        #[rasn(identifier = "ef-smss")]
+        pub ef_smss: Option<File>,
+        #[rasn(identifier = "ef-spn")]
+        pub ef_spn: File,
+        #[rasn(identifier = "ef-est")]
+        pub ef_est: File,
+        #[rasn(identifier = "ef-start-hfn")]
+        pub ef_start_hfn: Option<File>,
+        #[rasn(identifier = "ef-threshold")]
+        pub ef_threshold: Option<File>,
+        #[rasn(identifier = "ef-psloci")]
+        pub ef_psloci: Option<File>,
+        #[rasn(identifier = "ef-acc")]
+        pub ef_acc: File,
+        #[rasn(identifier = "ef-fplmn")]
+        pub ef_fplmn: Option<File>,
+        #[rasn(identifier = "ef-loci")]
+        pub ef_loci: Option<File>,
+        #[rasn(identifier = "ef-ad")]
+        pub ef_ad: Option<File>,
+        #[rasn(identifier = "ef-ecc")]
+        pub ef_ecc: File,
+        #[rasn(identifier = "ef-netpar")]
+        pub ef_netpar: Option<File>,
+        #[rasn(identifier = "ef-epsloci")]
+        pub ef_epsloci: Option<File>,
+        #[rasn(identifier = "ef-epsnsc")]
+        pub ef_epsnsc: Option<File>,
+    }
+    impl PEUSIM {
+        pub fn new(
+            usim_header: PEHeader,
+            template_id: ObjectIdentifier,
+            adf_usim: File,
+            ef_imsi: File,
+            ef_arr: File,
+            ef_keys: Option<File>,
+            ef_keys_ps: Option<File>,
+            ef_hpplmn: Option<File>,
+            ef_ust: File,
+            ef_fdn: Option<File>,
+            ef_sms: Option<File>,
+            ef_smsp: Option<File>,
+            ef_smss: Option<File>,
+            ef_spn: File,
+            ef_est: File,
+            ef_start_hfn: Option<File>,
+            ef_threshold: Option<File>,
+            ef_psloci: Option<File>,
+            ef_acc: File,
+            ef_fplmn: Option<File>,
+            ef_loci: Option<File>,
+            ef_ad: Option<File>,
+            ef_ecc: File,
+            ef_netpar: Option<File>,
+            ef_epsloci: Option<File>,
+            ef_epsnsc: Option<File>,
+        ) -> Self {
+            Self {
+                usim_header,
+                template_id,
+                adf_usim,
+                ef_imsi,
+                ef_arr,
+                ef_keys,
+                ef_keys_ps,
+                ef_hpplmn,
+                ef_ust,
+                ef_fdn,
+                ef_sms,
+                ef_smsp,
+                ef_smss,
+                ef_spn,
+                ef_est,
+                ef_start_hfn,
+                ef_threshold,
+                ef_psloci,
+                ef_acc,
+                ef_fplmn,
+                ef_loci,
+                ef_ad,
+                ef_ecc,
+                ef_netpar,
+                ef_epsloci,
+                ef_epsnsc,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEHeader {
+        pub mandated: Option<()>,
+        pub identification: UInt15,
+    }
+    impl PEHeader {
+        pub fn new(mandated: Option<()>, identification: UInt15) -> Self {
+            Self {
+                mandated,
+                identification,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PEStatus {
+        pub status: Integer,
+        pub identification: Option<UInt15>,
+        #[rasn(identifier = "additional-information")]
+        pub additional_information: Option<UInt8>,
+        pub offset: Option<UInt31>,
+    }
+    impl PEStatus {
+        pub fn new(
+            status: Integer,
+            identification: Option<UInt15>,
+            additional_information: Option<UInt8>,
+            offset: Option<UInt31>,
+        ) -> Self {
+            Self {
+                status,
+                identification,
+                additional_information,
+                offset,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PINConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PINKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pinValue")]
+        pub pin_value: OctetString,
+        #[rasn(identifier = "unblockingPINReference")]
+        pub unblocking_pinreference: Option<PUKKeyReferenceValue>,
+        #[rasn(
+            default = "pinconfiguration_pin_attributes_default",
+            identifier = "pinAttributes"
+        )]
+        pub pin_attributes: UInt8,
+        #[rasn(
+            default = "pinconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PINConfiguration {
+        pub fn new(
+            key_reference: PINKeyReferenceValue,
+            pin_value: OctetString,
+            unblocking_pinreference: Option<PUKKeyReferenceValue>,
+            pin_attributes: UInt8,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                pin_value,
+                unblocking_pinreference,
+                pin_attributes,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pinconfiguration_pin_attributes_default() -> UInt8 {
+        UInt8(7)
+    }
+    fn pinconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(51)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PINKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct PUKConfiguration {
+        #[rasn(identifier = "keyReference")]
+        pub key_reference: PUKKeyReferenceValue,
+        #[rasn(size("8"), identifier = "pukValue")]
+        pub puk_value: OctetString,
+        #[rasn(
+            default = "pukconfiguration_max_num_of_attemps_retry_num_left_default",
+            identifier = "maxNumOfAttemps-retryNumLeft"
+        )]
+        pub max_num_of_attemps_retry_num_left: UInt8,
+    }
+    impl PUKConfiguration {
+        pub fn new(
+            key_reference: PUKKeyReferenceValue,
+            puk_value: OctetString,
+            max_num_of_attemps_retry_num_left: UInt8,
+        ) -> Self {
+            Self {
+                key_reference,
+                puk_value,
+                max_num_of_attemps_retry_num_left,
+            }
+        }
+    }
+    fn pukconfiguration_max_num_of_attemps_retry_num_left_default() -> UInt8 {
+        UInt8(170)
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PUKKeyReferenceValue(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, automatic_tags)]
+    #[non_exhaustive]
+    pub enum ProfileElement {
+        header(ProfileHeader),
+        genericFileManagement(PEGenericFileManagement),
+        pinCodes(PEPINCodes),
+        pukCodes(PEPUKCodes),
+        akaParameter(PEAKAParameter),
+        cdmaParameter(PECDMAParameter),
+        securityDomain(PESecurityDomain),
+        rfm(PERFM),
+        application(PEApplication),
+        nonStandard(PENonStandard),
+        end(PEEnd),
+        ssimEapTLSParameters(PESSIMEAPTLSParameters),
+        rfu2(PEDummy),
+        rfu3(PEDummy),
+        rfu4(PEDummy),
+        rfu5(PEDummy),
+        mf(PEMF),
+        cd(PECD),
+        telecom(PETELECOM),
+        usim(PEUSIM),
+        #[rasn(identifier = "opt-usim")]
+        opt_usim(PEOPTUSIM),
+        isim(PEISIM),
+        #[rasn(identifier = "opt-isim")]
+        opt_isim(PEOPTISIM),
+        phonebook(PEPHONEBOOK),
+        #[rasn(identifier = "gsm-access")]
+        gsm_access(PEGSMACCESS),
+        csim(PECSIM),
+        #[rasn(identifier = "opt-csim")]
+        opt_csim(PEOPTCSIM),
+        eap(PEEAP),
+        #[rasn(identifier = "df-5gs")]
+        df_5gs(PEDF5GS),
+        #[rasn(identifier = "df-saip")]
+        df_saip(PEDFSAIP),
+        #[rasn(identifier = "df-snpn")]
+        df_snpn(PEDFSNPN),
+        #[rasn(identifier = "df-5gprose")]
+        df_5gprose(PEDF5GPROSE),
+        iot(PEIoT),
+        #[rasn(identifier = "opt-iot")]
+        opt_iot(PEOPTIoT),
+        ssim(PESSIM),
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags, identifier = "SEQUENCE")]
+    #[non_exhaustive]
+    pub struct AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub aid: ApplicationIdentifier,
+        #[rasn(size("2"))]
+        pub version: OctetString,
+    }
+    impl AnonymousProfileHeaderEUICCMandatoryAIDs {
+        pub fn new(aid: ApplicationIdentifier, version: OctetString) -> Self {
+            Self { aid, version }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ProfileHeaderEUICCMandatoryAIDs(
+        pub SequenceOf<AnonymousProfileHeaderEUICCMandatoryAIDs>,
+    );
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ProfileHeader {
+        #[rasn(identifier = "major-version")]
+        pub major_version: UInt8,
+        #[rasn(identifier = "minor-version")]
+        pub minor_version: UInt8,
+        #[rasn(identifier = "profileType")]
+        pub profile_type: Option<Utf8String>,
+        #[rasn(size("10"))]
+        pub iccid: OctetString,
+        pub pol: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-services")]
+        pub e_uicc_mandatory_services: ServicesList,
+        #[rasn(identifier = "eUICC-Mandatory-GFSTEList")]
+        pub e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+        #[rasn(identifier = "connectivityParameters")]
+        pub connectivity_parameters: Option<OctetString>,
+        #[rasn(identifier = "eUICC-Mandatory-AIDs")]
+        pub e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+        #[rasn(identifier = "iotOptions")]
+        pub iot_options: Option<IotOptions>,
+    }
+    impl ProfileHeader {
+        pub fn new(
+            major_version: UInt8,
+            minor_version: UInt8,
+            profile_type: Option<Utf8String>,
+            iccid: OctetString,
+            pol: Option<OctetString>,
+            e_uicc_mandatory_services: ServicesList,
+            e_uicc_mandatory_gfstelist: SequenceOf<ObjectIdentifier>,
+            connectivity_parameters: Option<OctetString>,
+            e_uicc_mandatory_aids: Option<ProfileHeaderEUICCMandatoryAIDs>,
+            iot_options: Option<IotOptions>,
+        ) -> Self {
+            Self {
+                major_version,
+                minor_version,
+                profile_type,
+                iccid,
+                pol,
+                e_uicc_mandatory_services,
+                e_uicc_mandatory_gfstelist,
+                connectivity_parameters,
+                e_uicc_mandatory_aids,
+                iot_options,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct ProprietaryInfo {
+        #[rasn(
+            size("1"),
+            tag(private, 0),
+            default = "proprietary_info_special_file_information_default",
+            identifier = "specialFileInformation"
+        )]
+        pub special_file_information: OctetString,
+        #[rasn(size("1..=200"), tag(private, 1), identifier = "fillPattern")]
+        pub fill_pattern: Option<OctetString>,
+        #[rasn(size("1..=200"), tag(private, 2), identifier = "repeatPattern")]
+        pub repeat_pattern: Option<OctetString>,
+        #[rasn(tag(context, 6), identifier = "maximumFileSize")]
+        pub maximum_file_size: Option<OctetString>,
+        #[rasn(
+            size("1"),
+            tag(context, 4),
+            default = "proprietary_info_file_details_default",
+            identifier = "fileDetails"
+        )]
+        pub file_details: OctetString,
+    }
+    impl ProprietaryInfo {
+        pub fn new(
+            special_file_information: OctetString,
+            fill_pattern: Option<OctetString>,
+            repeat_pattern: Option<OctetString>,
+            maximum_file_size: Option<OctetString>,
+            file_details: OctetString,
+        ) -> Self {
+            Self {
+                special_file_information,
+                fill_pattern,
+                repeat_pattern,
+                maximum_file_size,
+                file_details,
+            }
+        }
+    }
+    fn proprietary_info_special_file_information_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[0])
+    }
+    fn proprietary_info_file_details_default() -> OctetString {
+        <OctetString as From<&'static [u8]>>::from(&[1])
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct ServicesList {
+        pub contactless: Option<()>,
+        pub usim: Option<()>,
+        pub isim: Option<()>,
+        pub csim: Option<()>,
+        pub milenage: Option<()>,
+        pub tuak128: Option<()>,
+        pub cave: Option<()>,
+        #[rasn(identifier = "gba-usim")]
+        pub gba_usim: Option<()>,
+        #[rasn(identifier = "gba-isim")]
+        pub gba_isim: Option<()>,
+        pub mbms: Option<()>,
+        pub eap: Option<()>,
+        pub javacard: Option<()>,
+        pub multos: Option<()>,
+        #[rasn(identifier = "multiple-usim")]
+        pub multiple_usim: Option<()>,
+        #[rasn(identifier = "multiple-isim")]
+        pub multiple_isim: Option<()>,
+        #[rasn(identifier = "multiple-csim")]
+        pub multiple_csim: Option<()>,
+        pub tuak256: Option<()>,
+        #[rasn(identifier = "usim-test-algorithm")]
+        pub usim_test_algorithm: Option<()>,
+        #[rasn(identifier = "ber-tlv")]
+        pub ber_tlv: Option<()>,
+        #[rasn(identifier = "dfLink")]
+        pub df_link: Option<()>,
+        #[rasn(identifier = "cat-tp")]
+        pub cat_tp: Option<()>,
+        #[rasn(identifier = "get-identity")]
+        pub get_identity: Option<()>,
+        #[rasn(identifier = "profile-a-x25519")]
+        pub profile_a_x25519: Option<()>,
+        #[rasn(identifier = "profile-b-p256")]
+        pub profile_b_p256: Option<()>,
+        #[rasn(identifier = "suciCalculatorApi")]
+        pub suci_calculator_api: Option<()>,
+        #[rasn(identifier = "dns-resolution")]
+        pub dns_resolution: Option<()>,
+        pub scp11ac: Option<()>,
+        #[rasn(identifier = "scp11c-authorization-mechanism")]
+        pub scp11c_authorization_mechanism: Option<()>,
+        pub s16mode: Option<()>,
+        pub eaka: Option<()>,
+        #[rasn(identifier = "suci-nswo")]
+        pub suci_nswo: Option<()>,
+        #[rasn(identifier = "network-id")]
+        pub network_id: Option<()>,
+        pub coap: Option<()>,
+        #[rasn(identifier = "gbauApi")]
+        pub gbau_api: Option<()>,
+        #[rasn(identifier = "uir5GProSe")]
+        pub uir5_gpro_se: Option<()>,
+        #[rasn(identifier = "ssim-Eap-Tls")]
+        pub ssim_eap_tls: Option<()>,
+        #[rasn(identifier = "ssim-Eap-Aka-prime")]
+        pub ssim_eap_aka_prime: Option<()>,
+        #[rasn(identifier = "usatAppPairing")]
+        pub usat_app_pairing: Option<()>,
+    }
+    impl ServicesList {
+        pub fn new(
+            contactless: Option<()>,
+            usim: Option<()>,
+            isim: Option<()>,
+            csim: Option<()>,
+            milenage: Option<()>,
+            tuak128: Option<()>,
+            cave: Option<()>,
+            gba_usim: Option<()>,
+            gba_isim: Option<()>,
+            mbms: Option<()>,
+            eap: Option<()>,
+            javacard: Option<()>,
+            multos: Option<()>,
+            multiple_usim: Option<()>,
+            multiple_isim: Option<()>,
+            multiple_csim: Option<()>,
+            tuak256: Option<()>,
+            usim_test_algorithm: Option<()>,
+            ber_tlv: Option<()>,
+            df_link: Option<()>,
+            cat_tp: Option<()>,
+            get_identity: Option<()>,
+            profile_a_x25519: Option<()>,
+            profile_b_p256: Option<()>,
+            suci_calculator_api: Option<()>,
+            dns_resolution: Option<()>,
+            scp11ac: Option<()>,
+            scp11c_authorization_mechanism: Option<()>,
+            s16mode: Option<()>,
+            eaka: Option<()>,
+            suci_nswo: Option<()>,
+            network_id: Option<()>,
+            coap: Option<()>,
+            gbau_api: Option<()>,
+            uir5_gpro_se: Option<()>,
+            ssim_eap_tls: Option<()>,
+            ssim_eap_aka_prime: Option<()>,
+            usat_app_pairing: Option<()>,
+        ) -> Self {
+            Self {
+                contactless,
+                usim,
+                isim,
+                csim,
+                milenage,
+                tuak128,
+                cave,
+                gba_usim,
+                gba_isim,
+                mbms,
+                eap,
+                javacard,
+                multos,
+                multiple_usim,
+                multiple_isim,
+                multiple_csim,
+                tuak256,
+                usim_test_algorithm,
+                ber_tlv,
+                df_link,
+                cat_tp,
+                get_identity,
+                profile_a_x25519,
+                profile_b_p256,
+                suci_calculator_api,
+                dns_resolution,
+                scp11ac,
+                scp11c_authorization_mechanism,
+                s16mode,
+                eaka,
+                suci_nswo,
+                network_id,
+                coap,
+                gbau_api,
+                uir5_gpro_se,
+                ssim_eap_tls,
+                ssim_eap_aka_prime,
+                usat_app_pairing,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(automatic_tags)]
+    #[non_exhaustive]
+    pub struct TS102226AdditionalContactlessParameters {
+        #[rasn(identifier = "protocolParameterData")]
+        pub protocol_parameter_data: OctetString,
+    }
+    impl TS102226AdditionalContactlessParameters {
+        pub fn new(protocol_parameter_data: OctetString) -> Self {
+            Self {
+                protocol_parameter_data,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub struct UICCApplicationParameters {
+        #[rasn(
+            tag(context, 0),
+            identifier = "uiccToolkitApplicationSpecificParametersField"
+        )]
+        pub uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 1),
+            identifier = "uiccAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_access_application_specific_parameters_field: Option<OctetString>,
+        #[rasn(
+            tag(context, 2),
+            identifier = "uiccAdministrativeAccessApplicationSpecificParametersField"
+        )]
+        pub uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+    }
+    impl UICCApplicationParameters {
+        pub fn new(
+            uicc_toolkit_application_specific_parameters_field: Option<OctetString>,
+            uicc_access_application_specific_parameters_field: Option<OctetString>,
+            uicc_administrative_access_application_specific_parameters_field: Option<OctetString>,
+        ) -> Self {
+            Self {
+                uicc_toolkit_application_specific_parameters_field,
+                uicc_access_application_specific_parameters_field,
+                uicc_administrative_access_application_specific_parameters_field,
+            }
+        }
+    }
+    #[doc = " Definition of UICCCapability"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct UICCCapability(pub BitString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=32767"))]
+    pub struct UInt15(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=65535"))]
+    pub struct UInt16(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=2147483647"))]
+    pub struct UInt31(pub u32);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=255"))]
+    pub struct UInt8(pub u8);
+    pub static MAX_UINT15: LazyLock<Integer> = LazyLock::new(|| Integer::from(32767i128));
+    pub static MAX_UINT16: LazyLock<Integer> = LazyLock::new(|| Integer::from(65535i128));
+    pub static MAX_UINT31: LazyLock<Integer> = LazyLock::new(|| Integer::from(2147483647i128));
+    #[doc = " As defined in X.509 Public Key Infrastructure Certificate [RFC5280]"]
+    #[doc = " Basic integer types, for size constraints"]
+    pub static MAX_UINT8: LazyLock<Integer> = LazyLock::new(|| Integer::from(255i128));
+}
+#[allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused,
+    clippy::too_many_arguments
+)]
+pub mod pkix1_explicit88 {
+    extern crate alloc;
+    use core::borrow::Borrow;
+    use rasn::prelude::*;
+    use std::sync::LazyLock;
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, tag(explicit(application, 2)))]
+    pub enum AdministrationDomainName {
+        #[rasn(size("0..=16"))]
+        numeric(NumericString),
+        #[rasn(size("0..=16"))]
+        printable(PrintableString),
+    }
+    #[doc = " if present, MUST be v2"]
+    #[doc = " Version, Time, CertificateSerialNumber, and Extensions were"]
+    #[doc = " defined earlier for use in the certificate structure"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct AlgorithmIdentifier {
+        pub algorithm: ObjectIdentifier,
+        pub parameters: Option<Any>,
+    }
+    impl AlgorithmIdentifier {
+        pub fn new(algorithm: ObjectIdentifier, parameters: Option<Any>) -> Self {
+            Self {
+                algorithm,
+                parameters,
+            }
+        }
+    }
+    #[doc = " attribute data types"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct Attribute {
+        #[rasn(identifier = "type")]
+        pub r_type: AttributeType,
+        pub values: SetOf<AttributeValue>,
+    }
+    impl Attribute {
+        pub fn new(r_type: AttributeType, values: SetOf<AttributeValue>) -> Self {
+            Self { r_type, values }
+        }
+    }
+    #[doc = " at least one value is required"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct AttributeType(pub ObjectIdentifier);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct AttributeTypeAndValue {
+        #[rasn(identifier = "type")]
+        pub r_type: AttributeType,
+        pub value: AttributeValue,
+    }
+    impl AttributeTypeAndValue {
+        pub fn new(r_type: AttributeType, value: AttributeValue) -> Self {
+            Self { r_type, value }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct AttributeValue(pub Any);
+    #[doc = " UniversalString is defined in ASN.1:1993"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(universal, 30))]
+    pub struct BMPString(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct BuiltInDomainDefinedAttribute {
+        #[rasn(size("1..=8"), identifier = "type")]
+        pub r_type: PrintableString,
+        #[rasn(size("1..=128"))]
+        pub value: PrintableString,
+    }
+    impl BuiltInDomainDefinedAttribute {
+        pub fn new(r_type: PrintableString, value: PrintableString) -> Self {
+            Self { r_type, value }
+        }
+    }
+    #[doc = " Built-in Domain-defined Attributes"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct BuiltInDomainDefinedAttributes(pub SequenceOf<BuiltInDomainDefinedAttribute>);
+    #[doc = " Built-in Standard Attributes"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct BuiltInStandardAttributes {
+        #[rasn(identifier = "country-name")]
+        pub country_name: Option<CountryName>,
+        #[rasn(identifier = "administration-domain-name")]
+        pub administration_domain_name: Option<AdministrationDomainName>,
+        #[rasn(tag(context, 0), identifier = "network-address")]
+        pub network_address: Option<NetworkAddress>,
+        #[rasn(tag(context, 1), identifier = "terminal-identifier")]
+        pub terminal_identifier: Option<TerminalIdentifier>,
+        #[rasn(tag(explicit(context, 2)), identifier = "private-domain-name")]
+        pub private_domain_name: Option<PrivateDomainName>,
+        #[rasn(tag(context, 3), identifier = "organization-name")]
+        pub organization_name: Option<OrganizationName>,
+        #[rasn(tag(context, 4), identifier = "numeric-user-identifier")]
+        pub numeric_user_identifier: Option<NumericUserIdentifier>,
+        #[rasn(tag(context, 5), identifier = "personal-name")]
+        pub personal_name: Option<PersonalName>,
+        #[rasn(tag(context, 6), identifier = "organizational-unit-names")]
+        pub organizational_unit_names: Option<OrganizationalUnitNames>,
+    }
+    impl BuiltInStandardAttributes {
+        pub fn new(
+            country_name: Option<CountryName>,
+            administration_domain_name: Option<AdministrationDomainName>,
+            network_address: Option<NetworkAddress>,
+            terminal_identifier: Option<TerminalIdentifier>,
+            private_domain_name: Option<PrivateDomainName>,
+            organization_name: Option<OrganizationName>,
+            numeric_user_identifier: Option<NumericUserIdentifier>,
+            personal_name: Option<PersonalName>,
+            organizational_unit_names: Option<OrganizationalUnitNames>,
+        ) -> Self {
+            Self {
+                country_name,
+                administration_domain_name,
+                network_address,
+                terminal_identifier,
+                private_domain_name,
+                organization_name,
+                numeric_user_identifier,
+                personal_name,
+                organizational_unit_names,
+            }
+        }
+    }
+    #[doc = " certificate and CRL specific structures begin here"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct Certificate {
+        #[rasn(identifier = "tbsCertificate")]
+        pub tbs_certificate: TBSCertificate,
+        #[rasn(identifier = "signatureAlgorithm")]
+        pub signature_algorithm: AlgorithmIdentifier,
+        pub signature: BitString,
+    }
+    impl Certificate {
+        pub fn new(
+            tbs_certificate: TBSCertificate,
+            signature_algorithm: AlgorithmIdentifier,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                tbs_certificate,
+                signature_algorithm,
+                signature,
+            }
+        }
+    }
+    #[doc = " CRL structures"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct CertificateList {
+        #[rasn(identifier = "tbsCertList")]
+        pub tbs_cert_list: TBSCertList,
+        #[rasn(identifier = "signatureAlgorithm")]
+        pub signature_algorithm: AlgorithmIdentifier,
+        pub signature: BitString,
+    }
+    impl CertificateList {
+        pub fn new(
+            tbs_cert_list: TBSCertList,
+            signature_algorithm: AlgorithmIdentifier,
+            signature: BitString,
+        ) -> Self {
+            Self {
+                tbs_cert_list,
+                signature_algorithm,
+                signature,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct CertificateSerialNumber(pub Integer);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=64"))]
+    pub struct CommonName(pub PrintableString);
+    #[doc = " see also teletex-organizational-unit-names"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice, tag(explicit(application, 1)))]
+    pub enum CountryName {
+        #[rasn(size("3"), identifier = "x121-dcc-code")]
+        x121_dcc_code(NumericString),
+        #[rasn(size("2"), identifier = "iso-3166-alpha2-code")]
+        iso_3166_alpha2_code(PrintableString),
+    }
+    #[doc = " Directory string type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum DirectoryString {
+        teletexString(TeletexString),
+        #[rasn(size("1.."))]
+        printableString(PrintableString),
+        #[rasn(size("1.."))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1.."))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct DistinguishedName(pub RDNSequence);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct DomainComponent(pub Ia5String);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=128"))]
+    pub struct EmailAddress(pub Ia5String);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct ExtendedNetworkAddressE1634Address {
+        #[rasn(size("1..=15"), tag(context, 0))]
+        pub number: NumericString,
+        #[rasn(size("1..=40"), tag(context, 1), identifier = "sub-address")]
+        pub sub_address: Option<NumericString>,
+    }
+    impl ExtendedNetworkAddressE1634Address {
+        pub fn new(number: NumericString, sub_address: Option<NumericString>) -> Self {
+            Self {
+                number,
+                sub_address,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum ExtendedNetworkAddress {
+        #[rasn(identifier = "e163-4-address")]
+        e163_4_address(ExtendedNetworkAddressE1634Address),
+        #[rasn(tag(context, 0), identifier = "psap-address")]
+        psap_address(PresentationAddress),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct Extension {
+        #[rasn(identifier = "extnID")]
+        pub extn_id: ObjectIdentifier,
+        #[rasn(default = "extension_critical_default")]
+        pub critical: bool,
+        #[rasn(identifier = "extnValue")]
+        pub extn_value: OctetString,
+    }
+    impl Extension {
+        pub fn new(extn_id: ObjectIdentifier, critical: bool, extn_value: OctetString) -> Self {
+            Self {
+                extn_id,
+                critical,
+                extn_value,
+            }
+        }
+    }
+    fn extension_critical_default() -> bool {
+        false
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct ExtensionAttribute {
+        #[rasn(
+            value("0..=256"),
+            tag(context, 0),
+            identifier = "extension-attribute-type"
+        )]
+        pub extension_attribute_type: u16,
+        #[rasn(tag(explicit(context, 1)), identifier = "extension-attribute-value")]
+        pub extension_attribute_value: Any,
+    }
+    impl ExtensionAttribute {
+        pub fn new(extension_attribute_type: u16, extension_attribute_value: Any) -> Self {
+            Self {
+                extension_attribute_type,
+                extension_attribute_value,
+            }
+        }
+    }
+    #[doc = " Extension Attributes"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=256"))]
+    pub struct ExtensionAttributes(pub SetOf<ExtensionAttribute>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ExtensionORAddressComponents(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct ExtensionPhysicalDeliveryAddressComponents(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct Extensions(pub SequenceOf<Extension>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct LocalPostalAttributes(pub PDSParameter);
+    #[doc = " naming data types "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum Name {
+        rdnSequence(RDNSequence),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct NetworkAddress(pub X121Address);
+    #[doc = " see also teletex-organization-name"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct NumericUserIdentifier(pub NumericString);
+    #[doc = " contains a value of the type"]
+    #[doc = " registered for use with the"]
+    #[doc = " algorithm object identifier value"]
+    #[doc = " X.400 address syntax starts here"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct ORAddress {
+        #[rasn(identifier = "built-in-standard-attributes")]
+        pub built_in_standard_attributes: BuiltInStandardAttributes,
+        #[rasn(identifier = "built-in-domain-defined-attributes")]
+        pub built_in_domain_defined_attributes: Option<BuiltInDomainDefinedAttributes>,
+        #[rasn(identifier = "extension-attributes")]
+        pub extension_attributes: Option<ExtensionAttributes>,
+    }
+    impl ORAddress {
+        pub fn new(
+            built_in_standard_attributes: BuiltInStandardAttributes,
+            built_in_domain_defined_attributes: Option<BuiltInDomainDefinedAttributes>,
+            extension_attributes: Option<ExtensionAttributes>,
+        ) -> Self {
+            Self {
+                built_in_standard_attributes,
+                built_in_domain_defined_attributes,
+                extension_attributes,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=64"))]
+    pub struct OrganizationName(pub PrintableString);
+    #[doc = " see also teletex-organizational-unit-names"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct OrganizationalUnitName(pub PrintableString);
+    #[doc = " see also teletex-personal-name"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct OrganizationalUnitNames(pub SequenceOf<OrganizationalUnitName>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct PDSName(pub PrintableString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(set)]
+    pub struct PDSParameter {
+        #[rasn(size("1..=30"), identifier = "printable-string")]
+        pub printable_string: Option<PrintableString>,
+        #[rasn(identifier = "teletex-string")]
+        pub teletex_string: Option<TeletexString>,
+    }
+    impl PDSParameter {
+        pub fn new(
+            printable_string: Option<PrintableString>,
+            teletex_string: Option<TeletexString>,
+        ) -> Self {
+            Self {
+                printable_string,
+                teletex_string,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(set)]
+    pub struct PersonalName {
+        #[rasn(size("1..=40"), tag(context, 0))]
+        pub surname: PrintableString,
+        #[rasn(size("1..=16"), tag(context, 1), identifier = "given-name")]
+        pub given_name: Option<PrintableString>,
+        #[rasn(size("1..=5"), tag(context, 2))]
+        pub initials: Option<PrintableString>,
+        #[rasn(size("1..=3"), tag(context, 3), identifier = "generation-qualifier")]
+        pub generation_qualifier: Option<PrintableString>,
+    }
+    impl PersonalName {
+        pub fn new(
+            surname: PrintableString,
+            given_name: Option<PrintableString>,
+            initials: Option<PrintableString>,
+            generation_qualifier: Option<PrintableString>,
+        ) -> Self {
+            Self {
+                surname,
+                given_name,
+                initials,
+                generation_qualifier,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum PhysicalDeliveryCountryName {
+        #[rasn(size("3"), identifier = "x121-dcc-code")]
+        x121_dcc_code(NumericString),
+        #[rasn(size("2"), identifier = "iso-3166-alpha2-code")]
+        iso_3166_alpha2_code(PrintableString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PhysicalDeliveryOfficeName(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PhysicalDeliveryOfficeNumber(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PhysicalDeliveryOrganizationName(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PhysicalDeliveryPersonalName(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PostOfficeBoxAddress(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum PostalCode {
+        #[rasn(size("1..=16"), identifier = "numeric-code")]
+        numeric_code(NumericString),
+        #[rasn(size("1..=16"), identifier = "printable-code")]
+        printable_code(PrintableString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct PosteRestanteAddress(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct PresentationAddress {
+        #[rasn(tag(explicit(context, 0)), identifier = "pSelector")]
+        pub p_selector: Option<OctetString>,
+        #[rasn(tag(explicit(context, 1)), identifier = "sSelector")]
+        pub s_selector: Option<OctetString>,
+        #[rasn(tag(explicit(context, 2)), identifier = "tSelector")]
+        pub t_selector: Option<OctetString>,
+        #[rasn(size("1.."), tag(explicit(context, 3)), identifier = "nAddresses")]
+        pub n_addresses: SetOf<OctetString>,
+    }
+    impl PresentationAddress {
+        pub fn new(
+            p_selector: Option<OctetString>,
+            s_selector: Option<OctetString>,
+            t_selector: Option<OctetString>,
+            n_addresses: SetOf<OctetString>,
+        ) -> Self {
+            Self {
+                p_selector,
+                s_selector,
+                t_selector,
+                n_addresses,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum PrivateDomainName {
+        #[rasn(size("1..=16"))]
+        numeric(NumericString),
+        #[rasn(size("1..=16"))]
+        printable(PrintableString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct RDNSequence(pub SequenceOf<RelativeDistinguishedName>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1.."))]
+    pub struct RelativeDistinguishedName(pub SetOf<AttributeTypeAndValue>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct StreetAddress(pub PDSParameter);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct SubjectPublicKeyInfo {
+        pub algorithm: AlgorithmIdentifier,
+        #[rasn(identifier = "subjectPublicKey")]
+        pub subject_public_key: BitString,
+    }
+    impl SubjectPublicKeyInfo {
+        pub fn new(algorithm: AlgorithmIdentifier, subject_public_key: BitString) -> Self {
+            Self {
+                algorithm,
+                subject_public_key,
+            }
+        }
+    }
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(identifier = "SEQUENCE")]
+    pub struct AnonymousTBSCertListRevokedCertificates {
+        #[rasn(identifier = "userCertificate")]
+        pub user_certificate: CertificateSerialNumber,
+        #[rasn(identifier = "revocationDate")]
+        pub revocation_date: Time,
+        #[rasn(identifier = "crlEntryExtensions")]
+        pub crl_entry_extensions: Option<Extensions>,
+    }
+    impl AnonymousTBSCertListRevokedCertificates {
+        pub fn new(
+            user_certificate: CertificateSerialNumber,
+            revocation_date: Time,
+            crl_entry_extensions: Option<Extensions>,
+        ) -> Self {
+            Self {
+                user_certificate,
+                revocation_date,
+                crl_entry_extensions,
+            }
+        }
+    }
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct TBSCertListRevokedCertificates(
+        pub SequenceOf<AnonymousTBSCertListRevokedCertificates>,
+    );
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct TBSCertList {
+        pub version: Option<Version>,
+        pub signature: AlgorithmIdentifier,
+        pub issuer: Name,
+        #[rasn(identifier = "thisUpdate")]
+        pub this_update: Time,
+        #[rasn(identifier = "nextUpdate")]
+        pub next_update: Option<Time>,
+        #[rasn(identifier = "revokedCertificates")]
+        pub revoked_certificates: Option<TBSCertListRevokedCertificates>,
+        #[rasn(tag(explicit(context, 0)), identifier = "crlExtensions")]
+        pub crl_extensions: Option<Extensions>,
+    }
+    impl TBSCertList {
+        pub fn new(
+            version: Option<Version>,
+            signature: AlgorithmIdentifier,
+            issuer: Name,
+            this_update: Time,
+            next_update: Option<Time>,
+            revoked_certificates: Option<TBSCertListRevokedCertificates>,
+            crl_extensions: Option<Extensions>,
+        ) -> Self {
+            Self {
+                version,
+                signature,
+                issuer,
+                this_update,
+                next_update,
+                revoked_certificates,
+                crl_extensions,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct TBSCertificate {
+        #[rasn(tag(explicit(context, 0)), default = "tbscertificate_version_default")]
+        pub version: Version,
+        #[rasn(identifier = "serialNumber")]
+        pub serial_number: CertificateSerialNumber,
+        pub signature: AlgorithmIdentifier,
+        pub issuer: Name,
+        pub validity: Validity,
+        pub subject: Name,
+        #[rasn(identifier = "subjectPublicKeyInfo")]
+        pub subject_public_key_info: SubjectPublicKeyInfo,
+        #[rasn(tag(context, 1), identifier = "issuerUniqueID")]
+        pub issuer_unique_id: Option<UniqueIdentifier>,
+        #[rasn(tag(context, 2), identifier = "subjectUniqueID")]
+        pub subject_unique_id: Option<UniqueIdentifier>,
+        #[rasn(tag(explicit(context, 3)))]
+        pub extensions: Option<Extensions>,
+    }
+    impl TBSCertificate {
+        pub fn new(
+            version: Version,
+            serial_number: CertificateSerialNumber,
+            signature: AlgorithmIdentifier,
+            issuer: Name,
+            validity: Validity,
+            subject: Name,
+            subject_public_key_info: SubjectPublicKeyInfo,
+            issuer_unique_id: Option<UniqueIdentifier>,
+            subject_unique_id: Option<UniqueIdentifier>,
+            extensions: Option<Extensions>,
+        ) -> Self {
+            Self {
+                version,
+                serial_number,
+                signature,
+                issuer,
+                validity,
+                subject,
+                subject_public_key_info,
+                issuer_unique_id,
+                subject_unique_id,
+                extensions,
+            }
+        }
+    }
+    fn tbscertificate_version_default() -> Version {
+        Version(Integer::from(0i128))
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=64"))]
+    pub struct TeletexCommonName(pub TeletexString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct TeletexDomainDefinedAttribute {
+        #[rasn(identifier = "type")]
+        pub r_type: TeletexString,
+        pub value: TeletexString,
+    }
+    impl TeletexDomainDefinedAttribute {
+        pub fn new(r_type: TeletexString, value: TeletexString) -> Self {
+            Self { r_type, value }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct TeletexDomainDefinedAttributes(pub SequenceOf<TeletexDomainDefinedAttribute>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=64"))]
+    pub struct TeletexOrganizationName(pub TeletexString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=32"))]
+    pub struct TeletexOrganizationalUnitName(pub TeletexString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=4"))]
+    pub struct TeletexOrganizationalUnitNames(pub SequenceOf<TeletexOrganizationalUnitName>);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(set)]
+    pub struct TeletexPersonalName {
+        #[rasn(tag(context, 0))]
+        pub surname: TeletexString,
+        #[rasn(tag(context, 1), identifier = "given-name")]
+        pub given_name: Option<TeletexString>,
+        #[rasn(tag(context, 2))]
+        pub initials: Option<TeletexString>,
+        #[rasn(tag(context, 3), identifier = "generation-qualifier")]
+        pub generation_qualifier: Option<TeletexString>,
+    }
+    impl TeletexPersonalName {
+        pub fn new(
+            surname: TeletexString,
+            given_name: Option<TeletexString>,
+            initials: Option<TeletexString>,
+            generation_qualifier: Option<TeletexString>,
+        ) -> Self {
+            Self {
+                surname,
+                given_name,
+                initials,
+                generation_qualifier,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=24"))]
+    pub struct TerminalIdentifier(pub PrintableString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, value("0..=256"))]
+    pub struct TerminalType(pub u16);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum Time {
+        utcTime(UtcTime),
+        generalTime(GeneralizedTime),
+    }
+    #[doc = " BMPString is the subtype of UniversalString and models"]
+    #[doc = " the Basic Multilingual Plane of ISO/IEC/ITU 10646-1"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(universal, 12))]
+    pub struct UTF8String(pub OctetString);
+    #[doc = " Anonymous SEQUENCE OF member "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, identifier = "PrintableString", size("1..=30"))]
+    pub struct AnonymousUnformattedPostalAddressPrintableAddress(pub PrintableString);
+    #[doc = " Inner type "]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=6"))]
+    pub struct UnformattedPostalAddressPrintableAddress(
+        pub SequenceOf<AnonymousUnformattedPostalAddressPrintableAddress>,
+    );
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(set)]
+    pub struct UnformattedPostalAddress {
+        #[rasn(identifier = "printable-address")]
+        pub printable_address: Option<UnformattedPostalAddressPrintableAddress>,
+        #[rasn(identifier = "teletex-string")]
+        pub teletex_string: Option<TeletexString>,
+    }
+    impl UnformattedPostalAddress {
+        pub fn new(
+            printable_address: Option<UnformattedPostalAddressPrintableAddress>,
+            teletex_string: Option<TeletexString>,
+        ) -> Self {
+            Self {
+                printable_address,
+                teletex_string,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct UniqueIdentifier(pub BitString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct UniquePostalName(pub PDSParameter);
+    #[doc = " EXPORTS ALL "]
+    #[doc = " IMPORTS NONE "]
+    #[doc = " UNIVERSAL Types defined in 1993 and 1998 ASN.1"]
+    #[doc = " and required by this specification"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, tag(universal, 28))]
+    pub struct UniversalString(pub OctetString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    pub struct Validity {
+        #[rasn(identifier = "notBefore")]
+        pub not_before: Time,
+        #[rasn(identifier = "notAfter")]
+        pub not_after: Time,
+    }
+    impl Validity {
+        pub fn new(not_before: Time, not_after: Time) -> Self {
+            Self {
+                not_before,
+                not_after,
+            }
+        }
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct Version(pub Integer);
+    #[doc = " see also extended-network-address"]
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=16"))]
+    pub struct X121Address(pub NumericString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520CommonName {
+        teletexString(TeletexString),
+        #[rasn(size("1..=64"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=64"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=64"))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520LocalityName {
+        teletexString(TeletexString),
+        #[rasn(size("1..=128"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=128"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=128"))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520OrganizationName {
+        teletexString(TeletexString),
+        #[rasn(size("1..=64"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=64"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=64"))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520OrganizationalUnitName {
+        teletexString(TeletexString),
+        #[rasn(size("1..=64"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=64"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=64"))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520Pseudonym {
+        teletexString(TeletexString),
+        #[rasn(size("1..=128"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=128"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=128"))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("1..=64"))]
+    pub struct X520SerialNumber(pub PrintableString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520StateOrProvinceName {
+        teletexString(TeletexString),
+        #[rasn(size("1..=128"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=128"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=128"))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520Title {
+        teletexString(TeletexString),
+        #[rasn(size("1..=64"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=64"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=64"))]
+        bmpString(BmpString),
+    }
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate, size("2"))]
+    pub struct X520countryName(pub PrintableString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(delegate)]
+    pub struct X520dnQualifier(pub PrintableString);
+    #[derive(AsnType, Debug, Clone, Decode, Encode, PartialEq, Eq, Hash)]
+    #[rasn(choice)]
+    pub enum X520name {
+        teletexString(TeletexString),
+        #[rasn(size("1..=32768"))]
+        printableString(PrintableString),
+        #[rasn(size("1..=32768"))]
+        universalString(UniversalString),
+        utf8String(Utf8String),
+        #[rasn(size("1..=32768"))]
+        bmpString(BmpString),
+    }
+    #[doc = " Extension types and attribute values"]
+    pub static COMMON_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(1i128));
+    pub static EXTENDED_NETWORK_ADDRESS: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(22i128));
+    pub static EXTENSION_OR_ADDRESS_COMPONENTS: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(12i128));
+    pub static EXTENSION_PHYSICAL_DELIVERY_ADDRESS_COMPONENTS: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(15i128));
+    #[doc = " arc for extended key purpose OIDS"]
+    pub static ID_AD: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_PKIX, &[48u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    pub static ID_AD_CA_ISSUERS: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AD, &[2u32]].concat()).unwrap().to_owned());
+    pub static ID_AD_CA_REPOSITORY: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AD, &[5u32]].concat()).unwrap().to_owned());
+    #[doc = " OID for user notice qualifier"]
+    #[doc = " access descriptor definitions"]
+    pub static ID_AD_OCSP: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AD, &[1u32]].concat()).unwrap().to_owned());
+    pub static ID_AD_TIME_STAMPING: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_AD, &[3u32]].concat()).unwrap().to_owned());
+    #[doc = " suggested naming attributes: Definition of the following"]
+    #[doc = "   information object set may be augmented to meet local"]
+    #[doc = "   requirements.  Note that deleting members of the set may"]
+    #[doc = "   prevent interoperability with conforming implementations."]
+    #[doc = " presented in pairs: the AttributeType followed by the"]
+    #[doc = "   type definition for the corresponding AttributeValue"]
+    #[doc = "Arc for standard naming attributes"]
+    pub static ID_AT: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::const_new(&[2u32, 5u32, 4u32]).to_owned());
+    #[doc = " Naming attributes of type X520CommonName"]
+    pub static ID_AT_COMMON_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(Oid::new(&[&***ID_AT, &[3u32]].concat()).unwrap().to_owned())
+    });
+    #[doc = " Naming attributes of type X520countryName (digraph from IS 3166)"]
+    pub static ID_AT_COUNTRY_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(Oid::new(&[&***ID_AT, &[6u32]].concat()).unwrap().to_owned())
+    });
+    #[doc = " Naming attributes of type X520dnQualifier"]
+    pub static ID_AT_DN_QUALIFIER: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[46u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    pub static ID_AT_GENERATION_QUALIFIER: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[44u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    pub static ID_AT_GIVEN_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[42u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    pub static ID_AT_INITIALS: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[43u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    #[doc = " Naming attributes of type X520LocalityName"]
+    pub static ID_AT_LOCALITY_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(Oid::new(&[&***ID_AT, &[7u32]].concat()).unwrap().to_owned())
+    });
+    #[doc = " Naming attributes of type X520name"]
+    pub static ID_AT_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[41u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    #[doc = " Naming attributes of type X520OrganizationName"]
+    pub static ID_AT_ORGANIZATION_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[10u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    #[doc = " Naming attributes of type X520OrganizationalUnitName"]
+    pub static ID_AT_ORGANIZATIONAL_UNIT_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[11u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    #[doc = " Naming attributes of type X520Pseudonym"]
+    pub static ID_AT_PSEUDONYM: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[65u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    #[doc = " Naming attributes of type X520SerialNumber"]
+    pub static ID_AT_SERIAL_NUMBER: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(Oid::new(&[&***ID_AT, &[5u32]].concat()).unwrap().to_owned())
+    });
+    #[doc = " Naming attributes of type X520StateOrProvinceName"]
+    pub static ID_AT_STATE_OR_PROVINCE_NAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(Oid::new(&[&***ID_AT, &[8u32]].concat()).unwrap().to_owned())
+    });
+    pub static ID_AT_SURNAME: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(Oid::new(&[&***ID_AT, &[4u32]].concat()).unwrap().to_owned())
+    });
+    #[doc = " Naming attributes of type X520Title"]
+    pub static ID_AT_TITLE: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***ID_AT, &[12u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    #[doc = " Naming attributes of type DomainComponent (from RFC 2247)"]
+    pub static ID_DOMAIN_COMPONENT: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::const_new(&[0u32, 9u32, 2342u32, 19200300u32, 100u32, 1u32, 25u32]).to_owned(),
+        )
+    });
+    pub static ID_EMAIL_ADDRESS: LazyLock<AttributeType> = LazyLock::new(|| {
+        AttributeType(
+            Oid::new(&[&***PKCS_9, &[1u32]].concat())
+                .unwrap()
+                .to_owned(),
+        )
+    });
+    #[doc = " arc for policy qualifier types"]
+    pub static ID_KP: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_PKIX, &[3u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    #[doc = " PKIX arcs"]
+    pub static ID_PE: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_PKIX, &[1u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    #[doc = " The content of this type conforms to RFC 2279."]
+    #[doc = " PKIX specific OIDs"]
+    pub static ID_PKIX: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::const_new(&[1u32, 3u32, 6u32, 1u32, 5u32, 5u32, 7u32]).to_owned());
+    #[doc = " arc for private certificate extensions"]
+    pub static ID_QT: LazyLock<ObjectIdentifier> = LazyLock::new(|| {
+        Oid::new(&[&***ID_PKIX, &[2u32]].concat())
+            .unwrap()
+            .to_owned()
+    });
+    #[doc = " arc for access descriptors"]
+    #[doc = " policyQualifierIds for Internet policy qualifiers"]
+    pub static ID_QT_CPS: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_QT, &[1u32]].concat()).unwrap().to_owned());
+    #[doc = " OID for CPS qualifier"]
+    pub static ID_QT_UNOTICE: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::new(&[&***ID_QT, &[2u32]].concat()).unwrap().to_owned());
+    pub static LOCAL_POSTAL_ATTRIBUTES: LazyLock<Integer> = LazyLock::new(|| Integer::from(21i128));
+    pub static PDS_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(7i128));
+    pub static PHYSICAL_DELIVERY_COUNTRY_NAME: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(8i128));
+    pub static PHYSICAL_DELIVERY_OFFICE_NAME: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(10i128));
+    pub static PHYSICAL_DELIVERY_OFFICE_NUMBER: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(11i128));
+    pub static PHYSICAL_DELIVERY_ORGANIZATION_NAME: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(14i128));
+    pub static PHYSICAL_DELIVERY_PERSONAL_NAME: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(13i128));
+    #[doc = " Legacy attributes"]
+    pub static PKCS_9: LazyLock<ObjectIdentifier> =
+        LazyLock::new(|| Oid::const_new(&[1u32, 2u32, 840u32, 113549u32, 1u32, 9u32]).to_owned());
+    pub static POST_OFFICE_BOX_ADDRESS: LazyLock<Integer> = LazyLock::new(|| Integer::from(18i128));
+    pub static POSTAL_CODE: LazyLock<Integer> = LazyLock::new(|| Integer::from(9i128));
+    pub static POSTE_RESTANTE_ADDRESS: LazyLock<Integer> = LazyLock::new(|| Integer::from(19i128));
+    pub static STREET_ADDRESS: LazyLock<Integer> = LazyLock::new(|| Integer::from(17i128));
+    pub static TELETEX_COMMON_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(2i128));
+    #[doc = " Extension Domain-defined Attributes"]
+    pub static TELETEX_DOMAIN_DEFINED_ATTRIBUTES: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(6i128));
+    pub static TELETEX_ORGANIZATION_NAME: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(3i128));
+    pub static TELETEX_ORGANIZATIONAL_UNIT_NAMES: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(5i128));
+    pub static TELETEX_PERSONAL_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(4i128));
+    pub static TERMINAL_TYPE: LazyLock<Integer> = LazyLock::new(|| Integer::from(23i128));
+    pub static UB_COMMON_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(64i128));
+    pub static UB_COMMON_NAME_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(64i128));
+    pub static UB_COUNTRY_NAME_ALPHA_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(2i128));
+    pub static UB_COUNTRY_NAME_NUMERIC_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(3i128));
+    pub static UB_DOMAIN_DEFINED_ATTRIBUTE_TYPE_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(8i128));
+    pub static UB_DOMAIN_DEFINED_ATTRIBUTE_VALUE_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(128i128));
+    pub static UB_DOMAIN_DEFINED_ATTRIBUTES: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(4i128));
+    pub static UB_DOMAIN_NAME_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(16i128));
+    pub static UB_E163_4_NUMBER_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(15i128));
+    pub static UB_E163_4_SUB_ADDRESS_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(40i128));
+    pub static UB_EMAILADDRESS_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(128i128));
+    pub static UB_EXTENSION_ATTRIBUTES: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(256i128));
+    pub static UB_GENERATION_QUALIFIER_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(3i128));
+    pub static UB_GIVEN_NAME_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(16i128));
+    pub static UB_INITIALS_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(5i128));
+    pub static UB_INTEGER_OPTIONS: LazyLock<Integer> = LazyLock::new(|| Integer::from(256i128));
+    pub static UB_LOCALITY_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(128i128));
+    pub static UB_MATCH: LazyLock<Integer> = LazyLock::new(|| Integer::from(128i128));
+    #[doc = "  specifications of Upper Bounds MUST be regarded as mandatory"]
+    #[doc = "  from Annex B of ITU-T X.411 Reference Definition of MTS Parameter"]
+    #[doc = "  Upper Bounds"]
+    #[doc = " Upper Bounds"]
+    pub static UB_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(32768i128));
+    pub static UB_NUMERIC_USER_ID_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(32i128));
+    pub static UB_ORGANIZATION_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(64i128));
+    pub static UB_ORGANIZATION_NAME_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(64i128));
+    pub static UB_ORGANIZATIONAL_UNIT_NAME: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(64i128));
+    pub static UB_ORGANIZATIONAL_UNIT_NAME_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(32i128));
+    pub static UB_ORGANIZATIONAL_UNITS: LazyLock<Integer> = LazyLock::new(|| Integer::from(4i128));
+    pub static UB_PDS_NAME_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(16i128));
+    pub static UB_PDS_PARAMETER_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(30i128));
+    pub static UB_PDS_PHYSICAL_ADDRESS_LINES: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(6i128));
+    pub static UB_POSTAL_CODE_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(16i128));
+    pub static UB_PSEUDONYM: LazyLock<Integer> = LazyLock::new(|| Integer::from(128i128));
+    pub static UB_SERIAL_NUMBER: LazyLock<Integer> = LazyLock::new(|| Integer::from(64i128));
+    pub static UB_STATE_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(128i128));
+    pub static UB_SURNAME_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(40i128));
+    pub static UB_TERMINAL_ID_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(24i128));
+    pub static UB_TITLE: LazyLock<Integer> = LazyLock::new(|| Integer::from(64i128));
+    pub static UB_UNFORMATTED_ADDRESS_LENGTH: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(180i128));
+    pub static UB_X121_ADDRESS_LENGTH: LazyLock<Integer> = LazyLock::new(|| Integer::from(16i128));
+    pub static UNFORMATTED_POSTAL_ADDRESS: LazyLock<Integer> =
+        LazyLock::new(|| Integer::from(16i128));
+    pub static UNIQUE_POSTAL_NAME: LazyLock<Integer> = LazyLock::new(|| Integer::from(20i128));
+}

--- a/rasn-compiler-tests/tests/structured_types.rs
+++ b/rasn-compiler-tests/tests/structured_types.rs
@@ -233,3 +233,15 @@ e2e_pdu!(
         T ::= CHOICE { a INTEGER, b [1] BOOLEAN, c OCTET STRING }
     "#
 );
+
+// Regression test for issue #167.2 (Bug A): a SEQUENCE OF with a fixed-size element type
+// whose DEFAULT value must be wrapped in the generated newtype (`MySeqItems`) and each
+// element wrapped in the anonymous element type (`AnonymousMySeqItems`).
+e2e_pdu!(
+    sequence_of_fixed_octet_with_default,
+    r#"
+        MySeq ::= SEQUENCE {
+            items SEQUENCE OF OCTET STRING (SIZE(3)) DEFAULT {'AABBCC'H}
+        }
+    "#
+);

--- a/rasn-compiler-tests/tests/tca_compile_tests.rs
+++ b/rasn-compiler-tests/tests/tca_compile_tests.rs
@@ -1,0 +1,30 @@
+// Stage-2 compile tests for TCA Profile Package.
+//
+// The build.rs pre-compiles both TCA versions using rasn-compiler and writes
+// the generated Rust to OUT_DIR.  Including those files here means rustc
+// must compile the generated code — any type error in the output is a
+// compile-time failure of this test binary.
+//
+// KNOWN FAILURE (issue #167.2): tca_v2_3_1 currently fails to compile.
+//   peakaparameter_sqn_init_default() returns SequenceOf<OctetString> but the
+//   field type is PEAKAParameterSqnInit.  Remove this comment when fixed.
+
+mod tca_v2_3_1 {
+    include!(concat!(env!("OUT_DIR"), "/tca_v2_3_1.rs"));
+}
+
+mod tca_v3_4_1 {
+    include!(concat!(env!("OUT_DIR"), "/tca_v3_4_1.rs"));
+}
+
+#[test]
+fn tca_v2_3_1_generated_rust_is_valid() {
+    // Compilation of mod tca_v2_3_1 above is the real assertion.
+    let _ = std::any::type_name::<tca_v2_3_1::pedefinitions::ProfileElement>();
+}
+
+#[test]
+fn tca_v3_4_1_generated_rust_is_valid() {
+    // Compilation of mod tca_v3_4_1 above is the real assertion.
+    let _ = std::any::type_name::<tca_v3_4_1::pedefinitions::ProfileElement>();
+}

--- a/rasn-compiler-tests/tests/tca_tests.rs
+++ b/rasn-compiler-tests/tests/tca_tests.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+use rasn_compiler::{prelude::RasnBackend, Compiler};
+
+fn modules_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/modules")
+}
+
+fn compile_snapshot(module_filenames: &[&str]) -> String {
+    let dir = modules_dir();
+    let paths: Vec<PathBuf> = module_filenames.iter().map(|f| dir.join(f)).collect();
+
+    let result = Compiler::<RasnBackend, _>::new()
+        .add_asn_sources_by_path(paths.into_iter())
+        .compile_to_string();
+
+    match result {
+        Ok(result) => {
+            let mut output = String::new();
+            if !result.warnings.is_empty() {
+                output.push_str("Warnings:\n");
+                for warning in &result.warnings {
+                    output.push_str(&format!("  {warning}\n"));
+                }
+                output.push('\n');
+            }
+            output.push_str("Generated:\n");
+            output.push_str(result.generated.trim());
+            output.push('\n');
+            output
+        }
+        Err(err) => format!("Error: {err}\n"),
+    }
+}
+
+/// TCA Profile Package v2.3.1 — standalone module (no external imports).
+/// Covers: AUTOMATIC TAGS, CHOICE (30 variants), SEQUENCE with OPTIONAL/DEFAULT,
+/// SEQUENCE OF CHOICE (File type), APPLICATION/PRIVATE tag classes, NULL OPTIONAL flags.
+#[test]
+fn tca_v2_3_1_compiles() {
+    let output = compile_snapshot(&["tca_PEDefinitions_v2.3.1.asn1"]);
+    insta::with_settings!(
+        { omit_expression => true },
+        { insta::assert_snapshot!(output); }
+    );
+}
+
+/// TCA Profile Package v3.4.1 — requires PKIX1Explicit88 for `Certificate` import.
+/// Adds over v2.3.1: PE-IoT, PE-SSIM, PE-SSIM-EAPTLSParameters, PE-DF-SNPN,
+/// PE-DF-5GPROSE, IotOptions in ProfileHeader, SSIM service flags.
+#[test]
+fn tca_v3_4_1_compiles() {
+    let output = compile_snapshot(&[
+        "ietf_rfc_rfc3280_PKIX1Explicit88.asn1",
+        "tca_PEDefinitions_v3.4.1.asn1",
+    ]);
+    insta::with_settings!(
+        { omit_expression => true },
+        { insta::assert_snapshot!(output); }
+    );
+}

--- a/rasn-compiler/src/generator/rasn/utils.rs
+++ b/rasn-compiler/src/generator/rasn/utils.rs
@@ -687,6 +687,24 @@ impl Rasn {
         )
     }
 
+    /// Generates the private free functions that back `#[rasn(default = "…")]` attributes on
+    /// SEQUENCE/SET fields.  For each member that carries a DEFAULT value a function of the form
+    ///
+    /// ```rust,ignore
+    /// fn parent_name_field_name_default() -> FieldType { <value> }
+    /// ```
+    ///
+    /// is emitted.  Two field categories require special handling beyond a straight
+    /// `value_to_tokens` call:
+    ///
+    /// * **SequenceOf/SetOf with `needs_unnesting`** — when the element type has constraints or
+    ///   a tag the generator wraps the whole sequence in a named newtype
+    ///   (`OuterName(SequenceOf<ElemType>)`).  The default function must return that outer type
+    ///   rather than the raw `SequenceOf`.
+    ///
+    /// * **Type-alias integer defaults** — `UInt8 ::= INTEGER (0..255)` generates a newtype
+    ///   `struct UInt8(pub u8)`.  A plain integer literal DEFAULT must be wrapped as `UInt8(1)`,
+    ///   not left as the bare literal `1` that `value_to_tokens` produces.
     pub(crate) fn format_default_methods(
         &self,
         members: &Vec<SequenceOrSetMember>,
@@ -695,12 +713,95 @@ impl Rasn {
         let mut output = TokenStream::new();
         for member in members {
             if let Some(value) = member.optionality.default() {
-                let val = self.value_to_tokens(
-                    value,
-                    Some(&self.to_rust_title_case(&self.type_to_tokens(&member.ty)?.to_string())),
-                )?;
-                let ty = self.type_to_tokens(&member.ty)?;
                 let method_name = self.default_method_name(parent_name, &member.name);
+                let (ty, val) = match &member.ty {
+                    // SequenceOf/SetOf whose element type has constraints or a tag: the generator
+                    // always emits an outer newtype `OuterName(SequenceOf<ElemType>)`, so the
+                    // default method return type is `OuterName = inner_name(field, parent)`.
+                    //
+                    // Whether each element needs an additional `Anonymous*` wrapper depends on
+                    // the element type:
+                    //   • concrete element (OctetString, Integer, …) → builder creates
+                    //     `AnonymousOuterName`; each value must be wrapped in it.
+                    //   • ElsewhereDeclaredType element → builder uses the declared type name
+                    //     directly; no `Anonymous*` struct exists, so values are emitted as-is.
+                    ASN1Type::SequenceOf(so) | ASN1Type::SetOf(so)
+                        if Self::needs_unnesting(&member.ty) =>
+                    {
+                        // outer_name is e.g. `PEAKAParameterSqnInit` for field `sqnInit` in
+                        // parent `PEAKAParameter`.
+                        let outer_name = self.inner_name(&member.name, parent_name);
+                        let ASN1Value::LinkedArrayLikeValue(elems) = value else {
+                            return Err(error!(
+                                Unidentified,
+                                "Expected LinkedArrayLikeValue for SequenceOf DEFAULT, found {:?}",
+                                value
+                            ));
+                        };
+                        let elem_vals = if matches!(
+                            so.element_type.as_ref(),
+                            ASN1Type::ElsewhereDeclaredType(_)
+                        ) {
+                            // ElsewhereDeclaredType: builder uses the declared name as the vec
+                            // element type, no Anonymous* wrapper struct is generated.
+                            elems
+                                .iter()
+                                .map(|elem| self.value_to_tokens(elem, None))
+                                .collect::<Result<Vec<_>, GeneratorError>>()?
+                        } else {
+                            // Concrete element type: builder generates `AnonymousOuterName`
+                            // (e.g. `AnonymousPEAKAParameterSqnInit`) and each value must be
+                            // wrapped in it.
+                            let elem_name =
+                                format_ident!("Anonymous{}", outer_name.to_string());
+                            elems
+                                .iter()
+                                .map(|elem| {
+                                    let elem_val = self
+                                        .value_to_tokens_for_element(elem, &so.element_type)
+                                        .map_err(|mut e| {
+                                            e.details = format!(
+                                                "in field '{}.{}': {}",
+                                                parent_name, member.name, e.details
+                                            );
+                                            e
+                                        })?;
+                                    Ok(quote!(#elem_name(#elem_val)))
+                                })
+                                .collect::<Result<Vec<_>, GeneratorError>>()?
+                        };
+                        (
+                            outer_name.to_token_stream(),
+                            quote!(#outer_name(alloc::vec![#(#elem_vals),*])),
+                        )
+                    }
+                    _ => {
+                        let ty = self.type_to_tokens(&member.ty)?;
+                        let val_raw = self.value_to_tokens(
+                            value,
+                            Some(&self.to_rust_title_case(&ty.to_string())),
+                        )?;
+                        // ElsewhereDeclaredType with a plain integer DEFAULT: the generated type
+                        // is a newtype so the literal must be wrapped, e.g. `UInt8(1)` not `1`.
+                        //
+                        // Two value variants arise depending on whether the linker has run on
+                        // this member:
+                        //   • LinkedIntValue — normal top-level SEQUENCE, linked by validator
+                        //   • Integer        — anonymous inline type synthesised by the generator
+                        //     (never enters the linker's collect_supertypes pass)
+                        //
+                        // Note: LinkedNestedValue (named-value DEFAULT, e.g. `DEFAULT first`)
+                        // is already handled correctly by the nester in value_to_tokens.
+                        let val = match (&member.ty, value) {
+                            (
+                                ASN1Type::ElsewhereDeclaredType(_),
+                                ASN1Value::LinkedIntValue { .. } | ASN1Value::Integer(_),
+                            ) => quote!(#ty(#val_raw)),
+                            _ => val_raw,
+                        };
+                        (ty, val)
+                    }
+                };
                 output.append_all(quote! {
                     fn #method_name() -> #ty {
                         #val
@@ -709,6 +810,32 @@ impl Rasn {
             }
         }
         Ok(output)
+    }
+
+    /// Generates tokens for a single element of a SequenceOf/SetOf DEFAULT value, taking the
+    /// element's declared type into account.  When the element type is an `OCTET STRING` with a
+    /// fixed SIZE constraint the value is emitted as `FixedOctetString::new([…])` rather than
+    /// the heap-allocating `OctetString` form that `value_to_tokens` would produce.
+    fn value_to_tokens_for_element(
+        &self,
+        value: &ASN1Value,
+        element_type: &ASN1Type,
+    ) -> Result<TokenStream, GeneratorError> {
+        if let (ASN1Value::OctetString(bytes), ASN1Type::OctetString(o)) = (value, element_type) {
+            if let Some(n) = o.fixed_size() {
+                if bytes.len() == n {
+                    let byte_lits = bytes.iter().map(|b| Literal::u8_suffixed(*b));
+                    return Ok(quote!(FixedOctetString::new([#(#byte_lits),*])));
+                }
+                return Err(error!(
+                    Asn1TypeMismatch,
+                    "OCTET STRING DEFAULT value has {} bytes but SIZE constraint requires {}",
+                    bytes.len(),
+                    n
+                ));
+            }
+        }
+        self.value_to_tokens(value, None)
     }
 
     pub(crate) fn type_to_tokens(&self, ty: &ASN1Type) -> Result<TokenStream, GeneratorError> {


### PR DESCRIPTION
   ## Summary

  Fixes two bugs in `format_default_methods` (`generator/rasn/utils.rs`) where generated DEFAULT functions produced code that failed to compile.

  **Bug A — SequenceOf/SetOf with `needs_unnesting`:** when a SEQUENCE field's type is a `SequenceOf` whose element has constraints or a tag, the generator wraps it in a named outer newtype (e.g. `PEAKAParameterSqnInit`). The default function was
  returning the raw `SequenceOf<T>` instead of the outer newtype, and elements were not wrapped in their `Anonymous*` element type.

  **Bug B — `ElsewhereDeclaredType` with integer literal DEFAULT:** types like `UInt8 ::= INTEGER (0..255)` generate a newtype struct. A plain integer literal DEFAULT was emitted bare (`1`) instead of as a constructor call (`UInt8(1)`). This covers
  both the `LinkedIntValue` variant (normal top-level SEQUENCE members, linked by the validator) and the `Integer` variant (anonymous inline types synthesised by the generator that never pass through the linker's `collect_supertypes`).

  Also adds `value_to_tokens_for_element` to emit `FixedOctetString::new([])` for fixed-size `OCTET STRING` elements rather than the heap-allocating `OctetString` form.

  ## Impact

  Fixes 9 compile errors across TCA Profile Package v2.3.1 and v3.4.1. The same Bug A pattern also affected `itu-t_x_x411` and `itu-t_x_x420` modules (updated snapshots included).

  ## Test plan
  - [ ] `cargo test --workspace` passes
  - [ ] `cargo test --release --package rasn-compiler-tests -- --ignored parses_modules` -- review updated snapshots with `cargo insta review` and accept if DEFAULT function changes match expected newtype wrapping
  - [ ] `tca_compile_tests` -- both `tca_v2_3_1_generated_rust_is_valid` and `tca_v3_4_1_generated_rust_is_valid` pass (Stage 2 compile check)
  - [ ] New regression test `edge_cases::integer_type_alias_with_literal_default` (Bug B)
  - [ ] New regression test `structured_types::sequence_of_fixed_octet_with_default` (Bug A)